### PR TITLE
Fix template generator for ToString method

### DIFF
--- a/src/Vogen/Util.cs
+++ b/src/Vogen/Util.cs
@@ -198,7 +198,7 @@ public static class Util
 
     public static string GenerateToStringReadOnly(VoWorkItem item) =>
         item.HasToString ? string.Empty :
-            @"/// <summary>Returns the string representation of the underlying type</summary>
+            $@"/// <summary>Returns the string representation of the underlying type</summary>
     /// <inheritdoc cref=""{item.UnderlyingTypeFullName}.ToString()"" />
     public readonly override global::System.String ToString() => Value.ToString();";
 

--- a/tests/SnapshotTests/Config/snapshots/snap-v3.1/GlobalConfigTests.Conversion_and_exceptions_override.verified.txt
+++ b/tests/SnapshotTests/Config/snapshots/snap-v3.1/GlobalConfigTests.Conversion_and_exceptions_override.verified.txt
@@ -141,7 +141,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Config/snapshots/snap-v3.1/GlobalConfigTests.Customization_override.verified.txt
+++ b/tests/SnapshotTests/Config/snapshots/snap-v3.1/GlobalConfigTests.Customization_override.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Config/snapshots/snap-v3.1/GlobalConfigTests.Exception_override.verified.txt
+++ b/tests/SnapshotTests/Config/snapshots/snap-v3.1/GlobalConfigTests.Exception_override.verified.txt
@@ -143,7 +143,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Config/snapshots/snap-v3.1/GlobalConfigTests.Override_all.verified.txt
+++ b/tests/SnapshotTests/Config/snapshots/snap-v3.1/GlobalConfigTests.Override_all.verified.txt
@@ -141,7 +141,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Config/snapshots/snap-v3.1/GlobalConfigTests.Type_override.verified.txt
+++ b/tests/SnapshotTests/Config/snapshots/snap-v3.1/GlobalConfigTests.Type_override.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Config/snapshots/snap-v3.1/LocalConfigTests.Conversion_and_exceptions_override.verified.txt
+++ b/tests/SnapshotTests/Config/snapshots/snap-v3.1/LocalConfigTests.Conversion_and_exceptions_override.verified.txt
@@ -141,7 +141,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Config/snapshots/snap-v3.1/LocalConfigTests.Conversion_override.verified.txt
+++ b/tests/SnapshotTests/Config/snapshots/snap-v3.1/LocalConfigTests.Conversion_override.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Config/snapshots/snap-v3.1/LocalConfigTests.Defaults.verified.txt
+++ b/tests/SnapshotTests/Config/snapshots/snap-v3.1/LocalConfigTests.Defaults.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Config/snapshots/snap-v3.1/LocalConfigTests.Defaults_with_validation.verified.txt
+++ b/tests/SnapshotTests/Config/snapshots/snap-v3.1/LocalConfigTests.Defaults_with_validation.verified.txt
@@ -143,7 +143,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Config/snapshots/snap-v3.1/LocalConfigTests.Defaults_with_validation_and_instances.verified.txt
+++ b/tests/SnapshotTests/Config/snapshots/snap-v3.1/LocalConfigTests.Defaults_with_validation_and_instances.verified.txt
@@ -144,7 +144,7 @@ var validation = CustomerId.validate(value);
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Config/snapshots/snap-v3.1/LocalConfigTests.Exception_override.verified.txt
+++ b/tests/SnapshotTests/Config/snapshots/snap-v3.1/LocalConfigTests.Exception_override.verified.txt
@@ -143,7 +143,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Config/snapshots/snap-v3.1/LocalConfigTests.Override_global_config_locally.verified.txt
+++ b/tests/SnapshotTests/Config/snapshots/snap-v3.1/LocalConfigTests.Override_global_config_locally.verified.txt
@@ -225,7 +225,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Config/snapshots/snap-v3.1/LocalConfigTests.Type_override.verified.txt
+++ b/tests/SnapshotTests/Config/snapshots/snap-v3.1/LocalConfigTests.Type_override.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Config/snapshots/snap-v4.6.1/GlobalConfigTests.Conversion_and_exceptions_override.verified.txt
+++ b/tests/SnapshotTests/Config/snapshots/snap-v4.6.1/GlobalConfigTests.Conversion_and_exceptions_override.verified.txt
@@ -143,7 +143,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Config/snapshots/snap-v4.6.1/GlobalConfigTests.Customization_override.verified.txt
+++ b/tests/SnapshotTests/Config/snapshots/snap-v4.6.1/GlobalConfigTests.Customization_override.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Config/snapshots/snap-v4.6.1/GlobalConfigTests.Exception_override.verified.txt
+++ b/tests/SnapshotTests/Config/snapshots/snap-v4.6.1/GlobalConfigTests.Exception_override.verified.txt
@@ -143,7 +143,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Config/snapshots/snap-v4.6.1/GlobalConfigTests.Override_all.verified.txt
+++ b/tests/SnapshotTests/Config/snapshots/snap-v4.6.1/GlobalConfigTests.Override_all.verified.txt
@@ -143,7 +143,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Config/snapshots/snap-v4.6.1/GlobalConfigTests.Type_override.verified.txt
+++ b/tests/SnapshotTests/Config/snapshots/snap-v4.6.1/GlobalConfigTests.Type_override.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Config/snapshots/snap-v4.6.1/LocalConfigTests.Conversion_and_exceptions_override.verified.txt
+++ b/tests/SnapshotTests/Config/snapshots/snap-v4.6.1/LocalConfigTests.Conversion_and_exceptions_override.verified.txt
@@ -143,7 +143,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Config/snapshots/snap-v4.6.1/LocalConfigTests.Conversion_override.verified.txt
+++ b/tests/SnapshotTests/Config/snapshots/snap-v4.6.1/LocalConfigTests.Conversion_override.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Config/snapshots/snap-v4.6.1/LocalConfigTests.Defaults.verified.txt
+++ b/tests/SnapshotTests/Config/snapshots/snap-v4.6.1/LocalConfigTests.Defaults.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Config/snapshots/snap-v4.6.1/LocalConfigTests.Defaults_with_validation.verified.txt
+++ b/tests/SnapshotTests/Config/snapshots/snap-v4.6.1/LocalConfigTests.Defaults_with_validation.verified.txt
@@ -143,7 +143,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Config/snapshots/snap-v4.6.1/LocalConfigTests.Defaults_with_validation_and_instances.verified.txt
+++ b/tests/SnapshotTests/Config/snapshots/snap-v4.6.1/LocalConfigTests.Defaults_with_validation_and_instances.verified.txt
@@ -143,7 +143,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Config/snapshots/snap-v4.6.1/LocalConfigTests.Exception_override.verified.txt
+++ b/tests/SnapshotTests/Config/snapshots/snap-v4.6.1/LocalConfigTests.Exception_override.verified.txt
@@ -143,7 +143,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Config/snapshots/snap-v4.6.1/LocalConfigTests.Override_global_config_locally.verified.txt
+++ b/tests/SnapshotTests/Config/snapshots/snap-v4.6.1/LocalConfigTests.Override_global_config_locally.verified.txt
@@ -143,7 +143,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Config/snapshots/snap-v4.6.1/LocalConfigTests.Type_override.verified.txt
+++ b/tests/SnapshotTests/Config/snapshots/snap-v4.6.1/LocalConfigTests.Type_override.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Config/snapshots/snap-v4.8/GlobalConfigTests.Conversion_and_exceptions_override.verified.txt
+++ b/tests/SnapshotTests/Config/snapshots/snap-v4.8/GlobalConfigTests.Conversion_and_exceptions_override.verified.txt
@@ -141,7 +141,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Config/snapshots/snap-v4.8/GlobalConfigTests.Customization_override.verified.txt
+++ b/tests/SnapshotTests/Config/snapshots/snap-v4.8/GlobalConfigTests.Customization_override.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Config/snapshots/snap-v4.8/GlobalConfigTests.Exception_override.verified.txt
+++ b/tests/SnapshotTests/Config/snapshots/snap-v4.8/GlobalConfigTests.Exception_override.verified.txt
@@ -143,7 +143,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Config/snapshots/snap-v4.8/GlobalConfigTests.Override_all.verified.txt
+++ b/tests/SnapshotTests/Config/snapshots/snap-v4.8/GlobalConfigTests.Override_all.verified.txt
@@ -141,7 +141,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Config/snapshots/snap-v4.8/GlobalConfigTests.Type_override.verified.txt
+++ b/tests/SnapshotTests/Config/snapshots/snap-v4.8/GlobalConfigTests.Type_override.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Config/snapshots/snap-v4.8/LocalConfigTests.Conversion_and_exceptions_override.verified.txt
+++ b/tests/SnapshotTests/Config/snapshots/snap-v4.8/LocalConfigTests.Conversion_and_exceptions_override.verified.txt
@@ -141,7 +141,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Config/snapshots/snap-v4.8/LocalConfigTests.Conversion_override.verified.txt
+++ b/tests/SnapshotTests/Config/snapshots/snap-v4.8/LocalConfigTests.Conversion_override.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Config/snapshots/snap-v4.8/LocalConfigTests.Defaults.verified.txt
+++ b/tests/SnapshotTests/Config/snapshots/snap-v4.8/LocalConfigTests.Defaults.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Config/snapshots/snap-v4.8/LocalConfigTests.Defaults_with_validation.verified.txt
+++ b/tests/SnapshotTests/Config/snapshots/snap-v4.8/LocalConfigTests.Defaults_with_validation.verified.txt
@@ -143,7 +143,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Config/snapshots/snap-v4.8/LocalConfigTests.Defaults_with_validation_and_instances.verified.txt
+++ b/tests/SnapshotTests/Config/snapshots/snap-v4.8/LocalConfigTests.Defaults_with_validation_and_instances.verified.txt
@@ -144,7 +144,7 @@ var validation = CustomerId.validate(value);
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Config/snapshots/snap-v4.8/LocalConfigTests.Exception_override.verified.txt
+++ b/tests/SnapshotTests/Config/snapshots/snap-v4.8/LocalConfigTests.Exception_override.verified.txt
@@ -143,7 +143,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Config/snapshots/snap-v4.8/LocalConfigTests.Override_global_config_locally.verified.txt
+++ b/tests/SnapshotTests/Config/snapshots/snap-v4.8/LocalConfigTests.Override_global_config_locally.verified.txt
@@ -183,7 +183,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Config/snapshots/snap-v4.8/LocalConfigTests.Type_override.verified.txt
+++ b/tests/SnapshotTests/Config/snapshots/snap-v4.8/LocalConfigTests.Type_override.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Config/snapshots/snap-v5.0/GlobalConfigTests.Conversion_and_exceptions_override.verified.txt
+++ b/tests/SnapshotTests/Config/snapshots/snap-v5.0/GlobalConfigTests.Conversion_and_exceptions_override.verified.txt
@@ -141,7 +141,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Config/snapshots/snap-v5.0/GlobalConfigTests.Customization_override.verified.txt
+++ b/tests/SnapshotTests/Config/snapshots/snap-v5.0/GlobalConfigTests.Customization_override.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Config/snapshots/snap-v5.0/GlobalConfigTests.Exception_override.verified.txt
+++ b/tests/SnapshotTests/Config/snapshots/snap-v5.0/GlobalConfigTests.Exception_override.verified.txt
@@ -143,7 +143,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Config/snapshots/snap-v5.0/GlobalConfigTests.Override_all.verified.txt
+++ b/tests/SnapshotTests/Config/snapshots/snap-v5.0/GlobalConfigTests.Override_all.verified.txt
@@ -141,7 +141,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Config/snapshots/snap-v5.0/GlobalConfigTests.Type_override.verified.txt
+++ b/tests/SnapshotTests/Config/snapshots/snap-v5.0/GlobalConfigTests.Type_override.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Config/snapshots/snap-v5.0/LocalConfigTests.Conversion_and_exceptions_override.verified.txt
+++ b/tests/SnapshotTests/Config/snapshots/snap-v5.0/LocalConfigTests.Conversion_and_exceptions_override.verified.txt
@@ -141,7 +141,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Config/snapshots/snap-v5.0/LocalConfigTests.Conversion_override.verified.txt
+++ b/tests/SnapshotTests/Config/snapshots/snap-v5.0/LocalConfigTests.Conversion_override.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Config/snapshots/snap-v5.0/LocalConfigTests.Defaults.verified.txt
+++ b/tests/SnapshotTests/Config/snapshots/snap-v5.0/LocalConfigTests.Defaults.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Config/snapshots/snap-v5.0/LocalConfigTests.Defaults_with_validation.verified.txt
+++ b/tests/SnapshotTests/Config/snapshots/snap-v5.0/LocalConfigTests.Defaults_with_validation.verified.txt
@@ -143,7 +143,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Config/snapshots/snap-v5.0/LocalConfigTests.Defaults_with_validation_and_instances.verified.txt
+++ b/tests/SnapshotTests/Config/snapshots/snap-v5.0/LocalConfigTests.Defaults_with_validation_and_instances.verified.txt
@@ -144,7 +144,7 @@ var validation = CustomerId.validate(value);
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Config/snapshots/snap-v5.0/LocalConfigTests.Exception_override.verified.txt
+++ b/tests/SnapshotTests/Config/snapshots/snap-v5.0/LocalConfigTests.Exception_override.verified.txt
@@ -143,7 +143,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Config/snapshots/snap-v5.0/LocalConfigTests.Override_global_config_locally.verified.txt
+++ b/tests/SnapshotTests/Config/snapshots/snap-v5.0/LocalConfigTests.Override_global_config_locally.verified.txt
@@ -225,7 +225,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Config/snapshots/snap-v5.0/LocalConfigTests.Type_override.verified.txt
+++ b/tests/SnapshotTests/Config/snapshots/snap-v5.0/LocalConfigTests.Type_override.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Config/snapshots/snap-v6.0/GlobalConfigTests.Conversion_and_exceptions_override.verified.txt
+++ b/tests/SnapshotTests/Config/snapshots/snap-v6.0/GlobalConfigTests.Conversion_and_exceptions_override.verified.txt
@@ -141,7 +141,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Config/snapshots/snap-v6.0/GlobalConfigTests.Customization_override.verified.txt
+++ b/tests/SnapshotTests/Config/snapshots/snap-v6.0/GlobalConfigTests.Customization_override.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Config/snapshots/snap-v6.0/GlobalConfigTests.Exception_override.verified.txt
+++ b/tests/SnapshotTests/Config/snapshots/snap-v6.0/GlobalConfigTests.Exception_override.verified.txt
@@ -143,7 +143,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Config/snapshots/snap-v6.0/GlobalConfigTests.Override_all.verified.txt
+++ b/tests/SnapshotTests/Config/snapshots/snap-v6.0/GlobalConfigTests.Override_all.verified.txt
@@ -141,7 +141,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Config/snapshots/snap-v6.0/GlobalConfigTests.Type_override.verified.txt
+++ b/tests/SnapshotTests/Config/snapshots/snap-v6.0/GlobalConfigTests.Type_override.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Config/snapshots/snap-v6.0/LocalConfigTests.Conversion_and_exceptions_override.verified.txt
+++ b/tests/SnapshotTests/Config/snapshots/snap-v6.0/LocalConfigTests.Conversion_and_exceptions_override.verified.txt
@@ -141,7 +141,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Config/snapshots/snap-v6.0/LocalConfigTests.Conversion_override.verified.txt
+++ b/tests/SnapshotTests/Config/snapshots/snap-v6.0/LocalConfigTests.Conversion_override.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Config/snapshots/snap-v6.0/LocalConfigTests.Defaults.verified.txt
+++ b/tests/SnapshotTests/Config/snapshots/snap-v6.0/LocalConfigTests.Defaults.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Config/snapshots/snap-v6.0/LocalConfigTests.Defaults_with_validation.verified.txt
+++ b/tests/SnapshotTests/Config/snapshots/snap-v6.0/LocalConfigTests.Defaults_with_validation.verified.txt
@@ -143,7 +143,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Config/snapshots/snap-v6.0/LocalConfigTests.Defaults_with_validation_and_instances.verified.txt
+++ b/tests/SnapshotTests/Config/snapshots/snap-v6.0/LocalConfigTests.Defaults_with_validation_and_instances.verified.txt
@@ -144,7 +144,7 @@ var validation = CustomerId.validate(value);
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Config/snapshots/snap-v6.0/LocalConfigTests.Exception_override.verified.txt
+++ b/tests/SnapshotTests/Config/snapshots/snap-v6.0/LocalConfigTests.Exception_override.verified.txt
@@ -143,7 +143,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Config/snapshots/snap-v6.0/LocalConfigTests.Override_global_config_locally.verified.txt
+++ b/tests/SnapshotTests/Config/snapshots/snap-v6.0/LocalConfigTests.Override_global_config_locally.verified.txt
@@ -225,7 +225,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Config/snapshots/snap-v6.0/LocalConfigTests.Type_override.verified.txt
+++ b/tests/SnapshotTests/Config/snapshots/snap-v6.0/LocalConfigTests.Type_override.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Config/snapshots/snap-v7.0/GlobalConfigTests.Conversion_and_exceptions_override.verified.txt
+++ b/tests/SnapshotTests/Config/snapshots/snap-v7.0/GlobalConfigTests.Conversion_and_exceptions_override.verified.txt
@@ -141,7 +141,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Config/snapshots/snap-v7.0/GlobalConfigTests.Customization_override.verified.txt
+++ b/tests/SnapshotTests/Config/snapshots/snap-v7.0/GlobalConfigTests.Customization_override.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Config/snapshots/snap-v7.0/GlobalConfigTests.Exception_override.verified.txt
+++ b/tests/SnapshotTests/Config/snapshots/snap-v7.0/GlobalConfigTests.Exception_override.verified.txt
@@ -143,7 +143,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Config/snapshots/snap-v7.0/GlobalConfigTests.Override_all.verified.txt
+++ b/tests/SnapshotTests/Config/snapshots/snap-v7.0/GlobalConfigTests.Override_all.verified.txt
@@ -141,7 +141,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Config/snapshots/snap-v7.0/GlobalConfigTests.Type_override.verified.txt
+++ b/tests/SnapshotTests/Config/snapshots/snap-v7.0/GlobalConfigTests.Type_override.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Config/snapshots/snap-v7.0/LocalConfigTests.Conversion_and_exceptions_override.verified.txt
+++ b/tests/SnapshotTests/Config/snapshots/snap-v7.0/LocalConfigTests.Conversion_and_exceptions_override.verified.txt
@@ -141,7 +141,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Config/snapshots/snap-v7.0/LocalConfigTests.Conversion_override.verified.txt
+++ b/tests/SnapshotTests/Config/snapshots/snap-v7.0/LocalConfigTests.Conversion_override.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Config/snapshots/snap-v7.0/LocalConfigTests.Defaults.verified.txt
+++ b/tests/SnapshotTests/Config/snapshots/snap-v7.0/LocalConfigTests.Defaults.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Config/snapshots/snap-v7.0/LocalConfigTests.Defaults_with_validation.verified.txt
+++ b/tests/SnapshotTests/Config/snapshots/snap-v7.0/LocalConfigTests.Defaults_with_validation.verified.txt
@@ -143,7 +143,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Config/snapshots/snap-v7.0/LocalConfigTests.Defaults_with_validation_and_instances.verified.txt
+++ b/tests/SnapshotTests/Config/snapshots/snap-v7.0/LocalConfigTests.Defaults_with_validation_and_instances.verified.txt
@@ -144,7 +144,7 @@ var validation = CustomerId.validate(value);
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Config/snapshots/snap-v7.0/LocalConfigTests.Exception_override.verified.txt
+++ b/tests/SnapshotTests/Config/snapshots/snap-v7.0/LocalConfigTests.Exception_override.verified.txt
@@ -143,7 +143,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Config/snapshots/snap-v7.0/LocalConfigTests.Override_global_config_locally.verified.txt
+++ b/tests/SnapshotTests/Config/snapshots/snap-v7.0/LocalConfigTests.Override_global_config_locally.verified.txt
@@ -267,7 +267,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Config/snapshots/snap-v7.0/LocalConfigTests.Type_override.verified.txt
+++ b/tests/SnapshotTests/Config/snapshots/snap-v7.0/LocalConfigTests.Type_override.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct00oieaoYA5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct00oieaoYA5.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct05nZxSvOQy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct05nZxSvOQy.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct0CW6rWihRa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct0CW6rWihRa.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct0EiiHjJ0Jy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct0EiiHjJ0Jy.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct0HxVdkFuDk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct0HxVdkFuDk.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct0Sp8nFf9po.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct0Sp8nFf9po.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct0YOigHUonk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct0YOigHUonk.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct0mu68DyXFS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct0mu68DyXFS.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct0oZl05ifoL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct0oZl05ifoL.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct101P28DC6b.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct101P28DC6b.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct109xwVU7na.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct109xwVU7na.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct13ZLCuuDdg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct13ZLCuuDdg.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct164v5M7Oiu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct164v5M7Oiu.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct16i8Hnvzik.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct16i8Hnvzik.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct1B64P2KJTT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct1B64P2KJTT.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct1FLNprzFfg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct1FLNprzFfg.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct1Lodf8jQhi.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct1Lodf8jQhi.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct1NM3qeUh2p.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct1NM3qeUh2p.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct1QKloRyprM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct1QKloRyprM.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct1TeundtXb1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct1TeundtXb1.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct1e9vZ2ZVVl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct1e9vZ2ZVVl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct1ibkpE2U9t.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct1ibkpE2U9t.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct1jAvJkz71q.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct1jAvJkz71q.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct1kIcXqyaMm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct1kIcXqyaMm.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct1kIjvNmL26.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct1kIjvNmL26.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct1nopkP9yWt.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct1nopkP9yWt.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct1q3mpvDeuG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct1q3mpvDeuG.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct1rwcZsOxGm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct1rwcZsOxGm.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct1shpv6NmPc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct1shpv6NmPc.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct1tertRu9Xm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct1tertRu9Xm.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct1xSlrFoiE2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct1xSlrFoiE2.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct1xjEjG8zge.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct1xjEjG8zge.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct1zEPcP8TZ0.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct1zEPcP8TZ0.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct22wFvfGOQe.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct22wFvfGOQe.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct23OaGTh97N.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct23OaGTh97N.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct2C0v3cLs4t.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct2C0v3cLs4t.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct2Ii6Pytw94.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct2Ii6Pytw94.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct2KJvO9ifSa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct2KJvO9ifSa.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct2Oea4qEuqL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct2Oea4qEuqL.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct2PRjv73LUz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct2PRjv73LUz.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct2PlWXW13Oo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct2PlWXW13Oo.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct2RjyXdbOmS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct2RjyXdbOmS.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct2WJXBATRow.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct2WJXBATRow.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct2ePshLeWkH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct2ePshLeWkH.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct2iRAZCo7L5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct2iRAZCo7L5.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct2l1qlatawT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct2l1qlatawT.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct2lPhMAoDBl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct2lPhMAoDBl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct2mrBdiaAsD.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct2mrBdiaAsD.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct2yK9S7dzeX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct2yK9S7dzeX.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct2yeMfnvK5l.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct2yeMfnvK5l.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct34i0YswjFg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct34i0YswjFg.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct3AvV0e5RCv.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct3AvV0e5RCv.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct3Fkic0RvsS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct3Fkic0RvsS.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct3Q09CNhFqG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct3Q09CNhFqG.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct3W5X0ROtrE.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct3W5X0ROtrE.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct3YKEcUcTm6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct3YKEcUcTm6.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct3Ysql1aZTo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct3Ysql1aZTo.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct3aLcZ0Gzdp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct3aLcZ0Gzdp.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct3bQ2CbXXiG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct3bQ2CbXXiG.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct3hbQkh2oXr.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct3hbQkh2oXr.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct3o9W3tWIYr.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct3o9W3tWIYr.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct3oRAhgtPFs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct3oRAhgtPFs.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct3rEqyW20Ha.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct3rEqyW20Ha.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct3rh7agTF1u.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct3rh7agTF1u.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct3tAXhVgz0j.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct3tAXhVgz0j.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct3udOlsWezr.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct3udOlsWezr.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct3yavERh0QP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct3yavERh0QP.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct40R1V76roU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct40R1V76roU.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct44PftY660j.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct44PftY660j.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct46ykdVFGwG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct46ykdVFGwG.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct47pp9CzShs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct47pp9CzShs.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct49eWbTEG4e.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct49eWbTEG4e.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct4I0C5KiBcT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct4I0C5KiBcT.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct4NHzRc00m2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct4NHzRc00m2.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct4R1b3Sfk6J.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct4R1b3Sfk6J.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct4VkhuwJa8e.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct4VkhuwJa8e.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct4bA4rV4T7I.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct4bA4rV4T7I.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct4qOfIMBclV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct4qOfIMBclV.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct4tYHXfgnVZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct4tYHXfgnVZ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct4xCfXxpvdy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct4xCfXxpvdy.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct4zYtkggxX9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct4zYtkggxX9.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct566AUa8c9w.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct566AUa8c9w.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct5B3Ki66g8U.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct5B3Ki66g8U.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct5GIHfCnyF0.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct5GIHfCnyF0.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct5GXqW1XpIl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct5GXqW1XpIl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct5R3JtFMKyy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct5R3JtFMKyy.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct5WOnMXao7S.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct5WOnMXao7S.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct5WjoUCBC2W.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct5WjoUCBC2W.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct5YuboIIJis.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct5YuboIIJis.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct5coPgZ627S.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct5coPgZ627S.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct5nsLLrnYzS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct5nsLLrnYzS.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct5p0wzn3Twr.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct5p0wzn3Twr.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct5pUyGEiqRW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct5pUyGEiqRW.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct66VojQk1NI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct66VojQk1NI.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct67D9OX1YBs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct67D9OX1YBs.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct67XWJDtmLp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct67XWJDtmLp.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct6ACGifRdRw.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct6ACGifRdRw.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct6AkdgH06Lh.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct6AkdgH06Lh.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct6BWJO4ygCh.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct6BWJO4ygCh.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct6Eho6XNoOx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct6Eho6XNoOx.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct6Fnny4hIyl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct6Fnny4hIyl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct6GnahT2THT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct6GnahT2THT.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct6Gy1eE7iFg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct6Gy1eE7iFg.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct6InhhK3Bnx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct6InhhK3Bnx.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct6KaWm2V4so.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct6KaWm2V4so.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct6NVZQs4UrE.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct6NVZQs4UrE.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct6PUxZ29VTq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct6PUxZ29VTq.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct6fce05Qu1f.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct6fce05Qu1f.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct6tzbdxQpL4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct6tzbdxQpL4.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct763ixhZiPg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct763ixhZiPg.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct79tZSSX75b.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct79tZSSX75b.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct7E3RzOaVF1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct7E3RzOaVF1.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct7Ev4ba5U4g.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct7Ev4ba5U4g.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct7FkotSk0XD.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct7FkotSk0XD.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct7MpRJpjzYV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct7MpRJpjzYV.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct7UAHrFSXgp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct7UAHrFSXgp.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct7ZDRFK7C6w.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct7ZDRFK7C6w.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct7hWyxK9Im1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct7hWyxK9Im1.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct7vhsXm5Sqy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct7vhsXm5Sqy.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct7vwzjN2hQB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct7vwzjN2hQB.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct7x47kTkDWA.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct7x47kTkDWA.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct814BQq200G.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct814BQq200G.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct84TN7zjoK9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct84TN7zjoK9.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct8CllamWxHF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct8CllamWxHF.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct8KGpb7sMhV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct8KGpb7sMhV.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct8P1XTIrmCU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct8P1XTIrmCU.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct8eGauAG2Iy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct8eGauAG2Iy.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct8hD3MVC60I.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct8hD3MVC60I.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct8q0Jpdjx8u.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct8q0Jpdjx8u.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct8qIwjmR7oN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct8qIwjmR7oN.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct8tbcftbwF8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct8tbcftbwF8.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct8txOZ8smgu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct8txOZ8smgu.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct8yaeAzdZUO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct8yaeAzdZUO.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct98nsmL4Uyu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct98nsmL4Uyu.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct9CTRHeV5gV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct9CTRHeV5gV.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct9E3xYWs4gr.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct9E3xYWs4gr.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct9FbBK7sAEy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct9FbBK7sAEy.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct9HOIXHYhP9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct9HOIXHYhP9.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct9IzMME36Bl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct9IzMME36Bl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct9PLpEx4eEr.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct9PLpEx4eEr.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct9QX6aOMWmP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct9QX6aOMWmP.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct9XFvojKqS7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct9XFvojKqS7.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct9Z0NXJ0nuB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct9Z0NXJ0nuB.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct9cdQxj05PP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct9cdQxj05PP.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct9dJLrfdwrb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct9dJLrfdwrb.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct9fPHF2RcIG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct9fPHF2RcIG.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct9o9IQlJhfF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct9o9IQlJhfF.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct9rTJlJQ4St.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct9rTJlJQ4St.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct9tS75raz9v.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-struct9tS75raz9v.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structA0t67j1fxp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structA0t67j1fxp.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structA2y6S9lFjD.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structA2y6S9lFjD.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structA4N6i5eArl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structA4N6i5eArl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structA6J9ouYjJm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structA6J9ouYjJm.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structAB03r2H43b.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structAB03r2H43b.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structADRxlKyBIl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structADRxlKyBIl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structAE7oPkwYY6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structAE7oPkwYY6.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structAHdMDYZJaK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structAHdMDYZJaK.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structAK2drK1aH7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structAK2drK1aH7.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structAPZGaaiAsI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structAPZGaaiAsI.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structAQE2E9exgF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structAQE2E9exgF.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structAcoWvPhtlp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structAcoWvPhtlp.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structAiFfzJ9xOo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structAiFfzJ9xOo.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structAztsRhE0LF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structAztsRhE0LF.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structB9pN8GfUaU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structB9pN8GfUaU.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structBA8lKBvox6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structBA8lKBvox6.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structBBBafcZBl1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structBBBafcZBl1.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structBF8funmMCW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structBF8funmMCW.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structBNGrkk0Gq9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structBNGrkk0Gq9.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structBW4o7dJUoK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structBW4o7dJUoK.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structBWsRWzQ335.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structBWsRWzQ335.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structBfsVSixXGI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structBfsVSixXGI.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structBjERtQ98tj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structBjERtQ98tj.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structBjy5dZK2rM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structBjy5dZK2rM.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structBm7Ua0ACla.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structBm7Ua0ACla.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structBmz4OJxAlt.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structBmz4OJxAlt.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structBw3OKv2Qms.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structBw3OKv2Qms.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structBzSRBjnY22.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structBzSRBjnY22.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structC0g7V6d3fy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structC0g7V6d3fy.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structCBt0kIYRra.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structCBt0kIYRra.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structCOGSdZd0AL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structCOGSdZd0AL.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structCXeEkfG71q.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structCXeEkfG71q.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structCaHH2Xyhc7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structCaHH2Xyhc7.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structCcLnEruc0v.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structCcLnEruc0v.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structCfD3K5QvsN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structCfD3K5QvsN.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structCqQVJigrtI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structCqQVJigrtI.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structCzvlSZqJoZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structCzvlSZqJoZ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structD2oQVW5tnq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structD2oQVW5tnq.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structD4YplBwWDi.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structD4YplBwWDi.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structD9gno8tRvF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structD9gno8tRvF.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structDACFSZmJCd.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structDACFSZmJCd.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structDVPBdDC863.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structDVPBdDC863.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structDXFa0e4ozX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structDXFa0e4ozX.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structDZZWeqhEZS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structDZZWeqhEZS.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structDhEKpPXtbG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structDhEKpPXtbG.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structDi88qmJim6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structDi88qmJim6.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structDrIOG3dy4E.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structDrIOG3dy4E.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structE1izflhe7m.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structE1izflhe7m.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structE7tbP2KegJ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structE7tbP2KegJ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structECJjSKcI0x.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structECJjSKcI0x.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structECjdzNW2hb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structECjdzNW2hb.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structENNglh8DX6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structENNglh8DX6.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structEVUFJOsbyB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structEVUFJOsbyB.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structEa3Y8fmO5t.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structEa3Y8fmO5t.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structEbe6V1e8rk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structEbe6V1e8rk.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structEilgeng6RU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structEilgeng6RU.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structEjN7KM70nB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structEjN7KM70nB.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structEoc6yu6UZC.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structEoc6yu6UZC.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structEqZWhQIozu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structEqZWhQIozu.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structErRGvv06c5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structErRGvv06c5.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structEvFFf3fZGJ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structEvFFf3fZGJ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structEx5206L0wV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structEx5206L0wV.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structF3dNExh2mR.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structF3dNExh2mR.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structF8DhNrWv7E.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structF8DhNrWv7E.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structF9RjQ90jnp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structF9RjQ90jnp.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structFI3w6VQMfO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structFI3w6VQMfO.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structFJsonz9Nyz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structFJsonz9Nyz.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structFR85FzqbWk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structFR85FzqbWk.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structFXxZeDtCw5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structFXxZeDtCw5.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structFaTXoezJTa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structFaTXoezJTa.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structFhwETmltur.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structFhwETmltur.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structFjGw1Sgvhj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structFjGw1Sgvhj.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structFq1hfAwgHs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structFq1hfAwgHs.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structFvR9kgHTwq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structFvR9kgHTwq.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structFx3ViT9W1l.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structFx3ViT9W1l.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structG23iNFg5pV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structG23iNFg5pV.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structG4WvAWeyY2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structG4WvAWeyY2.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structG5eiJlW14L.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structG5eiJlW14L.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structG7DG28rR3I.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structG7DG28rR3I.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structG8t7pJyR0P.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structG8t7pJyR0P.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structGAhk4JD5f5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structGAhk4JD5f5.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structGElc6so5Vx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structGElc6so5Vx.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structGL3ENulfXA.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structGL3ENulfXA.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structGPgos6Ga6k.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structGPgos6Ga6k.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structGVka0u9TDq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structGVka0u9TDq.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structGXNEUsfHGV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structGXNEUsfHGV.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structGajQGzODLb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structGajQGzODLb.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structGbvlSI6ZFM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structGbvlSI6ZFM.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structGgvsKvoP9v.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structGgvsKvoP9v.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structGiiPLasS8y.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structGiiPLasS8y.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structGlUP6EKlOZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structGlUP6EKlOZ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structGmNuKgusEl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structGmNuKgusEl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structGnndCPLSRE.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structGnndCPLSRE.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structGseI8AQPtb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structGseI8AQPtb.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structGyODqQmfLk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structGyODqQmfLk.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structH5eQeBi4oY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structH5eQeBi4oY.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structH6F7xwrgKM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structH6F7xwrgKM.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structHAW6jHGG5q.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structHAW6jHGG5q.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structHGMhtcP1Gs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structHGMhtcP1Gs.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structHNoL72ys27.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structHNoL72ys27.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structHOwIYbq2Gd.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structHOwIYbq2Gd.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structHQ1FzQOf8n.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structHQ1FzQOf8n.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structHQRXU94JgV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structHQRXU94JgV.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structHSN0q7oMVM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structHSN0q7oMVM.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structHYnhl5ltDv.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structHYnhl5ltDv.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structHcCEQbo9Zf.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structHcCEQbo9Zf.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structHfRiDfgqPK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structHfRiDfgqPK.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structHnGXhmegvA.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structHnGXhmegvA.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structHnNLvYqbMR.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structHnNLvYqbMR.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structHt9F9jtMD0.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structHt9F9jtMD0.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structHusaUbKJVm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structHusaUbKJVm.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structHvGrPaR9Bu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structHvGrPaR9Bu.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structHvI693MHyM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structHvI693MHyM.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structHyrFeqyBCY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structHyrFeqyBCY.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structHzJtxAljeg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structHzJtxAljeg.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structI2aSLtV0nK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structI2aSLtV0nK.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structI5QO2BUMxk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structI5QO2BUMxk.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structI6BZQjT6lx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structI6BZQjT6lx.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structICD2Fjdvwq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structICD2Fjdvwq.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structIHkMJI02Cs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structIHkMJI02Cs.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structIJpxdh5h1j.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structIJpxdh5h1j.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structIKVPnPqtVG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structIKVPnPqtVG.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structIODsh0cyAj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structIODsh0cyAj.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structIWnVfC7bMR.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structIWnVfC7bMR.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structIg48IJ1BGz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structIg48IJ1BGz.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structIjpYds4lWa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structIjpYds4lWa.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structImqfRF5u5d.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structImqfRF5u5d.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structIpNWKHAjIK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structIpNWKHAjIK.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structIq2IxAwTbz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structIq2IxAwTbz.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structIqjoEWN5a6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structIqjoEWN5a6.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structJ1WoVnmoNK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structJ1WoVnmoNK.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structJ4N4ApAuNd.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structJ4N4ApAuNd.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structJ4sxZ95hzs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structJ4sxZ95hzs.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structJ5ThymSmBk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structJ5ThymSmBk.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structJBdaFHCitX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structJBdaFHCitX.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structJBjYKH35Id.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structJBjYKH35Id.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structJEL7o5TRHh.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structJEL7o5TRHh.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structJFU1xlKVwi.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structJFU1xlKVwi.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structJIOp0LkuGx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structJIOp0LkuGx.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structJKSxRHdkgU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structJKSxRHdkgU.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structJLl1JS3EBA.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structJLl1JS3EBA.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structJPod17bl3h.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structJPod17bl3h.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structJSkoDJdEmy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structJSkoDJdEmy.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structJXZ8aT3Z1A.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structJXZ8aT3Z1A.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structJYFDwGezZu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structJYFDwGezZu.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structJZBOzjdChs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structJZBOzjdChs.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structJcJCwPR9O6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structJcJCwPR9O6.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structJdaXHv9XGK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structJdaXHv9XGK.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structJguJlpO2Zx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structJguJlpO2Zx.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structJjOrVxY09U.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structJjOrVxY09U.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structJmS6AEcW3Z.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structJmS6AEcW3Z.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structJmgvdzeb5n.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structJmgvdzeb5n.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structJt6jf8vpBs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structJt6jf8vpBs.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structJyoG3utfUF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structJyoG3utfUF.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structK17aJaWFKp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structK17aJaWFKp.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structK6zBHvtXEz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structK6zBHvtXEz.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structK8yLeG1Rq8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structK8yLeG1Rq8.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structKAGtyEb0Mc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structKAGtyEb0Mc.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structKBZsUWVDxs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structKBZsUWVDxs.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structKD97Jf4W3S.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structKD97Jf4W3S.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structKDBDsZNe9Z.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structKDBDsZNe9Z.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structKDWeAZ2IPn.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structKDWeAZ2IPn.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structKF4sn2PYXa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structKF4sn2PYXa.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structKHnzHYYQv9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structKHnzHYYQv9.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structKJhvJs3EGG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structKJhvJs3EGG.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structKLSPh0PXhl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structKLSPh0PXhl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structKNZX9fxtdl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structKNZX9fxtdl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structKS9Hbi6AwZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structKS9Hbi6AwZ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structKVlfLjDmn1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structKVlfLjDmn1.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structKX2JHsJ0bd.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structKX2JHsJ0bd.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structKkESsYkID7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structKkESsYkID7.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structKkHcnJvU6l.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structKkHcnJvU6l.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structKkvn2ffBgz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structKkvn2ffBgz.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structKxmFSKOkr0.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structKxmFSKOkr0.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structL0iuHiXIxa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structL0iuHiXIxa.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structL28FwCaWlq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structL28FwCaWlq.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structL3YlcXIU3G.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structL3YlcXIU3G.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structL5PAA2Y49o.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structL5PAA2Y49o.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structL8rTw5Q3JI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structL8rTw5Q3JI.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structLJsbrcp1QV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structLJsbrcp1QV.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structLKxIRREq4D.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structLKxIRREq4D.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structLMQlSHV6GT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structLMQlSHV6GT.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structLV2nB9GvAz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structLV2nB9GvAz.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structLa1OJDLBp5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structLa1OJDLBp5.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structLcNNHqG92U.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structLcNNHqG92U.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structLnY2DL1Mbw.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structLnY2DL1Mbw.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structLpxoYUnOy7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structLpxoYUnOy7.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structLs7CLvlkgi.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structLs7CLvlkgi.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structLtMZ0XaStC.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structLtMZ0XaStC.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structLy4yvDjUuQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structLy4yvDjUuQ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structM9DKZGOLDg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structM9DKZGOLDg.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structMBndhRFxei.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structMBndhRFxei.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structMEcvkINwlN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structMEcvkINwlN.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structMFY7puSlGX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structMFY7puSlGX.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structMQnq3Fo18k.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structMQnq3Fo18k.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structMRN9c8EZAu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structMRN9c8EZAu.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structMSaXkM98gx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structMSaXkM98gx.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structMe4GO0lmyL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structMe4GO0lmyL.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structMf7H2FRsCR.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structMf7H2FRsCR.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structMgFMQz9tN4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structMgFMQz9tN4.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structMhWZ76XLqK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structMhWZ76XLqK.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structMiv3889DlT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structMiv3889DlT.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structMkNnqyG9Tl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structMkNnqyG9Tl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structMw7h6zUCoS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structMw7h6zUCoS.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structN5CGh6EWiK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structN5CGh6EWiK.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structN86zzxZWL3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structN86zzxZWL3.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structN9VLieAgkB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structN9VLieAgkB.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structNB005jf6q4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structNB005jf6q4.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structNW2O8zaFJU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structNW2O8zaFJU.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structNXVElSFyJY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structNXVElSFyJY.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structNXkTPXgNCQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structNXkTPXgNCQ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structNYxtIN1k6X.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structNYxtIN1k6X.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structNcunqydrcp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structNcunqydrcp.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structNfG8poVmRX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structNfG8poVmRX.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structNpSaGkUh99.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structNpSaGkUh99.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structNphpYJarez.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structNphpYJarez.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structNq8WSpQa6r.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structNq8WSpQa6r.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structNuHNDIZUYr.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structNuHNDIZUYr.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structO4Kr2Vp6iB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structO4Kr2Vp6iB.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structO5SpO4Lmqy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structO5SpO4Lmqy.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structO6aBEtLHCl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structO6aBEtLHCl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structO8aC92gkJu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structO8aC92gkJu.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structOAXjhVxHVW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structOAXjhVxHVW.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structOBggRrGGeA.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structOBggRrGGeA.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structOCKiZ8XvN4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structOCKiZ8XvN4.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structOTagHf6dta.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structOTagHf6dta.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structOmPR4GDmha.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structOmPR4GDmha.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structOnU7Y1iyOW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structOnU7Y1iyOW.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structOruSh6IU68.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structOruSh6IU68.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structP07kLcgWy2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structP07kLcgWy2.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structP0hi03Yr5J.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structP0hi03Yr5J.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structP51IT0iQls.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structP51IT0iQls.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structPC53CFAahl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structPC53CFAahl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structPDETEBub2B.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structPDETEBub2B.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structPIEO17rXv3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structPIEO17rXv3.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structPL1Vy8gAQG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structPL1Vy8gAQG.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structPOAJbOn5yN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structPOAJbOn5yN.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structPWOGZtzGIy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structPWOGZtzGIy.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structPWOtvXxst0.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structPWOtvXxst0.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structPaMBWeOEZb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structPaMBWeOEZb.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structPbViqUkC9s.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structPbViqUkC9s.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structPjXLhVCSo2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structPjXLhVCSo2.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structPmsSWhVFlx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structPmsSWhVFlx.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structPvttwCSove.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structPvttwCSove.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structPy7auxT2wm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structPy7auxT2wm.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structPzKBHCX9aj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structPzKBHCX9aj.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structQ1lt85NZkv.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structQ1lt85NZkv.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structQ9W3v3dQYW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structQ9W3v3dQYW.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structQBpF2mc1un.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structQBpF2mc1un.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structQLoTxIicfl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structQLoTxIicfl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structQNBjmFEISk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structQNBjmFEISk.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structQRNlszU7N1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structQRNlszU7N1.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structQRrZvgSvEl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structQRrZvgSvEl.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structQu8eKSWeIJ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structQu8eKSWeIJ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structQwjx7jDCDX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structQwjx7jDCDX.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structQwri7Ax9TK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structQwri7Ax9TK.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structR4xaEYdpRY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structR4xaEYdpRY.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structR6bsgVIYE6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structR6bsgVIYE6.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structR6j965l6JZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structR6j965l6JZ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structR6yPnOD0oz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structR6yPnOD0oz.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structR8eEQpI0YT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structR8eEQpI0YT.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structRBr9HNIGgm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structRBr9HNIGgm.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structRBwjivoMMP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structRBwjivoMMP.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structRFFK9pIT93.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structRFFK9pIT93.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structRJYj3K0a3c.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structRJYj3K0a3c.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structRLhaWW9haz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structRLhaWW9haz.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structRSckKIVPNO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structRSckKIVPNO.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structRX7hJYzEEc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structRX7hJYzEEc.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structRbEgtyrBAH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structRbEgtyrBAH.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structRbgB04HmL4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structRbgB04HmL4.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structRdgEVFWPU8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structRdgEVFWPU8.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structRjYd0rym9S.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structRjYd0rym9S.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structRpd0ErOBb6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structRpd0ErOBb6.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structRtcf0YV8fO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structRtcf0YV8fO.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structRtjThoUz7H.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structRtjThoUz7H.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structRyTk5RxJJO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structRyTk5RxJJO.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structS1RhuauboU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structS1RhuauboU.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structS6bmXaMMyl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structS6bmXaMMyl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structSDPIMkAwH8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structSDPIMkAwH8.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structSEmAsgVkk9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structSEmAsgVkk9.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structSIfHQocAM7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structSIfHQocAM7.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structSL3XN9PByF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structSL3XN9PByF.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structSOJZorG6h4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structSOJZorG6h4.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structSOQ2b3Trj9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structSOQ2b3Trj9.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structSOcWqfVVcP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structSOcWqfVVcP.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structSUuI5kWBPQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structSUuI5kWBPQ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structSWz0ZdY1fL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structSWz0ZdY1fL.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structSXB5wflpQj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structSXB5wflpQj.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structSaCKmxwW7X.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structSaCKmxwW7X.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structSkgZGVkxzj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structSkgZGVkxzj.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structSuSfIvUv2A.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structSuSfIvUv2A.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structSuaJbDOn73.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structSuaJbDOn73.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structSv55DLNwHy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structSv55DLNwHy.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structSvXjwmwWp8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structSvXjwmwWp8.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structT024qoIGBu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structT024qoIGBu.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structT396ygje53.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structT396ygje53.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structTA8Sp22K2U.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structTA8Sp22K2U.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structTGF07uM1y9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structTGF07uM1y9.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structTKbYYBx9QZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structTKbYYBx9QZ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structTLyC86eODa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structTLyC86eODa.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structTSEu5hclTq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structTSEu5hclTq.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structTX5YCrOcOo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structTX5YCrOcOo.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structTX6rXf2RZh.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structTX6rXf2RZh.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structTaJbzfeDjo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structTaJbzfeDjo.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structTaYGLKdSM8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structTaYGLKdSM8.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structTgcZPmWOx2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structTgcZPmWOx2.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structTh5NbnUqzI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structTh5NbnUqzI.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structTknpxoQFvS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structTknpxoQFvS.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structTqu8KoZQjY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structTqu8KoZQjY.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structTuAcbBNnZm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structTuAcbBNnZm.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structTuWH3zeluv.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structTuWH3zeluv.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structTwjPuMKDiB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structTwjPuMKDiB.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structTxF88EuH4Q.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structTxF88EuH4Q.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structTzQ4rWvlZ3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structTzQ4rWvlZ3.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structU2kogkOlcf.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structU2kogkOlcf.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structU3dy6bkQcN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structU3dy6bkQcN.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structUA5Zgdsa4W.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structUA5Zgdsa4W.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structUC7urls6rG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structUC7urls6rG.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structUJ5RVg0xHN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structUJ5RVg0xHN.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structUL0XgKUiea.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structUL0XgKUiea.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structUYdnQvYvKk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structUYdnQvYvKk.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structUaTPRyIwWQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structUaTPRyIwWQ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structUgp6Bg804O.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structUgp6Bg804O.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structUgsqUT0Fw8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structUgsqUT0Fw8.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structUomjJGDhS3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structUomjJGDhS3.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structUrJ7tMPYdi.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structUrJ7tMPYdi.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structUsGUm5feCJ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structUsGUm5feCJ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structUx6sDnae6o.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structUx6sDnae6o.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structUyBELJkxhd.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structUyBELJkxhd.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structV1mFMqHDyz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structV1mFMqHDyz.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structV3DEOjYkAI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structV3DEOjYkAI.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structV4EcMh64Nu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structV4EcMh64Nu.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structVABFQlbdB8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structVABFQlbdB8.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structVCKWE5qXDQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structVCKWE5qXDQ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structVF3eV6RT5A.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structVF3eV6RT5A.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structVGVFt2H4Jq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structVGVFt2H4Jq.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structVHmibu21U1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structVHmibu21U1.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structVJQMEbTTcW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structVJQMEbTTcW.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structVW9Wugrq8f.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structVW9Wugrq8f.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structVbui9U8nJN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structVbui9U8nJN.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structVqmZxmYjrS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structVqmZxmYjrS.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structVwumd12dMR.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structVwumd12dMR.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structW03TuqLzYH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structW03TuqLzYH.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structW6NGdR4FHA.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structW6NGdR4FHA.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structW8RwEte1K1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structW8RwEte1K1.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structWFr5O7xRwi.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structWFr5O7xRwi.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structWJw9ZLP7fK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structWJw9ZLP7fK.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structWODpD4eAmE.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structWODpD4eAmE.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structWOGNQBbIW7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structWOGNQBbIW7.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structWQN1KyUD5b.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structWQN1KyUD5b.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structWTDgYPieK1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structWTDgYPieK1.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structWVtboPH1aE.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structWVtboPH1aE.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structWiPM4vCvbR.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structWiPM4vCvbR.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structWk1zWo8r9K.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structWk1zWo8r9K.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structWkYOcVuG9r.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structWkYOcVuG9r.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structWqKLr6PuT3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structWqKLr6PuT3.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structWyFaNRxWDU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structWyFaNRxWDU.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structX0tLJiI6QS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structX0tLJiI6QS.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structX74WdLPgP3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structX74WdLPgP3.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structXLePVWtJFS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structXLePVWtJFS.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structXNJAbmwEpz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structXNJAbmwEpz.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structXOlFj8WTWU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structXOlFj8WTWU.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structXQpY9eJk4m.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structXQpY9eJk4m.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structXU2GzBHEnm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structXU2GzBHEnm.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structXWIUjIMjuc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structXWIUjIMjuc.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structXYOl2gpZhZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structXYOl2gpZhZ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structXYrXq7Kz5O.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structXYrXq7Kz5O.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structXab1L6RKkc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structXab1L6RKkc.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structXcQSZS9Pq3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structXcQSZS9Pq3.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structXdOq3rooU7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structXdOq3rooU7.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structXpfvMzo3SU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structXpfvMzo3SU.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structXs0m0HB3Ve.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structXs0m0HB3Ve.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structXsoVym5xGF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structXsoVym5xGF.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structXxbrxyvfJK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structXxbrxyvfJK.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structY0sbuM1lf1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structY0sbuM1lf1.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structY2WI2qZBJc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structY2WI2qZBJc.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structY3MSP8GJLq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structY3MSP8GJLq.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structY7ZzgHzGVw.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structY7ZzgHzGVw.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structY8HkjRfwpg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structY8HkjRfwpg.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structYAzsftuDhx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structYAzsftuDhx.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structYE37gD7DoN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structYE37gD7DoN.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structYNODMJt0nI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structYNODMJt0nI.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structYOoQMQYEZo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structYOoQMQYEZo.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structYPtr2Dr86B.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structYPtr2Dr86B.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structYXRqKm5H9U.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structYXRqKm5H9U.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structYa2X1A0XlS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structYa2X1A0XlS.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structYj7TbLsdP4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structYj7TbLsdP4.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structYlF6RxCqVs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structYlF6RxCqVs.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structYo1jTzfuKl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structYo1jTzfuKl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structYrew2qdBuH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structYrew2qdBuH.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structYwZwDfIvIG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structYwZwDfIvIG.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structZ3DY5gvzFY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structZ3DY5gvzFY.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structZBrvC38b8N.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structZBrvC38b8N.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structZC6ZaapQdD.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structZC6ZaapQdD.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structZGNK9Twr9S.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structZGNK9Twr9S.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structZGqp2bRDtx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structZGqp2bRDtx.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structZJSKolxfqc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structZJSKolxfqc.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structZR3LiJX7PO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structZR3LiJX7PO.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structZW26HGLchP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structZW26HGLchP.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structZi1RqmdSol.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structZi1RqmdSol.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structZoimFj6xEE.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structZoimFj6xEE.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structZpfDnRPksn.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structZpfDnRPksn.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structZr2k5TeLcE.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structZr2k5TeLcE.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structZtqbbnQjzj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structZtqbbnQjzj.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structZupKEHABUk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structZupKEHABUk.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structa0AhWFAoDG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structa0AhWFAoDG.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structa5eW784LQf.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structa5eW784LQf.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structa6BXYQAwEm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structa6BXYQAwEm.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structa6bL6toTDQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structa6bL6toTDQ.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structa85eS8wvGC.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structa85eS8wvGC.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structaBCMiwiL14.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structaBCMiwiL14.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structaCvUpfrOud.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structaCvUpfrOud.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structaMVAJ9INz0.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structaMVAJ9INz0.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structaNX02HPg7T.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structaNX02HPg7T.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structaacjP2BYDY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structaacjP2BYDY.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structafSLEQGtjb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structafSLEQGtjb.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structawZmlvXiXW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structawZmlvXiXW.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structaxV4fiWwZ7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structaxV4fiWwZ7.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structayNEhBBg4t.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structayNEhBBg4t.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structb265yb0csM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structb265yb0csM.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structb63fAzKNR7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structb63fAzKNR7.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structbBsug1Wd34.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structbBsug1Wd34.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structbNMyvNH8WM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structbNMyvNH8WM.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structbX4S27LXkH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structbX4S27LXkH.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structblpexlSs9M.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structblpexlSs9M.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structbmmnw9qu32.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structbmmnw9qu32.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structbsrrxTZOqn.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structbsrrxTZOqn.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structbtgnPXO5Rq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structbtgnPXO5Rq.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structbwtswCbHZn.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structbwtswCbHZn.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structc0ARtdYgED.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structc0ARtdYgED.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structc0K76QtGvt.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structc0K76QtGvt.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structc19BIAaEkY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structc19BIAaEkY.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structcIUFEZhrle.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structcIUFEZhrle.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structcU51DXcyE8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structcU51DXcyE8.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structcbnz0kvIwn.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structcbnz0kvIwn.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structcfbnUeCgbt.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structcfbnUeCgbt.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structcjMmD9Dwfx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structcjMmD9Dwfx.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structclmVkpAhb8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structclmVkpAhb8.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structcoAqE1boX6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structcoAqE1boX6.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structcormXUf4WS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structcormXUf4WS.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structcqdGRq2WNh.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structcqdGRq2WNh.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structczOiELiAB7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structczOiELiAB7.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structd2ojXxCaNW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structd2ojXxCaNW.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structd4OcbMDcGL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structd4OcbMDcGL.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structd9nB4x1U6u.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structd9nB4x1U6u.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structdEhJcrsORt.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structdEhJcrsORt.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structdKBNYvwyxK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structdKBNYvwyxK.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structdNGVHIlzAj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structdNGVHIlzAj.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structdSftno00MK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structdSftno00MK.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structdXZpHpuk3x.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structdXZpHpuk3x.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structdXgIF94ebo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structdXgIF94ebo.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structdhEH1P8yDX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structdhEH1P8yDX.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structdq0ytTGdT7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structdq0ytTGdT7.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structdr28D0z5ZH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structdr28D0z5ZH.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structe4z2kYEwsw.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structe4z2kYEwsw.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structe79Za4b7Ml.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structe79Za4b7Ml.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structeJF56nvsEj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structeJF56nvsEj.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structeW6hiVZjD9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structeW6hiVZjD9.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structegI0J6pwbq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structegI0J6pwbq.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structemjd05RWc3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structemjd05RWc3.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structeqBjnWgb5P.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structeqBjnWgb5P.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structf0akg4gumK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structf0akg4gumK.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structf32Rx1NpEm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structf32Rx1NpEm.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structf3hg4Duqet.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structf3hg4Duqet.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structf74ThK893J.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structf74ThK893J.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structfBkGsQBirP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structfBkGsQBirP.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structfCVtyydYxM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structfCVtyydYxM.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structfCayR9pma6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structfCayR9pma6.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structfG4ASdjUC9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structfG4ASdjUC9.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structfJdkVlyVac.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structfJdkVlyVac.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structfNnOzIDYzL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structfNnOzIDYzL.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structfOOjVzFOC9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structfOOjVzFOC9.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structfTXY9OU4mh.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structfTXY9OU4mh.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structfWEUc1K6FG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structfWEUc1K6FG.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structfYJ2Mkk1al.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structfYJ2Mkk1al.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structfcg2UqwprF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structfcg2UqwprF.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structfd0mCQVHBl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structfd0mCQVHBl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structfwecOIJDmQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structfwecOIJDmQ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structgBuG9DjtOU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structgBuG9DjtOU.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structgIAdPMClq9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structgIAdPMClq9.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structgJaEzQzHlG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structgJaEzQzHlG.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structgTI819u8oK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structgTI819u8oK.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structgaVRwvBYOY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structgaVRwvBYOY.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structgmDuxmO8uQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structgmDuxmO8uQ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structgnTh8YZCI4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structgnTh8YZCI4.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structgnzwfueLCU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structgnzwfueLCU.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structgodJTvsSrL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structgodJTvsSrL.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structgoyNOloADC.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structgoyNOloADC.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structgrMFKxp6Rp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structgrMFKxp6Rp.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structgu5AmoUnKH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structgu5AmoUnKH.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structgw0RpMV2f4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structgw0RpMV2f4.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structgzPFVO95T5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structgzPFVO95T5.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structh0wIvbjPFM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structh0wIvbjPFM.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structh0zYLuKys0.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structh0zYLuKys0.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structh4borQn8tt.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structh4borQn8tt.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structhEYyOpWNQA.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structhEYyOpWNQA.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structhKVOXTzhtj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structhKVOXTzhtj.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structhP7CI8CVIx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structhP7CI8CVIx.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structhRp6BjrXlq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structhRp6BjrXlq.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structhXluAaYGUP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structhXluAaYGUP.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structhc5U7IjcZc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structhc5U7IjcZc.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structhjYDoXKd1y.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structhjYDoXKd1y.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structhk5xXOFY3B.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structhk5xXOFY3B.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structhlXXNdntjL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structhlXXNdntjL.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structhnljKmvH1S.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structhnljKmvH1S.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structhsMP7WDnTb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structhsMP7WDnTb.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structi5tx16f99j.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structi5tx16f99j.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structi60i9flgEl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structi60i9flgEl.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structiGcBGhWkFg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structiGcBGhWkFg.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structiH2t1AudUv.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structiH2t1AudUv.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structiJO3yTUlA6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structiJO3yTUlA6.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structiMxQrDbyMm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structiMxQrDbyMm.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structiRTC8Ri5hh.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structiRTC8Ri5hh.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structiUTYiuw7nL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structiUTYiuw7nL.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structifVuZi4Efe.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structifVuZi4Efe.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structigySx6ywF4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structigySx6ywF4.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structimk6k6ZOQP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structimk6k6ZOQP.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structiyfYt6St4H.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structiyfYt6St4H.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structj0Jp6zlUkb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structj0Jp6zlUkb.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structj2noj6YBli.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structj2noj6YBli.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structj80X6OAWFM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structj80X6OAWFM.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structjATzvt82Yc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structjATzvt82Yc.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structjHYdKd1qGS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structjHYdKd1qGS.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structjIn9JVMI49.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structjIn9JVMI49.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structjKvkQzPnI2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structjKvkQzPnI2.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structjPeWDdzelT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structjPeWDdzelT.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structjVynlgrJOg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structjVynlgrJOg.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structjXzq5dAQfq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structjXzq5dAQfq.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structjlEQy1XgIm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structjlEQy1XgIm.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structjpZYztDGZv.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structjpZYztDGZv.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structjyzBmrWLpD.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structjyzBmrWLpD.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structjzLZ1Fd1su.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structjzLZ1Fd1su.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structk0RWOtD4Cb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structk0RWOtD4Cb.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structk5uhI551Ib.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structk5uhI551Ib.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structkBpo9DUgjg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structkBpo9DUgjg.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structkKCqpBwgSB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structkKCqpBwgSB.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structkMn4TDNnDw.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structkMn4TDNnDw.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structkTDa7zOTTq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structkTDa7zOTTq.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structkcnuBfgvqB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structkcnuBfgvqB.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structke5R4wNmaV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structke5R4wNmaV.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structkgOVznysHS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structkgOVznysHS.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structkjR2PqZPCx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structkjR2PqZPCx.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structkjvkPYElx2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structkjvkPYElx2.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structko3HKcubO4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structko3HKcubO4.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structl1rwee6A0W.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structl1rwee6A0W.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structl9GK15NFfI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structl9GK15NFfI.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structl9dEcAYjZX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structl9dEcAYjZX.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structlCbFTLeEcO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structlCbFTLeEcO.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structlFoUTH7TGY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structlFoUTH7TGY.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structlFuagxP4pj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structlFuagxP4pj.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structlKqlZNIiTG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structlKqlZNIiTG.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structlM9nCK9mVa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structlM9nCK9mVa.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structlNxcettVbW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structlNxcettVbW.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structlOMWejTcie.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structlOMWejTcie.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structlPPzP90v2M.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structlPPzP90v2M.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structlWE7ijbTPg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structlWE7ijbTPg.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structlWZpr8mFUz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structlWZpr8mFUz.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structlfb6Bcmyzv.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structlfb6Bcmyzv.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structliZR39PG4B.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structliZR39PG4B.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structlilo17vqrO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structlilo17vqrO.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structlmBHuI2CdK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structlmBHuI2CdK.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structlsRnaxudRi.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structlsRnaxudRi.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structlwBBVufID9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structlwBBVufID9.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structmE7fFfuHjx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structmE7fFfuHjx.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structmPX6OOh4Nl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structmPX6OOh4Nl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structmR2t9GgAZ5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structmR2t9GgAZ5.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structmU9k8N2S1x.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structmU9k8N2S1x.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structmUQioQKiXp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structmUQioQKiXp.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structmWBF30udKT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structmWBF30udKT.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structmaUySacG7e.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structmaUySacG7e.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structmj4Oyb3GgX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structmj4Oyb3GgX.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structmuAhuD4KVQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structmuAhuD4KVQ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structmwjaO3Uyrs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structmwjaO3Uyrs.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structn5h1DHBxub.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structn5h1DHBxub.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structnAdqmBnbeg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structnAdqmBnbeg.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structnAvYhH07Gs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structnAvYhH07Gs.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structnHnX8P1WDq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structnHnX8P1WDq.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structnNkjJDcz0P.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structnNkjJDcz0P.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structnPwZk9I7YN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structnPwZk9I7YN.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structnUJfW4NMaA.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structnUJfW4NMaA.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structnXMZUp9V4V.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structnXMZUp9V4V.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structnjkuDZnOoQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structnjkuDZnOoQ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structnq8k7vNWX3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structnq8k7vNWX3.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structnrVsGpyHSB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structnrVsGpyHSB.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structnsGvdkMRFZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structnsGvdkMRFZ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structoAhXI74h9j.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structoAhXI74h9j.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structoahbTSUqku.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structoahbTSUqku.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structoiRn4GygF9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structoiRn4GygF9.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structov6aJQLXqu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structov6aJQLXqu.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structovm1h7N1tD.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structovm1h7N1tD.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structoypCXXMXYK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structoypCXXMXYK.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structp39x1W6Nmw.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structp39x1W6Nmw.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structp5F0SqEi1N.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structp5F0SqEi1N.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structpK1zdl2ooH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structpK1zdl2ooH.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structpLXABe2wJc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structpLXABe2wJc.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structpMr2v6juAQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structpMr2v6juAQ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structpXZA41Y8fK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structpXZA41Y8fK.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structpkIouuiKqe.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structpkIouuiKqe.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structpnMhTmK3QH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structpnMhTmK3QH.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structpuA2r64pbW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structpuA2r64pbW.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structpwCAT0hshK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structpwCAT0hshK.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structq1BEWkecYX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structq1BEWkecYX.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structq2gqs38KnH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structq2gqs38KnH.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structq5OjZ10BEs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structq5OjZ10BEs.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structqGa10MSSRs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structqGa10MSSRs.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structqGuE1lEn2E.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structqGuE1lEn2E.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structqK7XKTZI6a.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structqK7XKTZI6a.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structqRtOraogqy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structqRtOraogqy.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structqTdD25cQMq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structqTdD25cQMq.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structqVenFBZMmB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structqVenFBZMmB.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structqVymoyiTzO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structqVymoyiTzO.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structqYoMOdyW5o.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structqYoMOdyW5o.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structqZqGFZMAp0.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structqZqGFZMAp0.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structqceTFkotG1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structqceTFkotG1.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structqklsh0VtCj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structqklsh0VtCj.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structqkwGFodzYo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structqkwGFodzYo.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structqlynSYPIzj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structqlynSYPIzj.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structqmylEQUQxN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structqmylEQUQxN.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structqsdnJQvtod.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structqsdnJQvtod.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structr1IUWdH7kS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structr1IUWdH7kS.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structrDLhl5fFyI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structrDLhl5fFyI.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structrJ6A29EFD3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structrJ6A29EFD3.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structrLI0qkdwNT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structrLI0qkdwNT.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structrNNNMoMUX5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structrNNNMoMUX5.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structrQyjIvxeGC.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structrQyjIvxeGC.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structrUZIsQzLzo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structrUZIsQzLzo.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structrUrNNgGYxl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structrUrNNgGYxl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structrZORE7saci.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structrZORE7saci.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structrnEvXbtOaJ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structrnEvXbtOaJ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structrv6cJ7e4eI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structrv6cJ7e4eI.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structrvnG4DB0O9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structrvnG4DB0O9.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structrxuRIzLrOd.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structrxuRIzLrOd.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structs0wKthNJDH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structs0wKthNJDH.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structs6tlj8Ujb6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structs6tlj8Ujb6.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structs81xiTr3V2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structs81xiTr3V2.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structs9FC686ssT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structs9FC686ssT.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structsU7ru1S3Bn.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structsU7ru1S3Bn.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structsconExg82n.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structsconExg82n.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structsnl6YWFzw6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structsnl6YWFzw6.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structsr11hihvVP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structsr11hihvVP.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structsrFnuySLJZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structsrFnuySLJZ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structsyMjE23XYL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structsyMjE23XYL.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structt1zhtoy3QG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structt1zhtoy3QG.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structt3vc10gLez.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structt3vc10gLez.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structt7Y6XwomUH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structt7Y6XwomUH.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structtFfTsyMFtj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structtFfTsyMFtj.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structtKTQH67TAx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structtKTQH67TAx.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structtRnRKY1Nt9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structtRnRKY1Nt9.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structtVv0gLLUw6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structtVv0gLLUw6.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structtdu9UH9BR6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structtdu9UH9BR6.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structtkLijaINDB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structtkLijaINDB.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structtmi3Y4xjWJ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structtmi3Y4xjWJ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structtoRHBeshpF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structtoRHBeshpF.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structtoojZOxzYL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structtoojZOxzYL.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structuEWock0xfg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structuEWock0xfg.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structuYFS57GpEz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structuYFS57GpEz.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structuZLTFqoTc9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structuZLTFqoTc9.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structuesCCsCmB9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structuesCCsCmB9.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structuk9n40Ba1s.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structuk9n40Ba1s.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structurOByRIJr5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structurOByRIJr5.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structusM7i9eFda.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structusM7i9eFda.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structuzTdZWiu60.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structuzTdZWiu60.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structv4jF52UQ9H.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structv4jF52UQ9H.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structv9bmg59CEV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structv9bmg59CEV.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structvE6YTruKB5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structvE6YTruKB5.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structvGYXxaXkfO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structvGYXxaXkfO.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structvIiPiag0AP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structvIiPiag0AP.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structvJXxV1TNGG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structvJXxV1TNGG.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structvLrhLw24Yo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structvLrhLw24Yo.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structvPLGLtUGvc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structvPLGLtUGvc.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structvQ4tBtsFIQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structvQ4tBtsFIQ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structvetTPo8phL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structvetTPo8phL.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structvh6HUMxCO1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structvh6HUMxCO1.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structvhPOJekCB6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structvhPOJekCB6.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structvqpjGCBNgC.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structvqpjGCBNgC.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structw1Jcuo2qcB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structw1Jcuo2qcB.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structw1LUTeHkEP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structw1LUTeHkEP.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structw704rOrUeD.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structw704rOrUeD.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structwAVE8pzuIw.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structwAVE8pzuIw.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structwE9USHmMoa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structwE9USHmMoa.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structwKyV6c3NXx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structwKyV6c3NXx.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structwNNWk20409.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structwNNWk20409.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structwPjsuxb7PR.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structwPjsuxb7PR.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structwquRams9Fs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structwquRams9Fs.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structwyz9cVcdwh.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structwyz9cVcdwh.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structx29mgYMw04.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structx29mgYMw04.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structx9kDs7ICzW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structx9kDs7ICzW.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structxFTWeVz86X.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structxFTWeVz86X.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structxI8aw5DOBf.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structxI8aw5DOBf.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structxKJxcMqgXp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structxKJxcMqgXp.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structxSyTOLVs2a.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structxSyTOLVs2a.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structxY83QlHYu8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structxY83QlHYu8.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structxatoIPHwut.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structxatoIPHwut.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structxayiSk9poY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structxayiSk9poY.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structxl0tHilNDj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structxl0tHilNDj.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structxpKM8hQmHX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structxpKM8hQmHX.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structxrKKgR1Fe1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structxrKKgR1Fe1.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structxsR9aAsAXm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structxsR9aAsAXm.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structxwNsI8Zdb1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structxwNsI8Zdb1.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structy2eHpFGRr5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structy2eHpFGRr5.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structy5X9cuxDIn.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structy5X9cuxDIn.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structy5wbr5f4bB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structy5wbr5f4bB.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structyAGnaq1EBc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structyAGnaq1EBc.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structyGjRe5am7c.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structyGjRe5am7c.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structyKsJfDGXaz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structyKsJfDGXaz.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structyNBvxKIcti.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structyNBvxKIcti.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structyPEdNMH6Lo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structyPEdNMH6Lo.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structyTmtkFKqd7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structyTmtkFKqd7.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structydbIqe0qPo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structydbIqe0qPo.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structyhDvAbXvCv.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structyhDvAbXvCv.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structynitZhhUeJ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structynitZhhUeJ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structyvVgkdYRXO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structyvVgkdYRXO.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structz1JgTXpAuI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structz1JgTXpAuI.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structz7dfzzL9Yk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structz7dfzzL9Yk.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structzIXefsJFSz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structzIXefsJFSz.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structzPWDt4oN6i.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structzPWDt4oN6i.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structzQUyc7Ws0e.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structzQUyc7Ws0e.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structzTIpN6ALMu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structzTIpN6ALMu.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structzYoD4xKxnZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structzYoD4xKxnZ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structzdXNEcof9V.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structzdXNEcof9V.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structzo3owhla9x.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structzo3owhla9x.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structzyowJj76a6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/partial-structzyowJj76a6.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct00oieaoYA5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct00oieaoYA5.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct05nZxSvOQy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct05nZxSvOQy.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct0CW6rWihRa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct0CW6rWihRa.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct0EiiHjJ0Jy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct0EiiHjJ0Jy.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct0HxVdkFuDk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct0HxVdkFuDk.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct0Sp8nFf9po.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct0Sp8nFf9po.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct0YOigHUonk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct0YOigHUonk.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct0mu68DyXFS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct0mu68DyXFS.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct0oZl05ifoL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct0oZl05ifoL.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct101P28DC6b.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct101P28DC6b.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct109xwVU7na.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct109xwVU7na.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct13ZLCuuDdg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct13ZLCuuDdg.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct164v5M7Oiu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct164v5M7Oiu.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct16i8Hnvzik.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct16i8Hnvzik.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct1B64P2KJTT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct1B64P2KJTT.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct1FLNprzFfg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct1FLNprzFfg.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct1Lodf8jQhi.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct1Lodf8jQhi.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct1NM3qeUh2p.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct1NM3qeUh2p.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct1QKloRyprM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct1QKloRyprM.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct1TeundtXb1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct1TeundtXb1.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct1e9vZ2ZVVl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct1e9vZ2ZVVl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct1ibkpE2U9t.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct1ibkpE2U9t.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct1jAvJkz71q.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct1jAvJkz71q.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct1kIcXqyaMm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct1kIcXqyaMm.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct1kIjvNmL26.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct1kIjvNmL26.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct1nopkP9yWt.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct1nopkP9yWt.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct1q3mpvDeuG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct1q3mpvDeuG.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct1rwcZsOxGm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct1rwcZsOxGm.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct1shpv6NmPc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct1shpv6NmPc.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct1tertRu9Xm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct1tertRu9Xm.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct1xSlrFoiE2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct1xSlrFoiE2.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct1xjEjG8zge.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct1xjEjG8zge.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct1zEPcP8TZ0.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct1zEPcP8TZ0.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct22wFvfGOQe.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct22wFvfGOQe.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct23OaGTh97N.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct23OaGTh97N.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct2C0v3cLs4t.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct2C0v3cLs4t.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct2Ii6Pytw94.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct2Ii6Pytw94.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct2KJvO9ifSa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct2KJvO9ifSa.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct2Oea4qEuqL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct2Oea4qEuqL.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct2PRjv73LUz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct2PRjv73LUz.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct2PlWXW13Oo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct2PlWXW13Oo.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct2RjyXdbOmS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct2RjyXdbOmS.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct2WJXBATRow.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct2WJXBATRow.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct2ePshLeWkH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct2ePshLeWkH.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct2iRAZCo7L5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct2iRAZCo7L5.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct2l1qlatawT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct2l1qlatawT.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct2lPhMAoDBl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct2lPhMAoDBl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct2mrBdiaAsD.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct2mrBdiaAsD.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct2yK9S7dzeX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct2yK9S7dzeX.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct2yeMfnvK5l.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct2yeMfnvK5l.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct34i0YswjFg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct34i0YswjFg.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct3AvV0e5RCv.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct3AvV0e5RCv.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct3Fkic0RvsS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct3Fkic0RvsS.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct3Q09CNhFqG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct3Q09CNhFqG.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct3W5X0ROtrE.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct3W5X0ROtrE.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct3YKEcUcTm6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct3YKEcUcTm6.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct3Ysql1aZTo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct3Ysql1aZTo.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct3aLcZ0Gzdp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct3aLcZ0Gzdp.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct3bQ2CbXXiG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct3bQ2CbXXiG.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct3hbQkh2oXr.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct3hbQkh2oXr.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct3o9W3tWIYr.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct3o9W3tWIYr.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct3oRAhgtPFs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct3oRAhgtPFs.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct3rEqyW20Ha.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct3rEqyW20Ha.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct3rh7agTF1u.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct3rh7agTF1u.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct3tAXhVgz0j.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct3tAXhVgz0j.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct3udOlsWezr.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct3udOlsWezr.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct3yavERh0QP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct3yavERh0QP.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct40R1V76roU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct40R1V76roU.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct44PftY660j.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct44PftY660j.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct46ykdVFGwG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct46ykdVFGwG.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct47pp9CzShs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct47pp9CzShs.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct49eWbTEG4e.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct49eWbTEG4e.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct4I0C5KiBcT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct4I0C5KiBcT.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct4NHzRc00m2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct4NHzRc00m2.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct4R1b3Sfk6J.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct4R1b3Sfk6J.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct4VkhuwJa8e.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct4VkhuwJa8e.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct4bA4rV4T7I.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct4bA4rV4T7I.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct4qOfIMBclV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct4qOfIMBclV.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct4tYHXfgnVZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct4tYHXfgnVZ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct4xCfXxpvdy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct4xCfXxpvdy.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct4zYtkggxX9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct4zYtkggxX9.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct566AUa8c9w.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct566AUa8c9w.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct5B3Ki66g8U.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct5B3Ki66g8U.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct5GIHfCnyF0.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct5GIHfCnyF0.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct5GXqW1XpIl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct5GXqW1XpIl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct5R3JtFMKyy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct5R3JtFMKyy.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct5WOnMXao7S.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct5WOnMXao7S.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct5WjoUCBC2W.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct5WjoUCBC2W.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct5YuboIIJis.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct5YuboIIJis.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct5coPgZ627S.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct5coPgZ627S.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct5nsLLrnYzS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct5nsLLrnYzS.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct5p0wzn3Twr.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct5p0wzn3Twr.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct5pUyGEiqRW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct5pUyGEiqRW.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct66VojQk1NI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct66VojQk1NI.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct67D9OX1YBs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct67D9OX1YBs.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct67XWJDtmLp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct67XWJDtmLp.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct6ACGifRdRw.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct6ACGifRdRw.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct6AkdgH06Lh.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct6AkdgH06Lh.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct6BWJO4ygCh.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct6BWJO4ygCh.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct6Eho6XNoOx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct6Eho6XNoOx.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct6Fnny4hIyl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct6Fnny4hIyl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct6GnahT2THT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct6GnahT2THT.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct6Gy1eE7iFg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct6Gy1eE7iFg.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct6InhhK3Bnx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct6InhhK3Bnx.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct6KaWm2V4so.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct6KaWm2V4so.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct6NVZQs4UrE.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct6NVZQs4UrE.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct6PUxZ29VTq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct6PUxZ29VTq.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct6fce05Qu1f.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct6fce05Qu1f.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct6tzbdxQpL4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct6tzbdxQpL4.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct763ixhZiPg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct763ixhZiPg.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct79tZSSX75b.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct79tZSSX75b.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct7E3RzOaVF1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct7E3RzOaVF1.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct7Ev4ba5U4g.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct7Ev4ba5U4g.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct7FkotSk0XD.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct7FkotSk0XD.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct7MpRJpjzYV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct7MpRJpjzYV.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct7UAHrFSXgp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct7UAHrFSXgp.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct7ZDRFK7C6w.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct7ZDRFK7C6w.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct7hWyxK9Im1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct7hWyxK9Im1.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct7vhsXm5Sqy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct7vhsXm5Sqy.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct7vwzjN2hQB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct7vwzjN2hQB.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct7x47kTkDWA.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct7x47kTkDWA.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct814BQq200G.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct814BQq200G.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct84TN7zjoK9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct84TN7zjoK9.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct8CllamWxHF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct8CllamWxHF.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct8KGpb7sMhV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct8KGpb7sMhV.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct8P1XTIrmCU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct8P1XTIrmCU.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct8eGauAG2Iy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct8eGauAG2Iy.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct8hD3MVC60I.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct8hD3MVC60I.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct8q0Jpdjx8u.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct8q0Jpdjx8u.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct8qIwjmR7oN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct8qIwjmR7oN.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct8tbcftbwF8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct8tbcftbwF8.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct8txOZ8smgu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct8txOZ8smgu.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct8yaeAzdZUO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct8yaeAzdZUO.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct98nsmL4Uyu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct98nsmL4Uyu.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct9CTRHeV5gV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct9CTRHeV5gV.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct9E3xYWs4gr.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct9E3xYWs4gr.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct9FbBK7sAEy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct9FbBK7sAEy.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct9HOIXHYhP9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct9HOIXHYhP9.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct9IzMME36Bl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct9IzMME36Bl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct9PLpEx4eEr.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct9PLpEx4eEr.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct9QX6aOMWmP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct9QX6aOMWmP.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct9XFvojKqS7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct9XFvojKqS7.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct9Z0NXJ0nuB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct9Z0NXJ0nuB.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct9cdQxj05PP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct9cdQxj05PP.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct9dJLrfdwrb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct9dJLrfdwrb.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct9fPHF2RcIG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct9fPHF2RcIG.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct9o9IQlJhfF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct9o9IQlJhfF.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct9rTJlJQ4St.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct9rTJlJQ4St.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct9tS75raz9v.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-struct9tS75raz9v.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structA0t67j1fxp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structA0t67j1fxp.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structA2y6S9lFjD.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structA2y6S9lFjD.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structA4N6i5eArl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structA4N6i5eArl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structA6J9ouYjJm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structA6J9ouYjJm.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structAB03r2H43b.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structAB03r2H43b.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structADRxlKyBIl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structADRxlKyBIl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structAE7oPkwYY6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structAE7oPkwYY6.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structAHdMDYZJaK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structAHdMDYZJaK.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structAK2drK1aH7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structAK2drK1aH7.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structAPZGaaiAsI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structAPZGaaiAsI.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structAQE2E9exgF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structAQE2E9exgF.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structAcoWvPhtlp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structAcoWvPhtlp.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structAiFfzJ9xOo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structAiFfzJ9xOo.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structAztsRhE0LF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structAztsRhE0LF.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structB9pN8GfUaU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structB9pN8GfUaU.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structBA8lKBvox6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structBA8lKBvox6.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structBBBafcZBl1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structBBBafcZBl1.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structBF8funmMCW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structBF8funmMCW.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structBNGrkk0Gq9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structBNGrkk0Gq9.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structBW4o7dJUoK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structBW4o7dJUoK.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structBWsRWzQ335.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structBWsRWzQ335.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structBfsVSixXGI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structBfsVSixXGI.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structBjERtQ98tj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structBjERtQ98tj.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structBjy5dZK2rM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structBjy5dZK2rM.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structBm7Ua0ACla.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structBm7Ua0ACla.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structBmz4OJxAlt.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structBmz4OJxAlt.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structBw3OKv2Qms.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structBw3OKv2Qms.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structBzSRBjnY22.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structBzSRBjnY22.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structC0g7V6d3fy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structC0g7V6d3fy.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structCBt0kIYRra.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structCBt0kIYRra.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structCOGSdZd0AL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structCOGSdZd0AL.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structCXeEkfG71q.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structCXeEkfG71q.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structCaHH2Xyhc7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structCaHH2Xyhc7.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structCcLnEruc0v.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structCcLnEruc0v.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structCfD3K5QvsN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structCfD3K5QvsN.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structCqQVJigrtI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structCqQVJigrtI.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structCzvlSZqJoZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structCzvlSZqJoZ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structD2oQVW5tnq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structD2oQVW5tnq.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structD4YplBwWDi.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structD4YplBwWDi.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structD9gno8tRvF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structD9gno8tRvF.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structDACFSZmJCd.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structDACFSZmJCd.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structDVPBdDC863.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structDVPBdDC863.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structDXFa0e4ozX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structDXFa0e4ozX.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structDZZWeqhEZS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structDZZWeqhEZS.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structDhEKpPXtbG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structDhEKpPXtbG.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structDi88qmJim6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structDi88qmJim6.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structDrIOG3dy4E.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structDrIOG3dy4E.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structE1izflhe7m.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structE1izflhe7m.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structE7tbP2KegJ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structE7tbP2KegJ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structECJjSKcI0x.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structECJjSKcI0x.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structECjdzNW2hb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structECjdzNW2hb.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structENNglh8DX6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structENNglh8DX6.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structEVUFJOsbyB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structEVUFJOsbyB.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structEa3Y8fmO5t.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structEa3Y8fmO5t.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structEbe6V1e8rk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structEbe6V1e8rk.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structEilgeng6RU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structEilgeng6RU.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structEjN7KM70nB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structEjN7KM70nB.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structEoc6yu6UZC.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structEoc6yu6UZC.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structEqZWhQIozu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structEqZWhQIozu.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structErRGvv06c5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structErRGvv06c5.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structEvFFf3fZGJ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structEvFFf3fZGJ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structEx5206L0wV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structEx5206L0wV.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structF3dNExh2mR.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structF3dNExh2mR.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structF8DhNrWv7E.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structF8DhNrWv7E.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structF9RjQ90jnp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structF9RjQ90jnp.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structFI3w6VQMfO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structFI3w6VQMfO.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structFJsonz9Nyz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structFJsonz9Nyz.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structFR85FzqbWk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structFR85FzqbWk.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structFXxZeDtCw5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structFXxZeDtCw5.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structFaTXoezJTa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structFaTXoezJTa.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structFhwETmltur.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structFhwETmltur.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structFjGw1Sgvhj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structFjGw1Sgvhj.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structFq1hfAwgHs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structFq1hfAwgHs.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structFvR9kgHTwq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structFvR9kgHTwq.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structFx3ViT9W1l.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structFx3ViT9W1l.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structG23iNFg5pV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structG23iNFg5pV.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structG4WvAWeyY2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structG4WvAWeyY2.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structG5eiJlW14L.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structG5eiJlW14L.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structG7DG28rR3I.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structG7DG28rR3I.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structG8t7pJyR0P.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structG8t7pJyR0P.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structGAhk4JD5f5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structGAhk4JD5f5.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structGElc6so5Vx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structGElc6so5Vx.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structGL3ENulfXA.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structGL3ENulfXA.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structGPgos6Ga6k.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structGPgos6Ga6k.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structGVka0u9TDq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structGVka0u9TDq.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structGXNEUsfHGV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structGXNEUsfHGV.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structGajQGzODLb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structGajQGzODLb.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structGbvlSI6ZFM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structGbvlSI6ZFM.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structGgvsKvoP9v.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structGgvsKvoP9v.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structGiiPLasS8y.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structGiiPLasS8y.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structGlUP6EKlOZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structGlUP6EKlOZ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structGmNuKgusEl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structGmNuKgusEl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structGnndCPLSRE.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structGnndCPLSRE.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structGseI8AQPtb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structGseI8AQPtb.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structGyODqQmfLk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structGyODqQmfLk.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structH5eQeBi4oY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structH5eQeBi4oY.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structH6F7xwrgKM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structH6F7xwrgKM.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structHAW6jHGG5q.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structHAW6jHGG5q.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structHGMhtcP1Gs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structHGMhtcP1Gs.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structHNoL72ys27.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structHNoL72ys27.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structHOwIYbq2Gd.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structHOwIYbq2Gd.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structHQ1FzQOf8n.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structHQ1FzQOf8n.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structHQRXU94JgV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structHQRXU94JgV.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structHSN0q7oMVM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structHSN0q7oMVM.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structHYnhl5ltDv.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structHYnhl5ltDv.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structHcCEQbo9Zf.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structHcCEQbo9Zf.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structHfRiDfgqPK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structHfRiDfgqPK.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structHnGXhmegvA.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structHnGXhmegvA.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structHnNLvYqbMR.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structHnNLvYqbMR.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structHt9F9jtMD0.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structHt9F9jtMD0.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structHusaUbKJVm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structHusaUbKJVm.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structHvGrPaR9Bu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structHvGrPaR9Bu.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structHvI693MHyM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structHvI693MHyM.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structHyrFeqyBCY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structHyrFeqyBCY.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structHzJtxAljeg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structHzJtxAljeg.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structI2aSLtV0nK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structI2aSLtV0nK.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structI5QO2BUMxk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structI5QO2BUMxk.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structI6BZQjT6lx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structI6BZQjT6lx.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structICD2Fjdvwq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structICD2Fjdvwq.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structIHkMJI02Cs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structIHkMJI02Cs.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structIJpxdh5h1j.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structIJpxdh5h1j.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structIKVPnPqtVG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structIKVPnPqtVG.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structIODsh0cyAj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structIODsh0cyAj.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structIWnVfC7bMR.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structIWnVfC7bMR.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structIg48IJ1BGz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structIg48IJ1BGz.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structIjpYds4lWa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structIjpYds4lWa.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structImqfRF5u5d.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structImqfRF5u5d.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structIpNWKHAjIK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structIpNWKHAjIK.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structIq2IxAwTbz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structIq2IxAwTbz.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structIqjoEWN5a6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structIqjoEWN5a6.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structJ1WoVnmoNK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structJ1WoVnmoNK.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structJ4N4ApAuNd.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structJ4N4ApAuNd.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structJ4sxZ95hzs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structJ4sxZ95hzs.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structJ5ThymSmBk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structJ5ThymSmBk.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structJBdaFHCitX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structJBdaFHCitX.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structJBjYKH35Id.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structJBjYKH35Id.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structJEL7o5TRHh.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structJEL7o5TRHh.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structJFU1xlKVwi.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structJFU1xlKVwi.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structJIOp0LkuGx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structJIOp0LkuGx.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structJKSxRHdkgU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structJKSxRHdkgU.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structJLl1JS3EBA.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structJLl1JS3EBA.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structJPod17bl3h.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structJPod17bl3h.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structJSkoDJdEmy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structJSkoDJdEmy.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structJXZ8aT3Z1A.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structJXZ8aT3Z1A.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structJYFDwGezZu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structJYFDwGezZu.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structJZBOzjdChs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structJZBOzjdChs.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structJcJCwPR9O6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structJcJCwPR9O6.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structJdaXHv9XGK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structJdaXHv9XGK.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structJguJlpO2Zx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structJguJlpO2Zx.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structJjOrVxY09U.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structJjOrVxY09U.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structJmS6AEcW3Z.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structJmS6AEcW3Z.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structJmgvdzeb5n.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structJmgvdzeb5n.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structJt6jf8vpBs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structJt6jf8vpBs.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structJyoG3utfUF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structJyoG3utfUF.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structK17aJaWFKp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structK17aJaWFKp.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structK6zBHvtXEz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structK6zBHvtXEz.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structK8yLeG1Rq8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structK8yLeG1Rq8.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structKAGtyEb0Mc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structKAGtyEb0Mc.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structKBZsUWVDxs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structKBZsUWVDxs.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structKD97Jf4W3S.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structKD97Jf4W3S.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structKDBDsZNe9Z.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structKDBDsZNe9Z.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structKDWeAZ2IPn.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structKDWeAZ2IPn.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structKF4sn2PYXa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structKF4sn2PYXa.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structKHnzHYYQv9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structKHnzHYYQv9.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structKJhvJs3EGG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structKJhvJs3EGG.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structKLSPh0PXhl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structKLSPh0PXhl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structKNZX9fxtdl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structKNZX9fxtdl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structKS9Hbi6AwZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structKS9Hbi6AwZ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structKVlfLjDmn1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structKVlfLjDmn1.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structKX2JHsJ0bd.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structKX2JHsJ0bd.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structKkESsYkID7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structKkESsYkID7.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structKkHcnJvU6l.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structKkHcnJvU6l.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structKkvn2ffBgz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structKkvn2ffBgz.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structKxmFSKOkr0.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structKxmFSKOkr0.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structL0iuHiXIxa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structL0iuHiXIxa.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structL28FwCaWlq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structL28FwCaWlq.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structL3YlcXIU3G.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structL3YlcXIU3G.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structL5PAA2Y49o.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structL5PAA2Y49o.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structL8rTw5Q3JI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structL8rTw5Q3JI.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structLJsbrcp1QV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structLJsbrcp1QV.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structLKxIRREq4D.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structLKxIRREq4D.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structLMQlSHV6GT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structLMQlSHV6GT.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structLV2nB9GvAz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structLV2nB9GvAz.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structLa1OJDLBp5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structLa1OJDLBp5.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structLcNNHqG92U.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structLcNNHqG92U.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structLnY2DL1Mbw.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structLnY2DL1Mbw.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structLpxoYUnOy7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structLpxoYUnOy7.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structLs7CLvlkgi.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structLs7CLvlkgi.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structLtMZ0XaStC.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structLtMZ0XaStC.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structLy4yvDjUuQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structLy4yvDjUuQ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structM9DKZGOLDg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structM9DKZGOLDg.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structMBndhRFxei.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structMBndhRFxei.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structMEcvkINwlN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structMEcvkINwlN.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structMFY7puSlGX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structMFY7puSlGX.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structMQnq3Fo18k.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structMQnq3Fo18k.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structMRN9c8EZAu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structMRN9c8EZAu.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structMSaXkM98gx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structMSaXkM98gx.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structMe4GO0lmyL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structMe4GO0lmyL.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structMf7H2FRsCR.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structMf7H2FRsCR.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structMgFMQz9tN4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structMgFMQz9tN4.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structMhWZ76XLqK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structMhWZ76XLqK.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structMiv3889DlT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structMiv3889DlT.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structMkNnqyG9Tl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structMkNnqyG9Tl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structMw7h6zUCoS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structMw7h6zUCoS.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structN5CGh6EWiK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structN5CGh6EWiK.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structN86zzxZWL3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structN86zzxZWL3.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structN9VLieAgkB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structN9VLieAgkB.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structNB005jf6q4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structNB005jf6q4.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structNW2O8zaFJU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structNW2O8zaFJU.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structNXVElSFyJY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structNXVElSFyJY.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structNXkTPXgNCQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structNXkTPXgNCQ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structNYxtIN1k6X.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structNYxtIN1k6X.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structNcunqydrcp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structNcunqydrcp.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structNfG8poVmRX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structNfG8poVmRX.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structNpSaGkUh99.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structNpSaGkUh99.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structNphpYJarez.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structNphpYJarez.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structNq8WSpQa6r.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structNq8WSpQa6r.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structNuHNDIZUYr.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structNuHNDIZUYr.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structO4Kr2Vp6iB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structO4Kr2Vp6iB.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structO5SpO4Lmqy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structO5SpO4Lmqy.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structO6aBEtLHCl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structO6aBEtLHCl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structO8aC92gkJu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structO8aC92gkJu.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structOAXjhVxHVW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structOAXjhVxHVW.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structOBggRrGGeA.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structOBggRrGGeA.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structOCKiZ8XvN4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structOCKiZ8XvN4.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structOTagHf6dta.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structOTagHf6dta.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structOmPR4GDmha.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structOmPR4GDmha.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structOnU7Y1iyOW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structOnU7Y1iyOW.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structOruSh6IU68.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structOruSh6IU68.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structP07kLcgWy2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structP07kLcgWy2.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structP0hi03Yr5J.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structP0hi03Yr5J.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structP51IT0iQls.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structP51IT0iQls.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structPC53CFAahl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structPC53CFAahl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structPDETEBub2B.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structPDETEBub2B.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structPIEO17rXv3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structPIEO17rXv3.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structPL1Vy8gAQG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structPL1Vy8gAQG.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structPOAJbOn5yN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structPOAJbOn5yN.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structPWOGZtzGIy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structPWOGZtzGIy.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structPWOtvXxst0.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structPWOtvXxst0.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structPaMBWeOEZb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structPaMBWeOEZb.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structPbViqUkC9s.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structPbViqUkC9s.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structPjXLhVCSo2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structPjXLhVCSo2.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structPmsSWhVFlx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structPmsSWhVFlx.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structPvttwCSove.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structPvttwCSove.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structPy7auxT2wm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structPy7auxT2wm.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structPzKBHCX9aj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structPzKBHCX9aj.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structQ1lt85NZkv.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structQ1lt85NZkv.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structQ9W3v3dQYW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structQ9W3v3dQYW.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structQBpF2mc1un.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structQBpF2mc1un.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structQLoTxIicfl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structQLoTxIicfl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structQNBjmFEISk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structQNBjmFEISk.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structQRNlszU7N1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structQRNlszU7N1.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structQRrZvgSvEl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structQRrZvgSvEl.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structQu8eKSWeIJ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structQu8eKSWeIJ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structQwjx7jDCDX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structQwjx7jDCDX.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structQwri7Ax9TK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structQwri7Ax9TK.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structR4xaEYdpRY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structR4xaEYdpRY.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structR6bsgVIYE6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structR6bsgVIYE6.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structR6j965l6JZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structR6j965l6JZ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structR6yPnOD0oz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structR6yPnOD0oz.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structR8eEQpI0YT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structR8eEQpI0YT.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structRBr9HNIGgm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structRBr9HNIGgm.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structRBwjivoMMP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structRBwjivoMMP.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structRFFK9pIT93.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structRFFK9pIT93.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structRJYj3K0a3c.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structRJYj3K0a3c.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structRLhaWW9haz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structRLhaWW9haz.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structRSckKIVPNO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structRSckKIVPNO.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structRX7hJYzEEc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structRX7hJYzEEc.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structRbEgtyrBAH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structRbEgtyrBAH.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structRbgB04HmL4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structRbgB04HmL4.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structRdgEVFWPU8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structRdgEVFWPU8.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structRjYd0rym9S.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structRjYd0rym9S.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structRpd0ErOBb6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structRpd0ErOBb6.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structRtcf0YV8fO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structRtcf0YV8fO.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structRtjThoUz7H.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structRtjThoUz7H.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structRyTk5RxJJO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structRyTk5RxJJO.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structS1RhuauboU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structS1RhuauboU.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structS6bmXaMMyl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structS6bmXaMMyl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structSDPIMkAwH8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structSDPIMkAwH8.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structSEmAsgVkk9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structSEmAsgVkk9.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structSIfHQocAM7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structSIfHQocAM7.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structSL3XN9PByF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structSL3XN9PByF.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structSOJZorG6h4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structSOJZorG6h4.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structSOQ2b3Trj9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structSOQ2b3Trj9.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structSOcWqfVVcP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structSOcWqfVVcP.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structSUuI5kWBPQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structSUuI5kWBPQ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structSWz0ZdY1fL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structSWz0ZdY1fL.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structSXB5wflpQj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structSXB5wflpQj.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structSaCKmxwW7X.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structSaCKmxwW7X.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structSkgZGVkxzj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structSkgZGVkxzj.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structSuSfIvUv2A.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structSuSfIvUv2A.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structSuaJbDOn73.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structSuaJbDOn73.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structSv55DLNwHy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structSv55DLNwHy.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structSvXjwmwWp8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structSvXjwmwWp8.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structT024qoIGBu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structT024qoIGBu.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structT396ygje53.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structT396ygje53.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structTA8Sp22K2U.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structTA8Sp22K2U.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structTGF07uM1y9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structTGF07uM1y9.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structTKbYYBx9QZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structTKbYYBx9QZ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structTLyC86eODa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structTLyC86eODa.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structTSEu5hclTq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structTSEu5hclTq.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structTX5YCrOcOo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structTX5YCrOcOo.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structTX6rXf2RZh.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structTX6rXf2RZh.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structTaJbzfeDjo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structTaJbzfeDjo.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structTaYGLKdSM8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structTaYGLKdSM8.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structTgcZPmWOx2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structTgcZPmWOx2.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structTh5NbnUqzI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structTh5NbnUqzI.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structTknpxoQFvS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structTknpxoQFvS.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structTqu8KoZQjY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structTqu8KoZQjY.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structTuAcbBNnZm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structTuAcbBNnZm.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structTuWH3zeluv.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structTuWH3zeluv.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structTwjPuMKDiB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structTwjPuMKDiB.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structTxF88EuH4Q.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structTxF88EuH4Q.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structTzQ4rWvlZ3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structTzQ4rWvlZ3.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structU2kogkOlcf.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structU2kogkOlcf.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structU3dy6bkQcN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structU3dy6bkQcN.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structUA5Zgdsa4W.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structUA5Zgdsa4W.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structUC7urls6rG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structUC7urls6rG.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structUJ5RVg0xHN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structUJ5RVg0xHN.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structUL0XgKUiea.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structUL0XgKUiea.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structUYdnQvYvKk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structUYdnQvYvKk.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structUaTPRyIwWQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structUaTPRyIwWQ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structUgp6Bg804O.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structUgp6Bg804O.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structUgsqUT0Fw8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structUgsqUT0Fw8.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structUomjJGDhS3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structUomjJGDhS3.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structUrJ7tMPYdi.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structUrJ7tMPYdi.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structUsGUm5feCJ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structUsGUm5feCJ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structUx6sDnae6o.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structUx6sDnae6o.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structUyBELJkxhd.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structUyBELJkxhd.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structV1mFMqHDyz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structV1mFMqHDyz.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structV3DEOjYkAI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structV3DEOjYkAI.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structV4EcMh64Nu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structV4EcMh64Nu.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structVABFQlbdB8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structVABFQlbdB8.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structVCKWE5qXDQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structVCKWE5qXDQ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structVF3eV6RT5A.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structVF3eV6RT5A.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structVGVFt2H4Jq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structVGVFt2H4Jq.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structVHmibu21U1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structVHmibu21U1.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structVJQMEbTTcW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structVJQMEbTTcW.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structVW9Wugrq8f.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structVW9Wugrq8f.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structVbui9U8nJN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structVbui9U8nJN.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structVqmZxmYjrS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structVqmZxmYjrS.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structVwumd12dMR.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structVwumd12dMR.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structW03TuqLzYH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structW03TuqLzYH.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structW6NGdR4FHA.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structW6NGdR4FHA.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structW8RwEte1K1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structW8RwEte1K1.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structWFr5O7xRwi.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structWFr5O7xRwi.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structWJw9ZLP7fK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structWJw9ZLP7fK.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structWODpD4eAmE.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structWODpD4eAmE.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structWOGNQBbIW7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structWOGNQBbIW7.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structWQN1KyUD5b.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structWQN1KyUD5b.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structWTDgYPieK1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structWTDgYPieK1.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structWVtboPH1aE.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structWVtboPH1aE.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structWiPM4vCvbR.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structWiPM4vCvbR.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structWk1zWo8r9K.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structWk1zWo8r9K.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structWkYOcVuG9r.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structWkYOcVuG9r.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structWqKLr6PuT3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structWqKLr6PuT3.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structWyFaNRxWDU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structWyFaNRxWDU.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structX0tLJiI6QS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structX0tLJiI6QS.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structX74WdLPgP3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structX74WdLPgP3.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structXLePVWtJFS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structXLePVWtJFS.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structXNJAbmwEpz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structXNJAbmwEpz.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structXOlFj8WTWU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structXOlFj8WTWU.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structXQpY9eJk4m.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structXQpY9eJk4m.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structXU2GzBHEnm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structXU2GzBHEnm.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structXWIUjIMjuc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structXWIUjIMjuc.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structXYOl2gpZhZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structXYOl2gpZhZ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structXYrXq7Kz5O.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structXYrXq7Kz5O.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structXab1L6RKkc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structXab1L6RKkc.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structXcQSZS9Pq3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structXcQSZS9Pq3.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structXdOq3rooU7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structXdOq3rooU7.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structXpfvMzo3SU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structXpfvMzo3SU.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structXs0m0HB3Ve.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structXs0m0HB3Ve.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structXsoVym5xGF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structXsoVym5xGF.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structXxbrxyvfJK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structXxbrxyvfJK.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structY0sbuM1lf1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structY0sbuM1lf1.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structY2WI2qZBJc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structY2WI2qZBJc.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structY3MSP8GJLq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structY3MSP8GJLq.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structY7ZzgHzGVw.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structY7ZzgHzGVw.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structY8HkjRfwpg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structY8HkjRfwpg.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structYAzsftuDhx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structYAzsftuDhx.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structYE37gD7DoN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structYE37gD7DoN.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structYNODMJt0nI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structYNODMJt0nI.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structYOoQMQYEZo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structYOoQMQYEZo.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structYPtr2Dr86B.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structYPtr2Dr86B.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structYXRqKm5H9U.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structYXRqKm5H9U.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structYa2X1A0XlS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structYa2X1A0XlS.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structYj7TbLsdP4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structYj7TbLsdP4.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structYlF6RxCqVs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structYlF6RxCqVs.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structYo1jTzfuKl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structYo1jTzfuKl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structYrew2qdBuH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structYrew2qdBuH.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structYwZwDfIvIG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structYwZwDfIvIG.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structZ3DY5gvzFY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structZ3DY5gvzFY.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structZBrvC38b8N.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structZBrvC38b8N.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structZC6ZaapQdD.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structZC6ZaapQdD.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structZGNK9Twr9S.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structZGNK9Twr9S.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structZGqp2bRDtx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structZGqp2bRDtx.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structZJSKolxfqc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structZJSKolxfqc.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structZR3LiJX7PO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structZR3LiJX7PO.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structZW26HGLchP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structZW26HGLchP.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structZi1RqmdSol.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structZi1RqmdSol.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structZoimFj6xEE.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structZoimFj6xEE.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structZpfDnRPksn.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structZpfDnRPksn.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structZr2k5TeLcE.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structZr2k5TeLcE.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structZtqbbnQjzj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structZtqbbnQjzj.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structZupKEHABUk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structZupKEHABUk.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structa0AhWFAoDG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structa0AhWFAoDG.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structa5eW784LQf.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structa5eW784LQf.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structa6BXYQAwEm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structa6BXYQAwEm.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structa6bL6toTDQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structa6bL6toTDQ.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structa85eS8wvGC.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structa85eS8wvGC.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structaBCMiwiL14.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structaBCMiwiL14.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structaCvUpfrOud.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structaCvUpfrOud.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structaMVAJ9INz0.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structaMVAJ9INz0.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structaNX02HPg7T.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structaNX02HPg7T.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structaacjP2BYDY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structaacjP2BYDY.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structafSLEQGtjb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structafSLEQGtjb.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structawZmlvXiXW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structawZmlvXiXW.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structaxV4fiWwZ7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structaxV4fiWwZ7.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structayNEhBBg4t.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structayNEhBBg4t.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structb265yb0csM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structb265yb0csM.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structb63fAzKNR7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structb63fAzKNR7.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structbBsug1Wd34.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structbBsug1Wd34.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structbNMyvNH8WM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structbNMyvNH8WM.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structbX4S27LXkH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structbX4S27LXkH.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structblpexlSs9M.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structblpexlSs9M.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structbmmnw9qu32.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structbmmnw9qu32.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structbsrrxTZOqn.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structbsrrxTZOqn.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structbtgnPXO5Rq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structbtgnPXO5Rq.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structbwtswCbHZn.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structbwtswCbHZn.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structc0ARtdYgED.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structc0ARtdYgED.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structc0K76QtGvt.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structc0K76QtGvt.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structc19BIAaEkY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structc19BIAaEkY.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structcIUFEZhrle.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structcIUFEZhrle.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structcU51DXcyE8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structcU51DXcyE8.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structcbnz0kvIwn.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structcbnz0kvIwn.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structcfbnUeCgbt.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structcfbnUeCgbt.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structcjMmD9Dwfx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structcjMmD9Dwfx.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structclmVkpAhb8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structclmVkpAhb8.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structcoAqE1boX6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structcoAqE1boX6.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structcormXUf4WS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structcormXUf4WS.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structcqdGRq2WNh.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structcqdGRq2WNh.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structczOiELiAB7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structczOiELiAB7.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structd2ojXxCaNW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structd2ojXxCaNW.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structd4OcbMDcGL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structd4OcbMDcGL.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structd9nB4x1U6u.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structd9nB4x1U6u.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structdEhJcrsORt.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structdEhJcrsORt.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structdKBNYvwyxK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structdKBNYvwyxK.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structdNGVHIlzAj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structdNGVHIlzAj.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structdSftno00MK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structdSftno00MK.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structdXZpHpuk3x.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structdXZpHpuk3x.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structdXgIF94ebo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structdXgIF94ebo.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structdhEH1P8yDX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structdhEH1P8yDX.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structdq0ytTGdT7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structdq0ytTGdT7.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structdr28D0z5ZH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structdr28D0z5ZH.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structe4z2kYEwsw.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structe4z2kYEwsw.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structe79Za4b7Ml.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structe79Za4b7Ml.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structeJF56nvsEj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structeJF56nvsEj.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structeW6hiVZjD9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structeW6hiVZjD9.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structegI0J6pwbq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structegI0J6pwbq.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structemjd05RWc3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structemjd05RWc3.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structeqBjnWgb5P.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structeqBjnWgb5P.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structf0akg4gumK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structf0akg4gumK.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structf32Rx1NpEm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structf32Rx1NpEm.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structf3hg4Duqet.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structf3hg4Duqet.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structf74ThK893J.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structf74ThK893J.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structfBkGsQBirP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structfBkGsQBirP.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structfCVtyydYxM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structfCVtyydYxM.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structfCayR9pma6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structfCayR9pma6.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structfG4ASdjUC9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structfG4ASdjUC9.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structfJdkVlyVac.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structfJdkVlyVac.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structfNnOzIDYzL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structfNnOzIDYzL.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structfOOjVzFOC9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structfOOjVzFOC9.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structfTXY9OU4mh.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structfTXY9OU4mh.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structfWEUc1K6FG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structfWEUc1K6FG.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structfYJ2Mkk1al.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structfYJ2Mkk1al.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structfcg2UqwprF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structfcg2UqwprF.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structfd0mCQVHBl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structfd0mCQVHBl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structfwecOIJDmQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structfwecOIJDmQ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structgBuG9DjtOU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structgBuG9DjtOU.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structgIAdPMClq9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structgIAdPMClq9.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structgJaEzQzHlG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structgJaEzQzHlG.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structgTI819u8oK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structgTI819u8oK.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structgaVRwvBYOY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structgaVRwvBYOY.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structgmDuxmO8uQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structgmDuxmO8uQ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structgnTh8YZCI4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structgnTh8YZCI4.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structgnzwfueLCU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structgnzwfueLCU.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structgodJTvsSrL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structgodJTvsSrL.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structgoyNOloADC.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structgoyNOloADC.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structgrMFKxp6Rp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structgrMFKxp6Rp.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structgu5AmoUnKH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structgu5AmoUnKH.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structgw0RpMV2f4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structgw0RpMV2f4.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structgzPFVO95T5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structgzPFVO95T5.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structh0wIvbjPFM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structh0wIvbjPFM.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structh0zYLuKys0.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structh0zYLuKys0.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structh4borQn8tt.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structh4borQn8tt.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structhEYyOpWNQA.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structhEYyOpWNQA.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structhKVOXTzhtj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structhKVOXTzhtj.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structhP7CI8CVIx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structhP7CI8CVIx.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structhRp6BjrXlq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structhRp6BjrXlq.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structhXluAaYGUP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structhXluAaYGUP.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structhc5U7IjcZc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structhc5U7IjcZc.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structhjYDoXKd1y.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structhjYDoXKd1y.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structhk5xXOFY3B.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structhk5xXOFY3B.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structhlXXNdntjL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structhlXXNdntjL.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structhnljKmvH1S.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structhnljKmvH1S.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structhsMP7WDnTb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structhsMP7WDnTb.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structi5tx16f99j.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structi5tx16f99j.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structi60i9flgEl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structi60i9flgEl.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structiGcBGhWkFg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structiGcBGhWkFg.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structiH2t1AudUv.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structiH2t1AudUv.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structiJO3yTUlA6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structiJO3yTUlA6.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structiMxQrDbyMm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structiMxQrDbyMm.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structiRTC8Ri5hh.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structiRTC8Ri5hh.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structiUTYiuw7nL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structiUTYiuw7nL.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structifVuZi4Efe.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structifVuZi4Efe.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structigySx6ywF4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structigySx6ywF4.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structimk6k6ZOQP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structimk6k6ZOQP.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structiyfYt6St4H.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structiyfYt6St4H.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structj0Jp6zlUkb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structj0Jp6zlUkb.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structj2noj6YBli.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structj2noj6YBli.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structj80X6OAWFM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structj80X6OAWFM.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structjATzvt82Yc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structjATzvt82Yc.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structjHYdKd1qGS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structjHYdKd1qGS.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structjIn9JVMI49.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structjIn9JVMI49.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structjKvkQzPnI2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structjKvkQzPnI2.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structjPeWDdzelT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structjPeWDdzelT.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structjVynlgrJOg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structjVynlgrJOg.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structjXzq5dAQfq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structjXzq5dAQfq.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structjlEQy1XgIm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structjlEQy1XgIm.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structjpZYztDGZv.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structjpZYztDGZv.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structjyzBmrWLpD.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structjyzBmrWLpD.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structjzLZ1Fd1su.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structjzLZ1Fd1su.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structk0RWOtD4Cb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structk0RWOtD4Cb.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structk5uhI551Ib.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structk5uhI551Ib.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structkBpo9DUgjg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structkBpo9DUgjg.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structkKCqpBwgSB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structkKCqpBwgSB.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structkMn4TDNnDw.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structkMn4TDNnDw.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structkTDa7zOTTq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structkTDa7zOTTq.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structkcnuBfgvqB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structkcnuBfgvqB.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structke5R4wNmaV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structke5R4wNmaV.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structkgOVznysHS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structkgOVznysHS.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structkjR2PqZPCx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structkjR2PqZPCx.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structkjvkPYElx2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structkjvkPYElx2.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structko3HKcubO4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structko3HKcubO4.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structl1rwee6A0W.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structl1rwee6A0W.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structl9GK15NFfI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structl9GK15NFfI.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structl9dEcAYjZX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structl9dEcAYjZX.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structlCbFTLeEcO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structlCbFTLeEcO.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structlFoUTH7TGY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structlFoUTH7TGY.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structlFuagxP4pj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structlFuagxP4pj.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structlKqlZNIiTG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structlKqlZNIiTG.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structlM9nCK9mVa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structlM9nCK9mVa.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structlNxcettVbW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structlNxcettVbW.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structlOMWejTcie.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structlOMWejTcie.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structlPPzP90v2M.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structlPPzP90v2M.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structlWE7ijbTPg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structlWE7ijbTPg.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structlWZpr8mFUz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structlWZpr8mFUz.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structlfb6Bcmyzv.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structlfb6Bcmyzv.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structliZR39PG4B.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structliZR39PG4B.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structlilo17vqrO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structlilo17vqrO.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structlmBHuI2CdK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structlmBHuI2CdK.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structlsRnaxudRi.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structlsRnaxudRi.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structlwBBVufID9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structlwBBVufID9.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structmE7fFfuHjx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structmE7fFfuHjx.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structmPX6OOh4Nl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structmPX6OOh4Nl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structmR2t9GgAZ5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structmR2t9GgAZ5.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structmU9k8N2S1x.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structmU9k8N2S1x.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structmUQioQKiXp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structmUQioQKiXp.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structmWBF30udKT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structmWBF30udKT.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structmaUySacG7e.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structmaUySacG7e.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structmj4Oyb3GgX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structmj4Oyb3GgX.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structmuAhuD4KVQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structmuAhuD4KVQ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structmwjaO3Uyrs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structmwjaO3Uyrs.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structn5h1DHBxub.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structn5h1DHBxub.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structnAdqmBnbeg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structnAdqmBnbeg.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structnAvYhH07Gs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structnAvYhH07Gs.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structnHnX8P1WDq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structnHnX8P1WDq.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structnNkjJDcz0P.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structnNkjJDcz0P.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structnPwZk9I7YN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structnPwZk9I7YN.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structnUJfW4NMaA.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structnUJfW4NMaA.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structnXMZUp9V4V.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structnXMZUp9V4V.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structnjkuDZnOoQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structnjkuDZnOoQ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structnq8k7vNWX3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structnq8k7vNWX3.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structnrVsGpyHSB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structnrVsGpyHSB.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structnsGvdkMRFZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structnsGvdkMRFZ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structoAhXI74h9j.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structoAhXI74h9j.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structoahbTSUqku.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structoahbTSUqku.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structoiRn4GygF9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structoiRn4GygF9.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structov6aJQLXqu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structov6aJQLXqu.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structovm1h7N1tD.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structovm1h7N1tD.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structoypCXXMXYK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structoypCXXMXYK.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structp39x1W6Nmw.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structp39x1W6Nmw.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structp5F0SqEi1N.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structp5F0SqEi1N.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structpK1zdl2ooH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structpK1zdl2ooH.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structpLXABe2wJc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structpLXABe2wJc.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structpMr2v6juAQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structpMr2v6juAQ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structpXZA41Y8fK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structpXZA41Y8fK.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structpkIouuiKqe.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structpkIouuiKqe.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structpnMhTmK3QH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structpnMhTmK3QH.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structpuA2r64pbW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structpuA2r64pbW.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structpwCAT0hshK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structpwCAT0hshK.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structq1BEWkecYX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structq1BEWkecYX.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structq2gqs38KnH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structq2gqs38KnH.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structq5OjZ10BEs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structq5OjZ10BEs.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structqGa10MSSRs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structqGa10MSSRs.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structqGuE1lEn2E.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structqGuE1lEn2E.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structqK7XKTZI6a.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structqK7XKTZI6a.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structqRtOraogqy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structqRtOraogqy.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structqTdD25cQMq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structqTdD25cQMq.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structqVenFBZMmB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structqVenFBZMmB.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structqVymoyiTzO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structqVymoyiTzO.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structqYoMOdyW5o.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structqYoMOdyW5o.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structqZqGFZMAp0.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structqZqGFZMAp0.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structqceTFkotG1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structqceTFkotG1.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structqklsh0VtCj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structqklsh0VtCj.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structqkwGFodzYo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structqkwGFodzYo.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structqlynSYPIzj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structqlynSYPIzj.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structqmylEQUQxN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structqmylEQUQxN.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structqsdnJQvtod.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structqsdnJQvtod.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structr1IUWdH7kS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structr1IUWdH7kS.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structrDLhl5fFyI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structrDLhl5fFyI.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structrJ6A29EFD3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structrJ6A29EFD3.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structrLI0qkdwNT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structrLI0qkdwNT.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structrNNNMoMUX5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structrNNNMoMUX5.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structrQyjIvxeGC.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structrQyjIvxeGC.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structrUZIsQzLzo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structrUZIsQzLzo.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structrUrNNgGYxl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structrUrNNgGYxl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structrZORE7saci.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structrZORE7saci.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structrnEvXbtOaJ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structrnEvXbtOaJ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structrv6cJ7e4eI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structrv6cJ7e4eI.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structrvnG4DB0O9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structrvnG4DB0O9.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structrxuRIzLrOd.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structrxuRIzLrOd.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structs0wKthNJDH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structs0wKthNJDH.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structs6tlj8Ujb6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structs6tlj8Ujb6.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structs81xiTr3V2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structs81xiTr3V2.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structs9FC686ssT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structs9FC686ssT.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structsU7ru1S3Bn.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structsU7ru1S3Bn.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structsconExg82n.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structsconExg82n.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structsnl6YWFzw6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structsnl6YWFzw6.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structsr11hihvVP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structsr11hihvVP.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structsrFnuySLJZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structsrFnuySLJZ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structsyMjE23XYL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structsyMjE23XYL.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structt1zhtoy3QG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structt1zhtoy3QG.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structt3vc10gLez.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structt3vc10gLez.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structt7Y6XwomUH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structt7Y6XwomUH.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structtFfTsyMFtj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structtFfTsyMFtj.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structtKTQH67TAx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structtKTQH67TAx.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structtRnRKY1Nt9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structtRnRKY1Nt9.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structtVv0gLLUw6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structtVv0gLLUw6.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structtdu9UH9BR6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structtdu9UH9BR6.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structtkLijaINDB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structtkLijaINDB.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structtmi3Y4xjWJ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structtmi3Y4xjWJ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structtoRHBeshpF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structtoRHBeshpF.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structtoojZOxzYL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structtoojZOxzYL.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structuEWock0xfg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structuEWock0xfg.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structuYFS57GpEz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structuYFS57GpEz.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structuZLTFqoTc9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structuZLTFqoTc9.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structuesCCsCmB9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structuesCCsCmB9.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structuk9n40Ba1s.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structuk9n40Ba1s.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structurOByRIJr5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structurOByRIJr5.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structusM7i9eFda.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structusM7i9eFda.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structuzTdZWiu60.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structuzTdZWiu60.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structv4jF52UQ9H.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structv4jF52UQ9H.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structv9bmg59CEV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structv9bmg59CEV.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structvE6YTruKB5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structvE6YTruKB5.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structvGYXxaXkfO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structvGYXxaXkfO.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structvIiPiag0AP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structvIiPiag0AP.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structvJXxV1TNGG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structvJXxV1TNGG.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structvLrhLw24Yo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structvLrhLw24Yo.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structvPLGLtUGvc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structvPLGLtUGvc.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structvQ4tBtsFIQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structvQ4tBtsFIQ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structvetTPo8phL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structvetTPo8phL.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structvh6HUMxCO1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structvh6HUMxCO1.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structvhPOJekCB6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structvhPOJekCB6.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structvqpjGCBNgC.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structvqpjGCBNgC.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structw1Jcuo2qcB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structw1Jcuo2qcB.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structw1LUTeHkEP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structw1LUTeHkEP.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structw704rOrUeD.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structw704rOrUeD.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structwAVE8pzuIw.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structwAVE8pzuIw.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structwE9USHmMoa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structwE9USHmMoa.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structwKyV6c3NXx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structwKyV6c3NXx.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structwNNWk20409.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structwNNWk20409.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structwPjsuxb7PR.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structwPjsuxb7PR.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structwquRams9Fs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structwquRams9Fs.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structwyz9cVcdwh.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structwyz9cVcdwh.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structx29mgYMw04.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structx29mgYMw04.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structx9kDs7ICzW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structx9kDs7ICzW.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structxFTWeVz86X.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structxFTWeVz86X.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structxI8aw5DOBf.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structxI8aw5DOBf.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structxKJxcMqgXp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structxKJxcMqgXp.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structxSyTOLVs2a.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structxSyTOLVs2a.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structxY83QlHYu8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structxY83QlHYu8.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structxatoIPHwut.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structxatoIPHwut.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structxayiSk9poY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structxayiSk9poY.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structxl0tHilNDj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structxl0tHilNDj.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structxpKM8hQmHX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structxpKM8hQmHX.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structxrKKgR1Fe1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structxrKKgR1Fe1.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structxsR9aAsAXm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structxsR9aAsAXm.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structxwNsI8Zdb1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structxwNsI8Zdb1.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structy2eHpFGRr5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structy2eHpFGRr5.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structy5X9cuxDIn.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structy5X9cuxDIn.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structy5wbr5f4bB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structy5wbr5f4bB.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structyAGnaq1EBc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structyAGnaq1EBc.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structyGjRe5am7c.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structyGjRe5am7c.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structyKsJfDGXaz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structyKsJfDGXaz.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structyNBvxKIcti.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structyNBvxKIcti.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structyPEdNMH6Lo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structyPEdNMH6Lo.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structyTmtkFKqd7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structyTmtkFKqd7.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structydbIqe0qPo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structydbIqe0qPo.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structyhDvAbXvCv.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structyhDvAbXvCv.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structynitZhhUeJ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structynitZhhUeJ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structyvVgkdYRXO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structyvVgkdYRXO.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structz1JgTXpAuI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structz1JgTXpAuI.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structz7dfzzL9Yk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structz7dfzzL9Yk.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structzIXefsJFSz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structzIXefsJFSz.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structzPWDt4oN6i.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structzPWDt4oN6i.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structzQUyc7Ws0e.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structzQUyc7Ws0e.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structzTIpN6ALMu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structzTIpN6ALMu.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structzYoD4xKxnZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structzYoD4xKxnZ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structzdXNEcof9V.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structzdXNEcof9V.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structzo3owhla9x.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structzo3owhla9x.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structzyowJj76a6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v3.1/readonly-partial-structzyowJj76a6.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct00oieaoYA5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct00oieaoYA5.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct05nZxSvOQy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct05nZxSvOQy.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct0CW6rWihRa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct0CW6rWihRa.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct0EiiHjJ0Jy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct0EiiHjJ0Jy.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct0HxVdkFuDk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct0HxVdkFuDk.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct0Sp8nFf9po.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct0Sp8nFf9po.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct0YOigHUonk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct0YOigHUonk.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct0mu68DyXFS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct0mu68DyXFS.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct0oZl05ifoL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct0oZl05ifoL.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct101P28DC6b.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct101P28DC6b.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct109xwVU7na.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct109xwVU7na.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct13ZLCuuDdg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct13ZLCuuDdg.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct164v5M7Oiu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct164v5M7Oiu.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct16i8Hnvzik.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct16i8Hnvzik.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct1B64P2KJTT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct1B64P2KJTT.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct1FLNprzFfg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct1FLNprzFfg.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct1Lodf8jQhi.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct1Lodf8jQhi.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct1NM3qeUh2p.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct1NM3qeUh2p.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct1QKloRyprM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct1QKloRyprM.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct1TeundtXb1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct1TeundtXb1.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct1e9vZ2ZVVl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct1e9vZ2ZVVl.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct1ibkpE2U9t.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct1ibkpE2U9t.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct1jAvJkz71q.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct1jAvJkz71q.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct1kIcXqyaMm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct1kIcXqyaMm.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct1kIjvNmL26.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct1kIjvNmL26.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct1nopkP9yWt.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct1nopkP9yWt.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct1q3mpvDeuG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct1q3mpvDeuG.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct1rwcZsOxGm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct1rwcZsOxGm.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct1shpv6NmPc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct1shpv6NmPc.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct1tertRu9Xm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct1tertRu9Xm.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct1xSlrFoiE2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct1xSlrFoiE2.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct1xjEjG8zge.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct1xjEjG8zge.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct1zEPcP8TZ0.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct1zEPcP8TZ0.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct22wFvfGOQe.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct22wFvfGOQe.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct23OaGTh97N.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct23OaGTh97N.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct2C0v3cLs4t.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct2C0v3cLs4t.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct2Ii6Pytw94.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct2Ii6Pytw94.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct2KJvO9ifSa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct2KJvO9ifSa.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct2Oea4qEuqL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct2Oea4qEuqL.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct2PRjv73LUz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct2PRjv73LUz.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct2PlWXW13Oo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct2PlWXW13Oo.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct2RjyXdbOmS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct2RjyXdbOmS.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct2WJXBATRow.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct2WJXBATRow.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct2ePshLeWkH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct2ePshLeWkH.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct2iRAZCo7L5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct2iRAZCo7L5.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct2l1qlatawT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct2l1qlatawT.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct2lPhMAoDBl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct2lPhMAoDBl.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct2mrBdiaAsD.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct2mrBdiaAsD.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct2yK9S7dzeX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct2yK9S7dzeX.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct2yeMfnvK5l.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct2yeMfnvK5l.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct34i0YswjFg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct34i0YswjFg.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct3AvV0e5RCv.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct3AvV0e5RCv.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct3Fkic0RvsS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct3Fkic0RvsS.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct3Q09CNhFqG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct3Q09CNhFqG.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct3W5X0ROtrE.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct3W5X0ROtrE.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct3YKEcUcTm6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct3YKEcUcTm6.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct3Ysql1aZTo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct3Ysql1aZTo.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct3aLcZ0Gzdp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct3aLcZ0Gzdp.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct3bQ2CbXXiG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct3bQ2CbXXiG.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct3hbQkh2oXr.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct3hbQkh2oXr.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct3o9W3tWIYr.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct3o9W3tWIYr.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct3oRAhgtPFs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct3oRAhgtPFs.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct3rEqyW20Ha.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct3rEqyW20Ha.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct3rh7agTF1u.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct3rh7agTF1u.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct3tAXhVgz0j.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct3tAXhVgz0j.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct3udOlsWezr.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct3udOlsWezr.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct3yavERh0QP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct3yavERh0QP.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct40R1V76roU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct40R1V76roU.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct44PftY660j.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct44PftY660j.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct46ykdVFGwG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct46ykdVFGwG.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct47pp9CzShs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct47pp9CzShs.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct49eWbTEG4e.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct49eWbTEG4e.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct4I0C5KiBcT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct4I0C5KiBcT.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct4NHzRc00m2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct4NHzRc00m2.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct4R1b3Sfk6J.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct4R1b3Sfk6J.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct4VkhuwJa8e.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct4VkhuwJa8e.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct4bA4rV4T7I.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct4bA4rV4T7I.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct4qOfIMBclV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct4qOfIMBclV.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct4tYHXfgnVZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct4tYHXfgnVZ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct4xCfXxpvdy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct4xCfXxpvdy.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct4zYtkggxX9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct4zYtkggxX9.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct566AUa8c9w.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct566AUa8c9w.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct5B3Ki66g8U.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct5B3Ki66g8U.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct5GIHfCnyF0.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct5GIHfCnyF0.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct5GXqW1XpIl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct5GXqW1XpIl.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct5R3JtFMKyy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct5R3JtFMKyy.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct5WOnMXao7S.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct5WOnMXao7S.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct5WjoUCBC2W.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct5WjoUCBC2W.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct5YuboIIJis.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct5YuboIIJis.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct5coPgZ627S.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct5coPgZ627S.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct5nsLLrnYzS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct5nsLLrnYzS.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct5p0wzn3Twr.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct5p0wzn3Twr.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct5pUyGEiqRW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct5pUyGEiqRW.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct66VojQk1NI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct66VojQk1NI.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct67D9OX1YBs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct67D9OX1YBs.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct67XWJDtmLp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct67XWJDtmLp.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct6ACGifRdRw.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct6ACGifRdRw.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct6AkdgH06Lh.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct6AkdgH06Lh.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct6BWJO4ygCh.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct6BWJO4ygCh.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct6Eho6XNoOx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct6Eho6XNoOx.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct6Fnny4hIyl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct6Fnny4hIyl.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct6GnahT2THT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct6GnahT2THT.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct6Gy1eE7iFg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct6Gy1eE7iFg.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct6InhhK3Bnx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct6InhhK3Bnx.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct6KaWm2V4so.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct6KaWm2V4so.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct6NVZQs4UrE.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct6NVZQs4UrE.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct6PUxZ29VTq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct6PUxZ29VTq.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct6fce05Qu1f.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct6fce05Qu1f.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct6tzbdxQpL4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct6tzbdxQpL4.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct763ixhZiPg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct763ixhZiPg.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct79tZSSX75b.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct79tZSSX75b.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct7E3RzOaVF1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct7E3RzOaVF1.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct7Ev4ba5U4g.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct7Ev4ba5U4g.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct7FkotSk0XD.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct7FkotSk0XD.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct7MpRJpjzYV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct7MpRJpjzYV.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct7UAHrFSXgp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct7UAHrFSXgp.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct7ZDRFK7C6w.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct7ZDRFK7C6w.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct7hWyxK9Im1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct7hWyxK9Im1.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct7vhsXm5Sqy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct7vhsXm5Sqy.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct7vwzjN2hQB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct7vwzjN2hQB.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct7x47kTkDWA.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct7x47kTkDWA.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct814BQq200G.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct814BQq200G.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct84TN7zjoK9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct84TN7zjoK9.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct8CllamWxHF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct8CllamWxHF.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct8KGpb7sMhV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct8KGpb7sMhV.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct8P1XTIrmCU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct8P1XTIrmCU.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct8eGauAG2Iy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct8eGauAG2Iy.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct8hD3MVC60I.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct8hD3MVC60I.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct8q0Jpdjx8u.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct8q0Jpdjx8u.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct8qIwjmR7oN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct8qIwjmR7oN.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct8tbcftbwF8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct8tbcftbwF8.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct8txOZ8smgu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct8txOZ8smgu.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct8yaeAzdZUO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct8yaeAzdZUO.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct98nsmL4Uyu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct98nsmL4Uyu.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct9CTRHeV5gV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct9CTRHeV5gV.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct9E3xYWs4gr.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct9E3xYWs4gr.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct9FbBK7sAEy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct9FbBK7sAEy.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct9HOIXHYhP9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct9HOIXHYhP9.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct9IzMME36Bl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct9IzMME36Bl.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct9PLpEx4eEr.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct9PLpEx4eEr.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct9QX6aOMWmP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct9QX6aOMWmP.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct9XFvojKqS7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct9XFvojKqS7.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct9Z0NXJ0nuB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct9Z0NXJ0nuB.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct9cdQxj05PP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct9cdQxj05PP.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct9dJLrfdwrb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct9dJLrfdwrb.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct9fPHF2RcIG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct9fPHF2RcIG.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct9o9IQlJhfF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct9o9IQlJhfF.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct9rTJlJQ4St.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct9rTJlJQ4St.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct9tS75raz9v.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-struct9tS75raz9v.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structA0t67j1fxp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structA0t67j1fxp.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structA2y6S9lFjD.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structA2y6S9lFjD.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structA4N6i5eArl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structA4N6i5eArl.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structA6J9ouYjJm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structA6J9ouYjJm.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structAB03r2H43b.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structAB03r2H43b.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structADRxlKyBIl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structADRxlKyBIl.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structAE7oPkwYY6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structAE7oPkwYY6.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structAHdMDYZJaK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structAHdMDYZJaK.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structAK2drK1aH7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structAK2drK1aH7.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structAPZGaaiAsI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structAPZGaaiAsI.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structAQE2E9exgF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structAQE2E9exgF.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structAcoWvPhtlp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structAcoWvPhtlp.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structAiFfzJ9xOo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structAiFfzJ9xOo.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structAztsRhE0LF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structAztsRhE0LF.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structB9pN8GfUaU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structB9pN8GfUaU.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structBA8lKBvox6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structBA8lKBvox6.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structBBBafcZBl1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structBBBafcZBl1.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structBF8funmMCW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structBF8funmMCW.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structBNGrkk0Gq9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structBNGrkk0Gq9.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structBW4o7dJUoK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structBW4o7dJUoK.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structBWsRWzQ335.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structBWsRWzQ335.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structBfsVSixXGI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structBfsVSixXGI.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structBjERtQ98tj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structBjERtQ98tj.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structBjy5dZK2rM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structBjy5dZK2rM.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structBm7Ua0ACla.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structBm7Ua0ACla.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structBmz4OJxAlt.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structBmz4OJxAlt.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structBw3OKv2Qms.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structBw3OKv2Qms.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structBzSRBjnY22.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structBzSRBjnY22.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structC0g7V6d3fy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structC0g7V6d3fy.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structCBt0kIYRra.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structCBt0kIYRra.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structCOGSdZd0AL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structCOGSdZd0AL.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structCXeEkfG71q.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structCXeEkfG71q.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structCaHH2Xyhc7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structCaHH2Xyhc7.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structCcLnEruc0v.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structCcLnEruc0v.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structCfD3K5QvsN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structCfD3K5QvsN.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structCqQVJigrtI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structCqQVJigrtI.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structCzvlSZqJoZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structCzvlSZqJoZ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structD2oQVW5tnq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structD2oQVW5tnq.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structD4YplBwWDi.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structD4YplBwWDi.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structD9gno8tRvF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structD9gno8tRvF.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structDACFSZmJCd.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structDACFSZmJCd.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structDVPBdDC863.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structDVPBdDC863.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structDXFa0e4ozX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structDXFa0e4ozX.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structDZZWeqhEZS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structDZZWeqhEZS.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structDhEKpPXtbG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structDhEKpPXtbG.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structDi88qmJim6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structDi88qmJim6.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structDrIOG3dy4E.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structDrIOG3dy4E.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structE1izflhe7m.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structE1izflhe7m.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structE7tbP2KegJ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structE7tbP2KegJ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structECJjSKcI0x.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structECJjSKcI0x.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structECjdzNW2hb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structECjdzNW2hb.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structENNglh8DX6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structENNglh8DX6.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structEVUFJOsbyB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structEVUFJOsbyB.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structEa3Y8fmO5t.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structEa3Y8fmO5t.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structEbe6V1e8rk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structEbe6V1e8rk.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structEilgeng6RU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structEilgeng6RU.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structEjN7KM70nB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structEjN7KM70nB.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structEoc6yu6UZC.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structEoc6yu6UZC.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structEqZWhQIozu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structEqZWhQIozu.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structErRGvv06c5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structErRGvv06c5.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structEvFFf3fZGJ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structEvFFf3fZGJ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structEx5206L0wV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structEx5206L0wV.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structF3dNExh2mR.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structF3dNExh2mR.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structF8DhNrWv7E.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structF8DhNrWv7E.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structF9RjQ90jnp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structF9RjQ90jnp.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structFI3w6VQMfO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structFI3w6VQMfO.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structFJsonz9Nyz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structFJsonz9Nyz.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structFR85FzqbWk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structFR85FzqbWk.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structFXxZeDtCw5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structFXxZeDtCw5.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structFaTXoezJTa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structFaTXoezJTa.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structFhwETmltur.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structFhwETmltur.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structFjGw1Sgvhj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structFjGw1Sgvhj.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structFq1hfAwgHs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structFq1hfAwgHs.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structFvR9kgHTwq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structFvR9kgHTwq.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structFx3ViT9W1l.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structFx3ViT9W1l.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structG23iNFg5pV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structG23iNFg5pV.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structG4WvAWeyY2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structG4WvAWeyY2.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structG5eiJlW14L.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structG5eiJlW14L.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structG7DG28rR3I.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structG7DG28rR3I.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structG8t7pJyR0P.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structG8t7pJyR0P.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structGAhk4JD5f5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structGAhk4JD5f5.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structGElc6so5Vx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structGElc6so5Vx.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structGL3ENulfXA.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structGL3ENulfXA.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structGPgos6Ga6k.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structGPgos6Ga6k.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structGVka0u9TDq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structGVka0u9TDq.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structGXNEUsfHGV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structGXNEUsfHGV.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structGajQGzODLb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structGajQGzODLb.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structGbvlSI6ZFM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structGbvlSI6ZFM.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structGgvsKvoP9v.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structGgvsKvoP9v.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structGiiPLasS8y.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structGiiPLasS8y.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structGlUP6EKlOZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structGlUP6EKlOZ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structGmNuKgusEl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structGmNuKgusEl.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structGnndCPLSRE.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structGnndCPLSRE.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structGseI8AQPtb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structGseI8AQPtb.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structGyODqQmfLk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structGyODqQmfLk.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structH5eQeBi4oY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structH5eQeBi4oY.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structH6F7xwrgKM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structH6F7xwrgKM.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structHAW6jHGG5q.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structHAW6jHGG5q.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structHGMhtcP1Gs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structHGMhtcP1Gs.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structHNoL72ys27.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structHNoL72ys27.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structHOwIYbq2Gd.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structHOwIYbq2Gd.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structHQ1FzQOf8n.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structHQ1FzQOf8n.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structHQRXU94JgV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structHQRXU94JgV.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structHSN0q7oMVM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structHSN0q7oMVM.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structHYnhl5ltDv.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structHYnhl5ltDv.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structHcCEQbo9Zf.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structHcCEQbo9Zf.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structHfRiDfgqPK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structHfRiDfgqPK.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structHnGXhmegvA.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structHnGXhmegvA.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structHnNLvYqbMR.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structHnNLvYqbMR.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structHt9F9jtMD0.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structHt9F9jtMD0.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structHusaUbKJVm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structHusaUbKJVm.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structHvGrPaR9Bu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structHvGrPaR9Bu.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structHvI693MHyM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structHvI693MHyM.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structHyrFeqyBCY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structHyrFeqyBCY.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structHzJtxAljeg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structHzJtxAljeg.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structI2aSLtV0nK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structI2aSLtV0nK.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structI5QO2BUMxk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structI5QO2BUMxk.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structI6BZQjT6lx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structI6BZQjT6lx.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structICD2Fjdvwq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structICD2Fjdvwq.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structIHkMJI02Cs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structIHkMJI02Cs.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structIJpxdh5h1j.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structIJpxdh5h1j.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structIKVPnPqtVG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structIKVPnPqtVG.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structIODsh0cyAj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structIODsh0cyAj.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structIWnVfC7bMR.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structIWnVfC7bMR.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structIg48IJ1BGz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structIg48IJ1BGz.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structIjpYds4lWa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structIjpYds4lWa.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structImqfRF5u5d.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structImqfRF5u5d.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structIpNWKHAjIK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structIpNWKHAjIK.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structIq2IxAwTbz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structIq2IxAwTbz.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structIqjoEWN5a6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structIqjoEWN5a6.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structJ1WoVnmoNK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structJ1WoVnmoNK.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structJ4N4ApAuNd.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structJ4N4ApAuNd.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structJ4sxZ95hzs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structJ4sxZ95hzs.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structJ5ThymSmBk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structJ5ThymSmBk.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structJBdaFHCitX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structJBdaFHCitX.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structJBjYKH35Id.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structJBjYKH35Id.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structJEL7o5TRHh.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structJEL7o5TRHh.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structJFU1xlKVwi.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structJFU1xlKVwi.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structJIOp0LkuGx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structJIOp0LkuGx.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structJKSxRHdkgU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structJKSxRHdkgU.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structJLl1JS3EBA.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structJLl1JS3EBA.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structJPod17bl3h.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structJPod17bl3h.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structJSkoDJdEmy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structJSkoDJdEmy.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structJXZ8aT3Z1A.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structJXZ8aT3Z1A.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structJYFDwGezZu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structJYFDwGezZu.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structJZBOzjdChs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structJZBOzjdChs.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structJcJCwPR9O6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structJcJCwPR9O6.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structJdaXHv9XGK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structJdaXHv9XGK.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structJguJlpO2Zx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structJguJlpO2Zx.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structJjOrVxY09U.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structJjOrVxY09U.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structJmS6AEcW3Z.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structJmS6AEcW3Z.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structJmgvdzeb5n.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structJmgvdzeb5n.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structJt6jf8vpBs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structJt6jf8vpBs.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structJyoG3utfUF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structJyoG3utfUF.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structK17aJaWFKp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structK17aJaWFKp.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structK6zBHvtXEz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structK6zBHvtXEz.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structK8yLeG1Rq8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structK8yLeG1Rq8.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structKAGtyEb0Mc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structKAGtyEb0Mc.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structKBZsUWVDxs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structKBZsUWVDxs.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structKD97Jf4W3S.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structKD97Jf4W3S.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structKDBDsZNe9Z.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structKDBDsZNe9Z.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structKDWeAZ2IPn.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structKDWeAZ2IPn.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structKF4sn2PYXa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structKF4sn2PYXa.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structKHnzHYYQv9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structKHnzHYYQv9.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structKJhvJs3EGG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structKJhvJs3EGG.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structKLSPh0PXhl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structKLSPh0PXhl.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structKNZX9fxtdl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structKNZX9fxtdl.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structKS9Hbi6AwZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structKS9Hbi6AwZ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structKVlfLjDmn1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structKVlfLjDmn1.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structKX2JHsJ0bd.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structKX2JHsJ0bd.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structKkESsYkID7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structKkESsYkID7.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structKkHcnJvU6l.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structKkHcnJvU6l.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structKkvn2ffBgz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structKkvn2ffBgz.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structKxmFSKOkr0.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structKxmFSKOkr0.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structL0iuHiXIxa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structL0iuHiXIxa.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structL28FwCaWlq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structL28FwCaWlq.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structL3YlcXIU3G.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structL3YlcXIU3G.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structL5PAA2Y49o.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structL5PAA2Y49o.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structL8rTw5Q3JI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structL8rTw5Q3JI.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structLJsbrcp1QV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structLJsbrcp1QV.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structLKxIRREq4D.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structLKxIRREq4D.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structLMQlSHV6GT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structLMQlSHV6GT.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structLV2nB9GvAz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structLV2nB9GvAz.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structLa1OJDLBp5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structLa1OJDLBp5.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structLcNNHqG92U.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structLcNNHqG92U.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structLnY2DL1Mbw.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structLnY2DL1Mbw.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structLpxoYUnOy7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structLpxoYUnOy7.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structLs7CLvlkgi.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structLs7CLvlkgi.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structLtMZ0XaStC.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structLtMZ0XaStC.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structLy4yvDjUuQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structLy4yvDjUuQ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structM9DKZGOLDg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structM9DKZGOLDg.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structMBndhRFxei.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structMBndhRFxei.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structMEcvkINwlN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structMEcvkINwlN.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structMFY7puSlGX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structMFY7puSlGX.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structMQnq3Fo18k.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structMQnq3Fo18k.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structMRN9c8EZAu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structMRN9c8EZAu.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structMSaXkM98gx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structMSaXkM98gx.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structMe4GO0lmyL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structMe4GO0lmyL.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structMf7H2FRsCR.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structMf7H2FRsCR.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structMgFMQz9tN4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structMgFMQz9tN4.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structMhWZ76XLqK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structMhWZ76XLqK.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structMiv3889DlT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structMiv3889DlT.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structMkNnqyG9Tl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structMkNnqyG9Tl.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structMw7h6zUCoS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structMw7h6zUCoS.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structN5CGh6EWiK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structN5CGh6EWiK.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structN86zzxZWL3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structN86zzxZWL3.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structN9VLieAgkB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structN9VLieAgkB.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structNB005jf6q4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structNB005jf6q4.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structNW2O8zaFJU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structNW2O8zaFJU.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structNXVElSFyJY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structNXVElSFyJY.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structNXkTPXgNCQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structNXkTPXgNCQ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structNYxtIN1k6X.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structNYxtIN1k6X.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structNcunqydrcp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structNcunqydrcp.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structNfG8poVmRX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structNfG8poVmRX.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structNpSaGkUh99.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structNpSaGkUh99.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structNphpYJarez.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structNphpYJarez.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structNq8WSpQa6r.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structNq8WSpQa6r.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structNuHNDIZUYr.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structNuHNDIZUYr.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structO4Kr2Vp6iB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structO4Kr2Vp6iB.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structO5SpO4Lmqy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structO5SpO4Lmqy.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structO6aBEtLHCl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structO6aBEtLHCl.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structO8aC92gkJu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structO8aC92gkJu.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structOAXjhVxHVW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structOAXjhVxHVW.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structOBggRrGGeA.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structOBggRrGGeA.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structOCKiZ8XvN4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structOCKiZ8XvN4.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structOTagHf6dta.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structOTagHf6dta.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structOmPR4GDmha.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structOmPR4GDmha.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structOnU7Y1iyOW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structOnU7Y1iyOW.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structOruSh6IU68.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structOruSh6IU68.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structP07kLcgWy2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structP07kLcgWy2.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structP0hi03Yr5J.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structP0hi03Yr5J.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structP51IT0iQls.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structP51IT0iQls.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structPC53CFAahl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structPC53CFAahl.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structPDETEBub2B.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structPDETEBub2B.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structPIEO17rXv3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structPIEO17rXv3.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structPL1Vy8gAQG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structPL1Vy8gAQG.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structPOAJbOn5yN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structPOAJbOn5yN.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structPWOGZtzGIy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structPWOGZtzGIy.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structPWOtvXxst0.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structPWOtvXxst0.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structPaMBWeOEZb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structPaMBWeOEZb.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structPbViqUkC9s.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structPbViqUkC9s.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structPjXLhVCSo2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structPjXLhVCSo2.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structPmsSWhVFlx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structPmsSWhVFlx.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structPvttwCSove.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structPvttwCSove.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structPy7auxT2wm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structPy7auxT2wm.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structPzKBHCX9aj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structPzKBHCX9aj.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structQ1lt85NZkv.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structQ1lt85NZkv.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structQ9W3v3dQYW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structQ9W3v3dQYW.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structQBpF2mc1un.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structQBpF2mc1un.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structQLoTxIicfl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structQLoTxIicfl.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structQNBjmFEISk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structQNBjmFEISk.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structQRNlszU7N1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structQRNlszU7N1.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structQRrZvgSvEl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structQRrZvgSvEl.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structQu8eKSWeIJ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structQu8eKSWeIJ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structQwjx7jDCDX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structQwjx7jDCDX.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structQwri7Ax9TK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structQwri7Ax9TK.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structR4xaEYdpRY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structR4xaEYdpRY.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structR6bsgVIYE6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structR6bsgVIYE6.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structR6j965l6JZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structR6j965l6JZ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structR6yPnOD0oz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structR6yPnOD0oz.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structR8eEQpI0YT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structR8eEQpI0YT.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structRBr9HNIGgm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structRBr9HNIGgm.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structRBwjivoMMP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structRBwjivoMMP.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structRFFK9pIT93.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structRFFK9pIT93.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structRJYj3K0a3c.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structRJYj3K0a3c.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structRLhaWW9haz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structRLhaWW9haz.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structRSckKIVPNO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structRSckKIVPNO.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structRX7hJYzEEc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structRX7hJYzEEc.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structRbEgtyrBAH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structRbEgtyrBAH.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structRbgB04HmL4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structRbgB04HmL4.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structRdgEVFWPU8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structRdgEVFWPU8.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structRjYd0rym9S.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structRjYd0rym9S.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structRpd0ErOBb6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structRpd0ErOBb6.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structRtcf0YV8fO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structRtcf0YV8fO.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structRtjThoUz7H.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structRtjThoUz7H.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structRyTk5RxJJO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structRyTk5RxJJO.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structS1RhuauboU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structS1RhuauboU.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structS6bmXaMMyl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structS6bmXaMMyl.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structSDPIMkAwH8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structSDPIMkAwH8.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structSEmAsgVkk9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structSEmAsgVkk9.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structSIfHQocAM7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structSIfHQocAM7.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structSL3XN9PByF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structSL3XN9PByF.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structSOJZorG6h4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structSOJZorG6h4.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structSOQ2b3Trj9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structSOQ2b3Trj9.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structSOcWqfVVcP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structSOcWqfVVcP.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structSUuI5kWBPQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structSUuI5kWBPQ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structSWz0ZdY1fL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structSWz0ZdY1fL.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structSXB5wflpQj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structSXB5wflpQj.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structSaCKmxwW7X.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structSaCKmxwW7X.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structSkgZGVkxzj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structSkgZGVkxzj.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structSuSfIvUv2A.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structSuSfIvUv2A.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structSuaJbDOn73.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structSuaJbDOn73.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structSv55DLNwHy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structSv55DLNwHy.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structSvXjwmwWp8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structSvXjwmwWp8.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structT024qoIGBu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structT024qoIGBu.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structT396ygje53.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structT396ygje53.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structTA8Sp22K2U.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structTA8Sp22K2U.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structTGF07uM1y9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structTGF07uM1y9.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structTKbYYBx9QZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structTKbYYBx9QZ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structTLyC86eODa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structTLyC86eODa.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structTSEu5hclTq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structTSEu5hclTq.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structTX5YCrOcOo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structTX5YCrOcOo.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structTX6rXf2RZh.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structTX6rXf2RZh.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structTaJbzfeDjo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structTaJbzfeDjo.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structTaYGLKdSM8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structTaYGLKdSM8.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structTgcZPmWOx2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structTgcZPmWOx2.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structTh5NbnUqzI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structTh5NbnUqzI.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structTknpxoQFvS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structTknpxoQFvS.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structTqu8KoZQjY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structTqu8KoZQjY.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structTuAcbBNnZm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structTuAcbBNnZm.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structTuWH3zeluv.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structTuWH3zeluv.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structTwjPuMKDiB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structTwjPuMKDiB.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structTxF88EuH4Q.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structTxF88EuH4Q.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structTzQ4rWvlZ3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structTzQ4rWvlZ3.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structU2kogkOlcf.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structU2kogkOlcf.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structU3dy6bkQcN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structU3dy6bkQcN.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structUA5Zgdsa4W.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structUA5Zgdsa4W.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structUC7urls6rG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structUC7urls6rG.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structUJ5RVg0xHN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structUJ5RVg0xHN.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structUL0XgKUiea.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structUL0XgKUiea.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structUYdnQvYvKk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structUYdnQvYvKk.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structUaTPRyIwWQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structUaTPRyIwWQ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structUgp6Bg804O.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structUgp6Bg804O.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structUgsqUT0Fw8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structUgsqUT0Fw8.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structUomjJGDhS3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structUomjJGDhS3.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structUrJ7tMPYdi.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structUrJ7tMPYdi.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structUsGUm5feCJ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structUsGUm5feCJ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structUx6sDnae6o.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structUx6sDnae6o.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structUyBELJkxhd.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structUyBELJkxhd.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structV1mFMqHDyz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structV1mFMqHDyz.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structV3DEOjYkAI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structV3DEOjYkAI.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structV4EcMh64Nu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structV4EcMh64Nu.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structVABFQlbdB8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structVABFQlbdB8.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structVCKWE5qXDQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structVCKWE5qXDQ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structVF3eV6RT5A.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structVF3eV6RT5A.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structVGVFt2H4Jq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structVGVFt2H4Jq.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structVHmibu21U1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structVHmibu21U1.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structVJQMEbTTcW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structVJQMEbTTcW.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structVW9Wugrq8f.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structVW9Wugrq8f.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structVbui9U8nJN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structVbui9U8nJN.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structVqmZxmYjrS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structVqmZxmYjrS.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structVwumd12dMR.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structVwumd12dMR.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structW03TuqLzYH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structW03TuqLzYH.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structW6NGdR4FHA.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structW6NGdR4FHA.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structW8RwEte1K1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structW8RwEte1K1.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structWFr5O7xRwi.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structWFr5O7xRwi.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structWJw9ZLP7fK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structWJw9ZLP7fK.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structWODpD4eAmE.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structWODpD4eAmE.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structWOGNQBbIW7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structWOGNQBbIW7.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structWQN1KyUD5b.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structWQN1KyUD5b.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structWTDgYPieK1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structWTDgYPieK1.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structWVtboPH1aE.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structWVtboPH1aE.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structWiPM4vCvbR.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structWiPM4vCvbR.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structWk1zWo8r9K.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structWk1zWo8r9K.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structWkYOcVuG9r.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structWkYOcVuG9r.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structWqKLr6PuT3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structWqKLr6PuT3.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structWyFaNRxWDU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structWyFaNRxWDU.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structX0tLJiI6QS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structX0tLJiI6QS.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structX74WdLPgP3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structX74WdLPgP3.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structXLePVWtJFS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structXLePVWtJFS.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structXNJAbmwEpz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structXNJAbmwEpz.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structXOlFj8WTWU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structXOlFj8WTWU.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structXQpY9eJk4m.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structXQpY9eJk4m.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structXU2GzBHEnm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structXU2GzBHEnm.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structXWIUjIMjuc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structXWIUjIMjuc.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structXYOl2gpZhZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structXYOl2gpZhZ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structXYrXq7Kz5O.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structXYrXq7Kz5O.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structXab1L6RKkc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structXab1L6RKkc.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structXcQSZS9Pq3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structXcQSZS9Pq3.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structXdOq3rooU7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structXdOq3rooU7.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structXpfvMzo3SU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structXpfvMzo3SU.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structXs0m0HB3Ve.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structXs0m0HB3Ve.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structXsoVym5xGF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structXsoVym5xGF.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structXxbrxyvfJK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structXxbrxyvfJK.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structY0sbuM1lf1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structY0sbuM1lf1.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structY2WI2qZBJc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structY2WI2qZBJc.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structY3MSP8GJLq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structY3MSP8GJLq.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structY7ZzgHzGVw.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structY7ZzgHzGVw.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structY8HkjRfwpg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structY8HkjRfwpg.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structYAzsftuDhx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structYAzsftuDhx.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structYE37gD7DoN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structYE37gD7DoN.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structYNODMJt0nI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structYNODMJt0nI.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structYOoQMQYEZo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structYOoQMQYEZo.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structYPtr2Dr86B.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structYPtr2Dr86B.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structYXRqKm5H9U.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structYXRqKm5H9U.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structYa2X1A0XlS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structYa2X1A0XlS.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structYj7TbLsdP4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structYj7TbLsdP4.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structYlF6RxCqVs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structYlF6RxCqVs.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structYo1jTzfuKl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structYo1jTzfuKl.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structYrew2qdBuH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structYrew2qdBuH.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structYwZwDfIvIG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structYwZwDfIvIG.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structZ3DY5gvzFY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structZ3DY5gvzFY.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structZBrvC38b8N.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structZBrvC38b8N.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structZC6ZaapQdD.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structZC6ZaapQdD.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structZGNK9Twr9S.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structZGNK9Twr9S.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structZGqp2bRDtx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structZGqp2bRDtx.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structZJSKolxfqc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structZJSKolxfqc.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structZR3LiJX7PO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structZR3LiJX7PO.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structZW26HGLchP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structZW26HGLchP.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structZi1RqmdSol.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structZi1RqmdSol.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structZoimFj6xEE.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structZoimFj6xEE.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structZpfDnRPksn.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structZpfDnRPksn.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structZr2k5TeLcE.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structZr2k5TeLcE.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structZtqbbnQjzj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structZtqbbnQjzj.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structZupKEHABUk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structZupKEHABUk.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structa0AhWFAoDG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structa0AhWFAoDG.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structa5eW784LQf.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structa5eW784LQf.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structa6BXYQAwEm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structa6BXYQAwEm.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structa6bL6toTDQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structa6bL6toTDQ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structa85eS8wvGC.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structa85eS8wvGC.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structaBCMiwiL14.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structaBCMiwiL14.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structaCvUpfrOud.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structaCvUpfrOud.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structaMVAJ9INz0.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structaMVAJ9INz0.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structaNX02HPg7T.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structaNX02HPg7T.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structaacjP2BYDY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structaacjP2BYDY.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structafSLEQGtjb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structafSLEQGtjb.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structawZmlvXiXW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structawZmlvXiXW.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structaxV4fiWwZ7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structaxV4fiWwZ7.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structayNEhBBg4t.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structayNEhBBg4t.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structb265yb0csM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structb265yb0csM.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structb63fAzKNR7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structb63fAzKNR7.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structbBsug1Wd34.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structbBsug1Wd34.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structbNMyvNH8WM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structbNMyvNH8WM.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structbX4S27LXkH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structbX4S27LXkH.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structblpexlSs9M.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structblpexlSs9M.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structbmmnw9qu32.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structbmmnw9qu32.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structbsrrxTZOqn.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structbsrrxTZOqn.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structbtgnPXO5Rq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structbtgnPXO5Rq.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structbwtswCbHZn.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structbwtswCbHZn.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structc0ARtdYgED.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structc0ARtdYgED.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structc0K76QtGvt.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structc0K76QtGvt.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structc19BIAaEkY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structc19BIAaEkY.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structcIUFEZhrle.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structcIUFEZhrle.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structcU51DXcyE8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structcU51DXcyE8.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structcbnz0kvIwn.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structcbnz0kvIwn.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structcfbnUeCgbt.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structcfbnUeCgbt.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structcjMmD9Dwfx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structcjMmD9Dwfx.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structclmVkpAhb8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structclmVkpAhb8.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structcoAqE1boX6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structcoAqE1boX6.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structcormXUf4WS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structcormXUf4WS.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structcqdGRq2WNh.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structcqdGRq2WNh.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structczOiELiAB7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structczOiELiAB7.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structd2ojXxCaNW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structd2ojXxCaNW.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structd4OcbMDcGL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structd4OcbMDcGL.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structd9nB4x1U6u.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structd9nB4x1U6u.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structdEhJcrsORt.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structdEhJcrsORt.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structdKBNYvwyxK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structdKBNYvwyxK.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structdNGVHIlzAj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structdNGVHIlzAj.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structdSftno00MK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structdSftno00MK.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structdXZpHpuk3x.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structdXZpHpuk3x.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structdXgIF94ebo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structdXgIF94ebo.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structdhEH1P8yDX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structdhEH1P8yDX.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structdq0ytTGdT7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structdq0ytTGdT7.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structdr28D0z5ZH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structdr28D0z5ZH.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structe4z2kYEwsw.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structe4z2kYEwsw.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structe79Za4b7Ml.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structe79Za4b7Ml.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structeJF56nvsEj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structeJF56nvsEj.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structeW6hiVZjD9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structeW6hiVZjD9.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structegI0J6pwbq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structegI0J6pwbq.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structemjd05RWc3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structemjd05RWc3.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structeqBjnWgb5P.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structeqBjnWgb5P.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structf0akg4gumK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structf0akg4gumK.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structf32Rx1NpEm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structf32Rx1NpEm.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structf3hg4Duqet.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structf3hg4Duqet.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structf74ThK893J.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structf74ThK893J.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structfBkGsQBirP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structfBkGsQBirP.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structfCVtyydYxM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structfCVtyydYxM.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structfCayR9pma6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structfCayR9pma6.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structfG4ASdjUC9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structfG4ASdjUC9.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structfJdkVlyVac.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structfJdkVlyVac.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structfNnOzIDYzL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structfNnOzIDYzL.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structfOOjVzFOC9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structfOOjVzFOC9.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structfTXY9OU4mh.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structfTXY9OU4mh.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structfWEUc1K6FG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structfWEUc1K6FG.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structfYJ2Mkk1al.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structfYJ2Mkk1al.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structfcg2UqwprF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structfcg2UqwprF.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structfd0mCQVHBl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structfd0mCQVHBl.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structfwecOIJDmQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structfwecOIJDmQ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structgBuG9DjtOU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structgBuG9DjtOU.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structgIAdPMClq9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structgIAdPMClq9.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structgJaEzQzHlG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structgJaEzQzHlG.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structgTI819u8oK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structgTI819u8oK.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structgaVRwvBYOY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structgaVRwvBYOY.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structgmDuxmO8uQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structgmDuxmO8uQ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structgnTh8YZCI4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structgnTh8YZCI4.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structgnzwfueLCU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structgnzwfueLCU.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structgodJTvsSrL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structgodJTvsSrL.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structgoyNOloADC.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structgoyNOloADC.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structgrMFKxp6Rp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structgrMFKxp6Rp.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structgu5AmoUnKH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structgu5AmoUnKH.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structgw0RpMV2f4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structgw0RpMV2f4.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structgzPFVO95T5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structgzPFVO95T5.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structh0wIvbjPFM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structh0wIvbjPFM.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structh0zYLuKys0.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structh0zYLuKys0.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structh4borQn8tt.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structh4borQn8tt.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structhEYyOpWNQA.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structhEYyOpWNQA.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structhKVOXTzhtj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structhKVOXTzhtj.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structhP7CI8CVIx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structhP7CI8CVIx.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structhRp6BjrXlq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structhRp6BjrXlq.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structhXluAaYGUP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structhXluAaYGUP.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structhc5U7IjcZc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structhc5U7IjcZc.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structhjYDoXKd1y.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structhjYDoXKd1y.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structhk5xXOFY3B.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structhk5xXOFY3B.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structhlXXNdntjL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structhlXXNdntjL.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structhnljKmvH1S.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structhnljKmvH1S.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structhsMP7WDnTb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structhsMP7WDnTb.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structi5tx16f99j.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structi5tx16f99j.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structi60i9flgEl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structi60i9flgEl.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structiGcBGhWkFg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structiGcBGhWkFg.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structiH2t1AudUv.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structiH2t1AudUv.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structiJO3yTUlA6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structiJO3yTUlA6.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structiMxQrDbyMm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structiMxQrDbyMm.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structiRTC8Ri5hh.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structiRTC8Ri5hh.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structiUTYiuw7nL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structiUTYiuw7nL.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structifVuZi4Efe.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structifVuZi4Efe.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structigySx6ywF4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structigySx6ywF4.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structimk6k6ZOQP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structimk6k6ZOQP.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structiyfYt6St4H.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structiyfYt6St4H.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structj0Jp6zlUkb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structj0Jp6zlUkb.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structj2noj6YBli.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structj2noj6YBli.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structj80X6OAWFM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structj80X6OAWFM.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structjATzvt82Yc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structjATzvt82Yc.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structjHYdKd1qGS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structjHYdKd1qGS.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structjIn9JVMI49.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structjIn9JVMI49.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structjKvkQzPnI2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structjKvkQzPnI2.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structjPeWDdzelT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structjPeWDdzelT.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structjVynlgrJOg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structjVynlgrJOg.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structjXzq5dAQfq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structjXzq5dAQfq.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structjlEQy1XgIm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structjlEQy1XgIm.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structjpZYztDGZv.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structjpZYztDGZv.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structjyzBmrWLpD.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structjyzBmrWLpD.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structjzLZ1Fd1su.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structjzLZ1Fd1su.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structk0RWOtD4Cb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structk0RWOtD4Cb.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structk5uhI551Ib.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structk5uhI551Ib.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structkBpo9DUgjg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structkBpo9DUgjg.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structkKCqpBwgSB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structkKCqpBwgSB.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structkMn4TDNnDw.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structkMn4TDNnDw.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structkTDa7zOTTq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structkTDa7zOTTq.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structkcnuBfgvqB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structkcnuBfgvqB.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structke5R4wNmaV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structke5R4wNmaV.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structkgOVznysHS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structkgOVznysHS.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structkjR2PqZPCx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structkjR2PqZPCx.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structkjvkPYElx2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structkjvkPYElx2.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structko3HKcubO4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structko3HKcubO4.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structl1rwee6A0W.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structl1rwee6A0W.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structl9GK15NFfI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structl9GK15NFfI.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structl9dEcAYjZX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structl9dEcAYjZX.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structlCbFTLeEcO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structlCbFTLeEcO.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structlFoUTH7TGY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structlFoUTH7TGY.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structlFuagxP4pj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structlFuagxP4pj.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structlKqlZNIiTG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structlKqlZNIiTG.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structlM9nCK9mVa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structlM9nCK9mVa.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structlNxcettVbW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structlNxcettVbW.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structlOMWejTcie.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structlOMWejTcie.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structlPPzP90v2M.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structlPPzP90v2M.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structlWE7ijbTPg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structlWE7ijbTPg.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structlWZpr8mFUz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structlWZpr8mFUz.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structlfb6Bcmyzv.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structlfb6Bcmyzv.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structliZR39PG4B.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structliZR39PG4B.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structlilo17vqrO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structlilo17vqrO.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structlmBHuI2CdK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structlmBHuI2CdK.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structlsRnaxudRi.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structlsRnaxudRi.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structlwBBVufID9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structlwBBVufID9.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structmE7fFfuHjx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structmE7fFfuHjx.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structmPX6OOh4Nl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structmPX6OOh4Nl.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structmR2t9GgAZ5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structmR2t9GgAZ5.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structmU9k8N2S1x.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structmU9k8N2S1x.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structmUQioQKiXp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structmUQioQKiXp.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structmWBF30udKT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structmWBF30udKT.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structmaUySacG7e.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structmaUySacG7e.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structmj4Oyb3GgX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structmj4Oyb3GgX.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structmuAhuD4KVQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structmuAhuD4KVQ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structmwjaO3Uyrs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structmwjaO3Uyrs.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structn5h1DHBxub.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structn5h1DHBxub.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structnAdqmBnbeg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structnAdqmBnbeg.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structnAvYhH07Gs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structnAvYhH07Gs.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structnHnX8P1WDq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structnHnX8P1WDq.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structnNkjJDcz0P.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structnNkjJDcz0P.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structnPwZk9I7YN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structnPwZk9I7YN.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structnUJfW4NMaA.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structnUJfW4NMaA.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structnXMZUp9V4V.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structnXMZUp9V4V.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structnjkuDZnOoQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structnjkuDZnOoQ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structnq8k7vNWX3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structnq8k7vNWX3.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structnrVsGpyHSB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structnrVsGpyHSB.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structnsGvdkMRFZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structnsGvdkMRFZ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structoAhXI74h9j.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structoAhXI74h9j.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structoahbTSUqku.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structoahbTSUqku.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structoiRn4GygF9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structoiRn4GygF9.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structov6aJQLXqu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structov6aJQLXqu.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structovm1h7N1tD.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structovm1h7N1tD.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structoypCXXMXYK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structoypCXXMXYK.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structp39x1W6Nmw.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structp39x1W6Nmw.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structp5F0SqEi1N.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structp5F0SqEi1N.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structpK1zdl2ooH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structpK1zdl2ooH.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structpLXABe2wJc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structpLXABe2wJc.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structpMr2v6juAQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structpMr2v6juAQ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structpXZA41Y8fK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structpXZA41Y8fK.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structpkIouuiKqe.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structpkIouuiKqe.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structpnMhTmK3QH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structpnMhTmK3QH.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structpuA2r64pbW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structpuA2r64pbW.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structpwCAT0hshK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structpwCAT0hshK.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structq1BEWkecYX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structq1BEWkecYX.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structq2gqs38KnH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structq2gqs38KnH.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structq5OjZ10BEs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structq5OjZ10BEs.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structqGa10MSSRs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structqGa10MSSRs.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structqGuE1lEn2E.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structqGuE1lEn2E.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structqK7XKTZI6a.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structqK7XKTZI6a.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structqRtOraogqy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structqRtOraogqy.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structqTdD25cQMq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structqTdD25cQMq.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structqVenFBZMmB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structqVenFBZMmB.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structqVymoyiTzO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structqVymoyiTzO.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structqYoMOdyW5o.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structqYoMOdyW5o.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structqZqGFZMAp0.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structqZqGFZMAp0.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structqceTFkotG1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structqceTFkotG1.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structqklsh0VtCj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structqklsh0VtCj.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structqkwGFodzYo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structqkwGFodzYo.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structqlynSYPIzj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structqlynSYPIzj.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structqmylEQUQxN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structqmylEQUQxN.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structqsdnJQvtod.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structqsdnJQvtod.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structr1IUWdH7kS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structr1IUWdH7kS.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structrDLhl5fFyI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structrDLhl5fFyI.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structrJ6A29EFD3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structrJ6A29EFD3.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structrLI0qkdwNT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structrLI0qkdwNT.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structrNNNMoMUX5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structrNNNMoMUX5.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structrQyjIvxeGC.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structrQyjIvxeGC.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structrUZIsQzLzo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structrUZIsQzLzo.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structrUrNNgGYxl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structrUrNNgGYxl.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structrZORE7saci.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structrZORE7saci.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structrnEvXbtOaJ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structrnEvXbtOaJ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structrv6cJ7e4eI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structrv6cJ7e4eI.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structrvnG4DB0O9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structrvnG4DB0O9.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structrxuRIzLrOd.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structrxuRIzLrOd.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structs0wKthNJDH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structs0wKthNJDH.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structs6tlj8Ujb6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structs6tlj8Ujb6.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structs81xiTr3V2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structs81xiTr3V2.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structs9FC686ssT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structs9FC686ssT.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structsU7ru1S3Bn.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structsU7ru1S3Bn.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structsconExg82n.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structsconExg82n.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structsnl6YWFzw6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structsnl6YWFzw6.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structsr11hihvVP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structsr11hihvVP.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structsrFnuySLJZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structsrFnuySLJZ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structsyMjE23XYL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structsyMjE23XYL.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structt1zhtoy3QG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structt1zhtoy3QG.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structt3vc10gLez.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structt3vc10gLez.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structt7Y6XwomUH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structt7Y6XwomUH.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structtFfTsyMFtj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structtFfTsyMFtj.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structtKTQH67TAx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structtKTQH67TAx.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structtRnRKY1Nt9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structtRnRKY1Nt9.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structtVv0gLLUw6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structtVv0gLLUw6.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structtdu9UH9BR6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structtdu9UH9BR6.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structtkLijaINDB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structtkLijaINDB.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structtmi3Y4xjWJ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structtmi3Y4xjWJ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structtoRHBeshpF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structtoRHBeshpF.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structtoojZOxzYL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structtoojZOxzYL.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structuEWock0xfg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structuEWock0xfg.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structuYFS57GpEz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structuYFS57GpEz.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structuZLTFqoTc9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structuZLTFqoTc9.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structuesCCsCmB9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structuesCCsCmB9.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structuk9n40Ba1s.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structuk9n40Ba1s.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structurOByRIJr5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structurOByRIJr5.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structusM7i9eFda.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structusM7i9eFda.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structuzTdZWiu60.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structuzTdZWiu60.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structv4jF52UQ9H.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structv4jF52UQ9H.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structv9bmg59CEV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structv9bmg59CEV.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structvE6YTruKB5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structvE6YTruKB5.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structvGYXxaXkfO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structvGYXxaXkfO.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structvIiPiag0AP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structvIiPiag0AP.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structvJXxV1TNGG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structvJXxV1TNGG.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structvLrhLw24Yo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structvLrhLw24Yo.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structvPLGLtUGvc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structvPLGLtUGvc.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structvQ4tBtsFIQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structvQ4tBtsFIQ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structvetTPo8phL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structvetTPo8phL.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structvh6HUMxCO1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structvh6HUMxCO1.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structvhPOJekCB6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structvhPOJekCB6.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structvqpjGCBNgC.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structvqpjGCBNgC.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structw1Jcuo2qcB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structw1Jcuo2qcB.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structw1LUTeHkEP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structw1LUTeHkEP.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structw704rOrUeD.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structw704rOrUeD.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structwAVE8pzuIw.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structwAVE8pzuIw.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structwE9USHmMoa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structwE9USHmMoa.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structwKyV6c3NXx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structwKyV6c3NXx.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structwNNWk20409.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structwNNWk20409.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structwPjsuxb7PR.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structwPjsuxb7PR.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structwquRams9Fs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structwquRams9Fs.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structwyz9cVcdwh.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structwyz9cVcdwh.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structx29mgYMw04.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structx29mgYMw04.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structx9kDs7ICzW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structx9kDs7ICzW.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structxFTWeVz86X.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structxFTWeVz86X.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structxI8aw5DOBf.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structxI8aw5DOBf.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structxKJxcMqgXp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structxKJxcMqgXp.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structxSyTOLVs2a.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structxSyTOLVs2a.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structxY83QlHYu8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structxY83QlHYu8.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structxatoIPHwut.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structxatoIPHwut.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structxayiSk9poY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structxayiSk9poY.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structxl0tHilNDj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structxl0tHilNDj.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structxpKM8hQmHX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structxpKM8hQmHX.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structxrKKgR1Fe1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structxrKKgR1Fe1.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structxsR9aAsAXm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structxsR9aAsAXm.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structxwNsI8Zdb1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structxwNsI8Zdb1.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structy2eHpFGRr5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structy2eHpFGRr5.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structy5X9cuxDIn.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structy5X9cuxDIn.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structy5wbr5f4bB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structy5wbr5f4bB.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structyAGnaq1EBc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structyAGnaq1EBc.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structyGjRe5am7c.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structyGjRe5am7c.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structyKsJfDGXaz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structyKsJfDGXaz.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structyNBvxKIcti.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structyNBvxKIcti.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structyPEdNMH6Lo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structyPEdNMH6Lo.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structyTmtkFKqd7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structyTmtkFKqd7.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structydbIqe0qPo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structydbIqe0qPo.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structyhDvAbXvCv.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structyhDvAbXvCv.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structynitZhhUeJ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structynitZhhUeJ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structyvVgkdYRXO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structyvVgkdYRXO.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structz1JgTXpAuI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structz1JgTXpAuI.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structz7dfzzL9Yk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structz7dfzzL9Yk.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structzIXefsJFSz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structzIXefsJFSz.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structzPWDt4oN6i.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structzPWDt4oN6i.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structzQUyc7Ws0e.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structzQUyc7Ws0e.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structzTIpN6ALMu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structzTIpN6ALMu.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structzYoD4xKxnZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structzYoD4xKxnZ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structzdXNEcof9V.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structzdXNEcof9V.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structzo3owhla9x.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structzo3owhla9x.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structzyowJj76a6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/partial-structzyowJj76a6.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct00oieaoYA5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct00oieaoYA5.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct05nZxSvOQy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct05nZxSvOQy.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct0CW6rWihRa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct0CW6rWihRa.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct0EiiHjJ0Jy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct0EiiHjJ0Jy.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct0HxVdkFuDk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct0HxVdkFuDk.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct0Sp8nFf9po.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct0Sp8nFf9po.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct0YOigHUonk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct0YOigHUonk.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct0mu68DyXFS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct0mu68DyXFS.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct0oZl05ifoL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct0oZl05ifoL.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct101P28DC6b.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct101P28DC6b.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct109xwVU7na.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct109xwVU7na.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct13ZLCuuDdg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct13ZLCuuDdg.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct164v5M7Oiu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct164v5M7Oiu.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct16i8Hnvzik.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct16i8Hnvzik.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct1B64P2KJTT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct1B64P2KJTT.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct1FLNprzFfg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct1FLNprzFfg.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct1Lodf8jQhi.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct1Lodf8jQhi.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct1NM3qeUh2p.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct1NM3qeUh2p.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct1QKloRyprM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct1QKloRyprM.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct1TeundtXb1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct1TeundtXb1.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct1e9vZ2ZVVl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct1e9vZ2ZVVl.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct1ibkpE2U9t.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct1ibkpE2U9t.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct1jAvJkz71q.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct1jAvJkz71q.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct1kIcXqyaMm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct1kIcXqyaMm.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct1kIjvNmL26.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct1kIjvNmL26.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct1nopkP9yWt.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct1nopkP9yWt.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct1q3mpvDeuG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct1q3mpvDeuG.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct1rwcZsOxGm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct1rwcZsOxGm.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct1shpv6NmPc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct1shpv6NmPc.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct1tertRu9Xm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct1tertRu9Xm.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct1xSlrFoiE2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct1xSlrFoiE2.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct1xjEjG8zge.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct1xjEjG8zge.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct1zEPcP8TZ0.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct1zEPcP8TZ0.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct22wFvfGOQe.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct22wFvfGOQe.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct23OaGTh97N.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct23OaGTh97N.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct2C0v3cLs4t.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct2C0v3cLs4t.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct2Ii6Pytw94.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct2Ii6Pytw94.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct2KJvO9ifSa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct2KJvO9ifSa.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct2Oea4qEuqL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct2Oea4qEuqL.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct2PRjv73LUz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct2PRjv73LUz.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct2PlWXW13Oo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct2PlWXW13Oo.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct2RjyXdbOmS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct2RjyXdbOmS.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct2WJXBATRow.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct2WJXBATRow.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct2ePshLeWkH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct2ePshLeWkH.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct2iRAZCo7L5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct2iRAZCo7L5.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct2l1qlatawT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct2l1qlatawT.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct2lPhMAoDBl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct2lPhMAoDBl.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct2mrBdiaAsD.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct2mrBdiaAsD.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct2yK9S7dzeX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct2yK9S7dzeX.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct2yeMfnvK5l.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct2yeMfnvK5l.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct34i0YswjFg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct34i0YswjFg.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct3AvV0e5RCv.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct3AvV0e5RCv.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct3Fkic0RvsS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct3Fkic0RvsS.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct3Q09CNhFqG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct3Q09CNhFqG.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct3W5X0ROtrE.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct3W5X0ROtrE.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct3YKEcUcTm6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct3YKEcUcTm6.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct3Ysql1aZTo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct3Ysql1aZTo.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct3aLcZ0Gzdp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct3aLcZ0Gzdp.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct3bQ2CbXXiG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct3bQ2CbXXiG.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct3hbQkh2oXr.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct3hbQkh2oXr.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct3o9W3tWIYr.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct3o9W3tWIYr.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct3oRAhgtPFs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct3oRAhgtPFs.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct3rEqyW20Ha.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct3rEqyW20Ha.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct3rh7agTF1u.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct3rh7agTF1u.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct3tAXhVgz0j.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct3tAXhVgz0j.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct3udOlsWezr.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct3udOlsWezr.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct3yavERh0QP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct3yavERh0QP.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct40R1V76roU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct40R1V76roU.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct44PftY660j.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct44PftY660j.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct46ykdVFGwG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct46ykdVFGwG.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct47pp9CzShs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct47pp9CzShs.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct49eWbTEG4e.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct49eWbTEG4e.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct4I0C5KiBcT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct4I0C5KiBcT.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct4NHzRc00m2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct4NHzRc00m2.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct4R1b3Sfk6J.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct4R1b3Sfk6J.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct4VkhuwJa8e.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct4VkhuwJa8e.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct4bA4rV4T7I.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct4bA4rV4T7I.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct4qOfIMBclV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct4qOfIMBclV.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct4tYHXfgnVZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct4tYHXfgnVZ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct4xCfXxpvdy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct4xCfXxpvdy.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct4zYtkggxX9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct4zYtkggxX9.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct566AUa8c9w.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct566AUa8c9w.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct5B3Ki66g8U.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct5B3Ki66g8U.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct5GIHfCnyF0.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct5GIHfCnyF0.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct5GXqW1XpIl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct5GXqW1XpIl.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct5R3JtFMKyy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct5R3JtFMKyy.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct5WOnMXao7S.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct5WOnMXao7S.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct5WjoUCBC2W.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct5WjoUCBC2W.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct5YuboIIJis.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct5YuboIIJis.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct5coPgZ627S.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct5coPgZ627S.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct5nsLLrnYzS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct5nsLLrnYzS.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct5p0wzn3Twr.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct5p0wzn3Twr.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct5pUyGEiqRW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct5pUyGEiqRW.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct66VojQk1NI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct66VojQk1NI.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct67D9OX1YBs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct67D9OX1YBs.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct67XWJDtmLp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct67XWJDtmLp.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct6ACGifRdRw.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct6ACGifRdRw.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct6AkdgH06Lh.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct6AkdgH06Lh.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct6BWJO4ygCh.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct6BWJO4ygCh.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct6Eho6XNoOx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct6Eho6XNoOx.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct6Fnny4hIyl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct6Fnny4hIyl.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct6GnahT2THT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct6GnahT2THT.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct6Gy1eE7iFg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct6Gy1eE7iFg.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct6InhhK3Bnx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct6InhhK3Bnx.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct6KaWm2V4so.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct6KaWm2V4so.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct6NVZQs4UrE.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct6NVZQs4UrE.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct6PUxZ29VTq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct6PUxZ29VTq.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct6fce05Qu1f.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct6fce05Qu1f.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct6tzbdxQpL4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct6tzbdxQpL4.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct763ixhZiPg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct763ixhZiPg.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct79tZSSX75b.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct79tZSSX75b.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct7E3RzOaVF1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct7E3RzOaVF1.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct7Ev4ba5U4g.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct7Ev4ba5U4g.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct7FkotSk0XD.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct7FkotSk0XD.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct7MpRJpjzYV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct7MpRJpjzYV.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct7UAHrFSXgp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct7UAHrFSXgp.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct7ZDRFK7C6w.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct7ZDRFK7C6w.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct7hWyxK9Im1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct7hWyxK9Im1.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct7vhsXm5Sqy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct7vhsXm5Sqy.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct7vwzjN2hQB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct7vwzjN2hQB.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct7x47kTkDWA.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct7x47kTkDWA.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct814BQq200G.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct814BQq200G.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct84TN7zjoK9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct84TN7zjoK9.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct8CllamWxHF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct8CllamWxHF.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct8KGpb7sMhV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct8KGpb7sMhV.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct8P1XTIrmCU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct8P1XTIrmCU.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct8eGauAG2Iy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct8eGauAG2Iy.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct8hD3MVC60I.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct8hD3MVC60I.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct8q0Jpdjx8u.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct8q0Jpdjx8u.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct8qIwjmR7oN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct8qIwjmR7oN.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct8tbcftbwF8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct8tbcftbwF8.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct8txOZ8smgu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct8txOZ8smgu.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct8yaeAzdZUO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct8yaeAzdZUO.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct98nsmL4Uyu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct98nsmL4Uyu.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct9CTRHeV5gV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct9CTRHeV5gV.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct9E3xYWs4gr.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct9E3xYWs4gr.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct9FbBK7sAEy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct9FbBK7sAEy.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct9HOIXHYhP9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct9HOIXHYhP9.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct9IzMME36Bl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct9IzMME36Bl.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct9PLpEx4eEr.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct9PLpEx4eEr.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct9QX6aOMWmP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct9QX6aOMWmP.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct9XFvojKqS7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct9XFvojKqS7.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct9Z0NXJ0nuB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct9Z0NXJ0nuB.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct9cdQxj05PP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct9cdQxj05PP.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct9dJLrfdwrb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct9dJLrfdwrb.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct9fPHF2RcIG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct9fPHF2RcIG.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct9o9IQlJhfF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct9o9IQlJhfF.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct9rTJlJQ4St.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct9rTJlJQ4St.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct9tS75raz9v.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-struct9tS75raz9v.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structA0t67j1fxp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structA0t67j1fxp.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structA2y6S9lFjD.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structA2y6S9lFjD.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structA4N6i5eArl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structA4N6i5eArl.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structA6J9ouYjJm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structA6J9ouYjJm.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structAB03r2H43b.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structAB03r2H43b.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structADRxlKyBIl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structADRxlKyBIl.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structAE7oPkwYY6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structAE7oPkwYY6.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structAHdMDYZJaK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structAHdMDYZJaK.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structAK2drK1aH7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structAK2drK1aH7.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structAPZGaaiAsI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structAPZGaaiAsI.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structAQE2E9exgF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structAQE2E9exgF.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structAcoWvPhtlp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structAcoWvPhtlp.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structAiFfzJ9xOo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structAiFfzJ9xOo.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structAztsRhE0LF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structAztsRhE0LF.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structB9pN8GfUaU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structB9pN8GfUaU.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structBA8lKBvox6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structBA8lKBvox6.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structBBBafcZBl1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structBBBafcZBl1.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structBF8funmMCW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structBF8funmMCW.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structBNGrkk0Gq9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structBNGrkk0Gq9.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structBW4o7dJUoK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structBW4o7dJUoK.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structBWsRWzQ335.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structBWsRWzQ335.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structBfsVSixXGI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structBfsVSixXGI.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structBjERtQ98tj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structBjERtQ98tj.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structBjy5dZK2rM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structBjy5dZK2rM.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structBm7Ua0ACla.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structBm7Ua0ACla.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structBmz4OJxAlt.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structBmz4OJxAlt.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structBw3OKv2Qms.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structBw3OKv2Qms.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structBzSRBjnY22.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structBzSRBjnY22.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structC0g7V6d3fy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structC0g7V6d3fy.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structCBt0kIYRra.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structCBt0kIYRra.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structCOGSdZd0AL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structCOGSdZd0AL.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structCXeEkfG71q.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structCXeEkfG71q.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structCaHH2Xyhc7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structCaHH2Xyhc7.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structCcLnEruc0v.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structCcLnEruc0v.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structCfD3K5QvsN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structCfD3K5QvsN.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structCqQVJigrtI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structCqQVJigrtI.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structCzvlSZqJoZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structCzvlSZqJoZ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structD2oQVW5tnq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structD2oQVW5tnq.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structD4YplBwWDi.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structD4YplBwWDi.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structD9gno8tRvF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structD9gno8tRvF.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structDACFSZmJCd.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structDACFSZmJCd.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structDVPBdDC863.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structDVPBdDC863.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structDXFa0e4ozX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structDXFa0e4ozX.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structDZZWeqhEZS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structDZZWeqhEZS.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structDhEKpPXtbG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structDhEKpPXtbG.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structDi88qmJim6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structDi88qmJim6.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structDrIOG3dy4E.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structDrIOG3dy4E.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structE1izflhe7m.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structE1izflhe7m.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structE7tbP2KegJ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structE7tbP2KegJ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structECJjSKcI0x.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structECJjSKcI0x.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structECjdzNW2hb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structECjdzNW2hb.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structENNglh8DX6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structENNglh8DX6.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structEVUFJOsbyB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structEVUFJOsbyB.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structEa3Y8fmO5t.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structEa3Y8fmO5t.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structEbe6V1e8rk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structEbe6V1e8rk.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structEilgeng6RU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structEilgeng6RU.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structEjN7KM70nB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structEjN7KM70nB.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structEoc6yu6UZC.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structEoc6yu6UZC.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structEqZWhQIozu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structEqZWhQIozu.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structErRGvv06c5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structErRGvv06c5.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structEvFFf3fZGJ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structEvFFf3fZGJ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structEx5206L0wV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structEx5206L0wV.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structF3dNExh2mR.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structF3dNExh2mR.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structF8DhNrWv7E.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structF8DhNrWv7E.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structF9RjQ90jnp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structF9RjQ90jnp.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structFI3w6VQMfO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structFI3w6VQMfO.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structFJsonz9Nyz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structFJsonz9Nyz.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structFR85FzqbWk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structFR85FzqbWk.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structFXxZeDtCw5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structFXxZeDtCw5.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structFaTXoezJTa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structFaTXoezJTa.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structFhwETmltur.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structFhwETmltur.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structFjGw1Sgvhj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structFjGw1Sgvhj.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structFq1hfAwgHs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structFq1hfAwgHs.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structFvR9kgHTwq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structFvR9kgHTwq.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structFx3ViT9W1l.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structFx3ViT9W1l.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structG23iNFg5pV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structG23iNFg5pV.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structG4WvAWeyY2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structG4WvAWeyY2.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structG5eiJlW14L.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structG5eiJlW14L.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structG7DG28rR3I.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structG7DG28rR3I.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structG8t7pJyR0P.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structG8t7pJyR0P.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structGAhk4JD5f5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structGAhk4JD5f5.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structGElc6so5Vx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structGElc6so5Vx.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structGL3ENulfXA.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structGL3ENulfXA.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structGPgos6Ga6k.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structGPgos6Ga6k.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structGVka0u9TDq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structGVka0u9TDq.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structGXNEUsfHGV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structGXNEUsfHGV.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structGajQGzODLb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structGajQGzODLb.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structGbvlSI6ZFM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structGbvlSI6ZFM.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structGgvsKvoP9v.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structGgvsKvoP9v.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structGiiPLasS8y.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structGiiPLasS8y.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structGlUP6EKlOZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structGlUP6EKlOZ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structGmNuKgusEl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structGmNuKgusEl.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structGnndCPLSRE.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structGnndCPLSRE.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structGseI8AQPtb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structGseI8AQPtb.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structGyODqQmfLk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structGyODqQmfLk.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structH5eQeBi4oY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structH5eQeBi4oY.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structH6F7xwrgKM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structH6F7xwrgKM.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structHAW6jHGG5q.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structHAW6jHGG5q.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structHGMhtcP1Gs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structHGMhtcP1Gs.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structHNoL72ys27.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structHNoL72ys27.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structHOwIYbq2Gd.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structHOwIYbq2Gd.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structHQ1FzQOf8n.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structHQ1FzQOf8n.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structHQRXU94JgV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structHQRXU94JgV.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structHSN0q7oMVM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structHSN0q7oMVM.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structHYnhl5ltDv.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structHYnhl5ltDv.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structHcCEQbo9Zf.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structHcCEQbo9Zf.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structHfRiDfgqPK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structHfRiDfgqPK.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structHnGXhmegvA.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structHnGXhmegvA.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structHnNLvYqbMR.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structHnNLvYqbMR.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structHt9F9jtMD0.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structHt9F9jtMD0.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structHusaUbKJVm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structHusaUbKJVm.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structHvGrPaR9Bu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structHvGrPaR9Bu.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structHvI693MHyM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structHvI693MHyM.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structHyrFeqyBCY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structHyrFeqyBCY.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structHzJtxAljeg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structHzJtxAljeg.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structI2aSLtV0nK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structI2aSLtV0nK.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structI5QO2BUMxk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structI5QO2BUMxk.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structI6BZQjT6lx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structI6BZQjT6lx.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structICD2Fjdvwq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structICD2Fjdvwq.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structIHkMJI02Cs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structIHkMJI02Cs.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structIJpxdh5h1j.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structIJpxdh5h1j.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structIKVPnPqtVG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structIKVPnPqtVG.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structIODsh0cyAj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structIODsh0cyAj.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structIWnVfC7bMR.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structIWnVfC7bMR.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structIg48IJ1BGz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structIg48IJ1BGz.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structIjpYds4lWa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structIjpYds4lWa.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structImqfRF5u5d.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structImqfRF5u5d.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structIpNWKHAjIK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structIpNWKHAjIK.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structIq2IxAwTbz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structIq2IxAwTbz.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structIqjoEWN5a6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structIqjoEWN5a6.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structJ1WoVnmoNK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structJ1WoVnmoNK.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structJ4N4ApAuNd.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structJ4N4ApAuNd.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structJ4sxZ95hzs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structJ4sxZ95hzs.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structJ5ThymSmBk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structJ5ThymSmBk.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structJBdaFHCitX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structJBdaFHCitX.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structJBjYKH35Id.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structJBjYKH35Id.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structJEL7o5TRHh.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structJEL7o5TRHh.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structJFU1xlKVwi.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structJFU1xlKVwi.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structJIOp0LkuGx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structJIOp0LkuGx.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structJKSxRHdkgU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structJKSxRHdkgU.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structJLl1JS3EBA.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structJLl1JS3EBA.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structJPod17bl3h.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structJPod17bl3h.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structJSkoDJdEmy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structJSkoDJdEmy.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structJXZ8aT3Z1A.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structJXZ8aT3Z1A.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structJYFDwGezZu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structJYFDwGezZu.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structJZBOzjdChs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structJZBOzjdChs.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structJcJCwPR9O6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structJcJCwPR9O6.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structJdaXHv9XGK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structJdaXHv9XGK.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structJguJlpO2Zx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structJguJlpO2Zx.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structJjOrVxY09U.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structJjOrVxY09U.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structJmS6AEcW3Z.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structJmS6AEcW3Z.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structJmgvdzeb5n.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structJmgvdzeb5n.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structJt6jf8vpBs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structJt6jf8vpBs.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structJyoG3utfUF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structJyoG3utfUF.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structK17aJaWFKp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structK17aJaWFKp.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structK6zBHvtXEz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structK6zBHvtXEz.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structK8yLeG1Rq8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structK8yLeG1Rq8.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structKAGtyEb0Mc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structKAGtyEb0Mc.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structKBZsUWVDxs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structKBZsUWVDxs.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structKD97Jf4W3S.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structKD97Jf4W3S.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structKDBDsZNe9Z.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structKDBDsZNe9Z.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structKDWeAZ2IPn.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structKDWeAZ2IPn.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structKF4sn2PYXa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structKF4sn2PYXa.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structKHnzHYYQv9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structKHnzHYYQv9.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structKJhvJs3EGG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structKJhvJs3EGG.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structKLSPh0PXhl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structKLSPh0PXhl.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structKNZX9fxtdl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structKNZX9fxtdl.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structKS9Hbi6AwZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structKS9Hbi6AwZ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structKVlfLjDmn1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structKVlfLjDmn1.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structKX2JHsJ0bd.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structKX2JHsJ0bd.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structKkESsYkID7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structKkESsYkID7.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structKkHcnJvU6l.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structKkHcnJvU6l.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structKkvn2ffBgz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structKkvn2ffBgz.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structKxmFSKOkr0.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structKxmFSKOkr0.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structL0iuHiXIxa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structL0iuHiXIxa.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structL28FwCaWlq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structL28FwCaWlq.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structL3YlcXIU3G.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structL3YlcXIU3G.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structL5PAA2Y49o.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structL5PAA2Y49o.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structL8rTw5Q3JI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structL8rTw5Q3JI.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structLJsbrcp1QV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structLJsbrcp1QV.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structLKxIRREq4D.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structLKxIRREq4D.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structLMQlSHV6GT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structLMQlSHV6GT.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structLV2nB9GvAz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structLV2nB9GvAz.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structLa1OJDLBp5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structLa1OJDLBp5.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structLcNNHqG92U.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structLcNNHqG92U.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structLnY2DL1Mbw.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structLnY2DL1Mbw.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structLpxoYUnOy7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structLpxoYUnOy7.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structLs7CLvlkgi.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structLs7CLvlkgi.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structLtMZ0XaStC.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structLtMZ0XaStC.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structLy4yvDjUuQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structLy4yvDjUuQ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structM9DKZGOLDg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structM9DKZGOLDg.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structMBndhRFxei.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structMBndhRFxei.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structMEcvkINwlN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structMEcvkINwlN.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structMFY7puSlGX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structMFY7puSlGX.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structMQnq3Fo18k.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structMQnq3Fo18k.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structMRN9c8EZAu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structMRN9c8EZAu.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structMSaXkM98gx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structMSaXkM98gx.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structMe4GO0lmyL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structMe4GO0lmyL.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structMf7H2FRsCR.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structMf7H2FRsCR.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structMgFMQz9tN4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structMgFMQz9tN4.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structMhWZ76XLqK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structMhWZ76XLqK.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structMiv3889DlT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structMiv3889DlT.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structMkNnqyG9Tl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structMkNnqyG9Tl.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structMw7h6zUCoS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structMw7h6zUCoS.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structN5CGh6EWiK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structN5CGh6EWiK.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structN86zzxZWL3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structN86zzxZWL3.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structN9VLieAgkB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structN9VLieAgkB.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structNB005jf6q4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structNB005jf6q4.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structNW2O8zaFJU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structNW2O8zaFJU.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structNXVElSFyJY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structNXVElSFyJY.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structNXkTPXgNCQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structNXkTPXgNCQ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structNYxtIN1k6X.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structNYxtIN1k6X.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structNcunqydrcp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structNcunqydrcp.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structNfG8poVmRX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structNfG8poVmRX.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structNpSaGkUh99.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structNpSaGkUh99.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structNphpYJarez.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structNphpYJarez.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structNq8WSpQa6r.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structNq8WSpQa6r.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structNuHNDIZUYr.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structNuHNDIZUYr.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structO4Kr2Vp6iB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structO4Kr2Vp6iB.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structO5SpO4Lmqy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structO5SpO4Lmqy.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structO6aBEtLHCl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structO6aBEtLHCl.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structO8aC92gkJu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structO8aC92gkJu.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structOAXjhVxHVW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structOAXjhVxHVW.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structOBggRrGGeA.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structOBggRrGGeA.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structOCKiZ8XvN4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structOCKiZ8XvN4.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structOTagHf6dta.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structOTagHf6dta.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structOmPR4GDmha.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structOmPR4GDmha.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structOnU7Y1iyOW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structOnU7Y1iyOW.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structOruSh6IU68.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structOruSh6IU68.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structP07kLcgWy2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structP07kLcgWy2.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structP0hi03Yr5J.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structP0hi03Yr5J.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structP51IT0iQls.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structP51IT0iQls.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structPC53CFAahl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structPC53CFAahl.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structPDETEBub2B.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structPDETEBub2B.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structPIEO17rXv3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structPIEO17rXv3.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structPL1Vy8gAQG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structPL1Vy8gAQG.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structPOAJbOn5yN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structPOAJbOn5yN.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structPWOGZtzGIy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structPWOGZtzGIy.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structPWOtvXxst0.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structPWOtvXxst0.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structPaMBWeOEZb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structPaMBWeOEZb.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structPbViqUkC9s.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structPbViqUkC9s.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structPjXLhVCSo2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structPjXLhVCSo2.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structPmsSWhVFlx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structPmsSWhVFlx.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structPvttwCSove.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structPvttwCSove.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structPy7auxT2wm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structPy7auxT2wm.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structPzKBHCX9aj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structPzKBHCX9aj.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structQ1lt85NZkv.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structQ1lt85NZkv.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structQ9W3v3dQYW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structQ9W3v3dQYW.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structQBpF2mc1un.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structQBpF2mc1un.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structQLoTxIicfl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structQLoTxIicfl.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structQNBjmFEISk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structQNBjmFEISk.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structQRNlszU7N1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structQRNlszU7N1.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structQRrZvgSvEl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structQRrZvgSvEl.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structQu8eKSWeIJ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structQu8eKSWeIJ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structQwjx7jDCDX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structQwjx7jDCDX.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structQwri7Ax9TK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structQwri7Ax9TK.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structR4xaEYdpRY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structR4xaEYdpRY.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structR6bsgVIYE6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structR6bsgVIYE6.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structR6j965l6JZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structR6j965l6JZ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structR6yPnOD0oz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structR6yPnOD0oz.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structR8eEQpI0YT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structR8eEQpI0YT.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structRBr9HNIGgm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structRBr9HNIGgm.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structRBwjivoMMP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structRBwjivoMMP.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structRFFK9pIT93.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structRFFK9pIT93.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structRJYj3K0a3c.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structRJYj3K0a3c.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structRLhaWW9haz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structRLhaWW9haz.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structRSckKIVPNO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structRSckKIVPNO.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structRX7hJYzEEc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structRX7hJYzEEc.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structRbEgtyrBAH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structRbEgtyrBAH.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structRbgB04HmL4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structRbgB04HmL4.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structRdgEVFWPU8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structRdgEVFWPU8.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structRjYd0rym9S.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structRjYd0rym9S.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structRpd0ErOBb6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structRpd0ErOBb6.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structRtcf0YV8fO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structRtcf0YV8fO.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structRtjThoUz7H.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structRtjThoUz7H.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structRyTk5RxJJO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structRyTk5RxJJO.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structS1RhuauboU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structS1RhuauboU.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structS6bmXaMMyl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structS6bmXaMMyl.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structSDPIMkAwH8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structSDPIMkAwH8.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structSEmAsgVkk9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structSEmAsgVkk9.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structSIfHQocAM7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structSIfHQocAM7.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structSL3XN9PByF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structSL3XN9PByF.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structSOJZorG6h4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structSOJZorG6h4.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structSOQ2b3Trj9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structSOQ2b3Trj9.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structSOcWqfVVcP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structSOcWqfVVcP.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structSUuI5kWBPQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structSUuI5kWBPQ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structSWz0ZdY1fL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structSWz0ZdY1fL.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structSXB5wflpQj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structSXB5wflpQj.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structSaCKmxwW7X.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structSaCKmxwW7X.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structSkgZGVkxzj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structSkgZGVkxzj.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structSuSfIvUv2A.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structSuSfIvUv2A.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structSuaJbDOn73.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structSuaJbDOn73.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structSv55DLNwHy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structSv55DLNwHy.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structSvXjwmwWp8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structSvXjwmwWp8.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structT024qoIGBu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structT024qoIGBu.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structT396ygje53.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structT396ygje53.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structTA8Sp22K2U.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structTA8Sp22K2U.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structTGF07uM1y9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structTGF07uM1y9.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structTKbYYBx9QZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structTKbYYBx9QZ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structTLyC86eODa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structTLyC86eODa.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structTSEu5hclTq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structTSEu5hclTq.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structTX5YCrOcOo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structTX5YCrOcOo.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structTX6rXf2RZh.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structTX6rXf2RZh.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structTaJbzfeDjo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structTaJbzfeDjo.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structTaYGLKdSM8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structTaYGLKdSM8.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structTgcZPmWOx2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structTgcZPmWOx2.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structTh5NbnUqzI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structTh5NbnUqzI.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structTknpxoQFvS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structTknpxoQFvS.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structTqu8KoZQjY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structTqu8KoZQjY.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structTuAcbBNnZm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structTuAcbBNnZm.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structTuWH3zeluv.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structTuWH3zeluv.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structTwjPuMKDiB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structTwjPuMKDiB.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structTxF88EuH4Q.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structTxF88EuH4Q.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structTzQ4rWvlZ3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structTzQ4rWvlZ3.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structU2kogkOlcf.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structU2kogkOlcf.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structU3dy6bkQcN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structU3dy6bkQcN.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structUA5Zgdsa4W.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structUA5Zgdsa4W.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structUC7urls6rG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structUC7urls6rG.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structUJ5RVg0xHN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structUJ5RVg0xHN.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structUL0XgKUiea.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structUL0XgKUiea.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structUYdnQvYvKk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structUYdnQvYvKk.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structUaTPRyIwWQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structUaTPRyIwWQ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structUgp6Bg804O.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structUgp6Bg804O.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structUgsqUT0Fw8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structUgsqUT0Fw8.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structUomjJGDhS3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structUomjJGDhS3.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structUrJ7tMPYdi.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structUrJ7tMPYdi.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structUsGUm5feCJ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structUsGUm5feCJ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structUx6sDnae6o.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structUx6sDnae6o.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structUyBELJkxhd.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structUyBELJkxhd.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structV1mFMqHDyz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structV1mFMqHDyz.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structV3DEOjYkAI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structV3DEOjYkAI.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structV4EcMh64Nu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structV4EcMh64Nu.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structVABFQlbdB8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structVABFQlbdB8.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structVCKWE5qXDQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structVCKWE5qXDQ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structVF3eV6RT5A.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structVF3eV6RT5A.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structVGVFt2H4Jq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structVGVFt2H4Jq.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structVHmibu21U1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structVHmibu21U1.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structVJQMEbTTcW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structVJQMEbTTcW.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structVW9Wugrq8f.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structVW9Wugrq8f.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structVbui9U8nJN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structVbui9U8nJN.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structVqmZxmYjrS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structVqmZxmYjrS.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structVwumd12dMR.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structVwumd12dMR.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structW03TuqLzYH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structW03TuqLzYH.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structW6NGdR4FHA.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structW6NGdR4FHA.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structW8RwEte1K1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structW8RwEte1K1.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structWFr5O7xRwi.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structWFr5O7xRwi.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structWJw9ZLP7fK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structWJw9ZLP7fK.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structWODpD4eAmE.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structWODpD4eAmE.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structWOGNQBbIW7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structWOGNQBbIW7.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structWQN1KyUD5b.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structWQN1KyUD5b.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structWTDgYPieK1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structWTDgYPieK1.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structWVtboPH1aE.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structWVtboPH1aE.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structWiPM4vCvbR.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structWiPM4vCvbR.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structWk1zWo8r9K.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structWk1zWo8r9K.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structWkYOcVuG9r.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structWkYOcVuG9r.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structWqKLr6PuT3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structWqKLr6PuT3.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structWyFaNRxWDU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structWyFaNRxWDU.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structX0tLJiI6QS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structX0tLJiI6QS.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structX74WdLPgP3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structX74WdLPgP3.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structXLePVWtJFS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structXLePVWtJFS.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structXNJAbmwEpz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structXNJAbmwEpz.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structXOlFj8WTWU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structXOlFj8WTWU.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structXQpY9eJk4m.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structXQpY9eJk4m.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structXU2GzBHEnm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structXU2GzBHEnm.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structXWIUjIMjuc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structXWIUjIMjuc.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structXYOl2gpZhZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structXYOl2gpZhZ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structXYrXq7Kz5O.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structXYrXq7Kz5O.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structXab1L6RKkc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structXab1L6RKkc.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structXcQSZS9Pq3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structXcQSZS9Pq3.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structXdOq3rooU7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structXdOq3rooU7.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structXpfvMzo3SU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structXpfvMzo3SU.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structXs0m0HB3Ve.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structXs0m0HB3Ve.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structXsoVym5xGF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structXsoVym5xGF.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structXxbrxyvfJK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structXxbrxyvfJK.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structY0sbuM1lf1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structY0sbuM1lf1.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structY2WI2qZBJc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structY2WI2qZBJc.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structY3MSP8GJLq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structY3MSP8GJLq.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structY7ZzgHzGVw.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structY7ZzgHzGVw.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structY8HkjRfwpg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structY8HkjRfwpg.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structYAzsftuDhx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structYAzsftuDhx.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structYE37gD7DoN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structYE37gD7DoN.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structYNODMJt0nI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structYNODMJt0nI.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structYOoQMQYEZo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structYOoQMQYEZo.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structYPtr2Dr86B.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structYPtr2Dr86B.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structYXRqKm5H9U.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structYXRqKm5H9U.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structYa2X1A0XlS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structYa2X1A0XlS.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structYj7TbLsdP4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structYj7TbLsdP4.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structYlF6RxCqVs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structYlF6RxCqVs.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structYo1jTzfuKl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structYo1jTzfuKl.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structYrew2qdBuH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structYrew2qdBuH.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structYwZwDfIvIG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structYwZwDfIvIG.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structZ3DY5gvzFY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structZ3DY5gvzFY.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structZBrvC38b8N.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structZBrvC38b8N.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structZC6ZaapQdD.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structZC6ZaapQdD.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structZGNK9Twr9S.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structZGNK9Twr9S.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structZGqp2bRDtx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structZGqp2bRDtx.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structZJSKolxfqc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structZJSKolxfqc.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structZR3LiJX7PO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structZR3LiJX7PO.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structZW26HGLchP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structZW26HGLchP.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structZi1RqmdSol.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structZi1RqmdSol.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structZoimFj6xEE.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structZoimFj6xEE.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structZpfDnRPksn.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structZpfDnRPksn.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structZr2k5TeLcE.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structZr2k5TeLcE.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structZtqbbnQjzj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structZtqbbnQjzj.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structZupKEHABUk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structZupKEHABUk.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structa0AhWFAoDG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structa0AhWFAoDG.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structa5eW784LQf.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structa5eW784LQf.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structa6BXYQAwEm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structa6BXYQAwEm.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structa6bL6toTDQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structa6bL6toTDQ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structa85eS8wvGC.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structa85eS8wvGC.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structaBCMiwiL14.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structaBCMiwiL14.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structaCvUpfrOud.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structaCvUpfrOud.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structaMVAJ9INz0.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structaMVAJ9INz0.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structaNX02HPg7T.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structaNX02HPg7T.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structaacjP2BYDY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structaacjP2BYDY.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structafSLEQGtjb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structafSLEQGtjb.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structawZmlvXiXW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structawZmlvXiXW.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structaxV4fiWwZ7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structaxV4fiWwZ7.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structayNEhBBg4t.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structayNEhBBg4t.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structb265yb0csM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structb265yb0csM.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structb63fAzKNR7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structb63fAzKNR7.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structbBsug1Wd34.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structbBsug1Wd34.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structbNMyvNH8WM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structbNMyvNH8WM.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structbX4S27LXkH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structbX4S27LXkH.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structblpexlSs9M.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structblpexlSs9M.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structbmmnw9qu32.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structbmmnw9qu32.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structbsrrxTZOqn.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structbsrrxTZOqn.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structbtgnPXO5Rq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structbtgnPXO5Rq.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structbwtswCbHZn.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structbwtswCbHZn.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structc0ARtdYgED.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structc0ARtdYgED.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structc0K76QtGvt.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structc0K76QtGvt.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structc19BIAaEkY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structc19BIAaEkY.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structcIUFEZhrle.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structcIUFEZhrle.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structcU51DXcyE8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structcU51DXcyE8.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structcbnz0kvIwn.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structcbnz0kvIwn.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structcfbnUeCgbt.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structcfbnUeCgbt.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structcjMmD9Dwfx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structcjMmD9Dwfx.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structclmVkpAhb8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structclmVkpAhb8.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structcoAqE1boX6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structcoAqE1boX6.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structcormXUf4WS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structcormXUf4WS.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structcqdGRq2WNh.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structcqdGRq2WNh.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structczOiELiAB7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structczOiELiAB7.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structd2ojXxCaNW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structd2ojXxCaNW.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structd4OcbMDcGL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structd4OcbMDcGL.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structd9nB4x1U6u.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structd9nB4x1U6u.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structdEhJcrsORt.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structdEhJcrsORt.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structdKBNYvwyxK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structdKBNYvwyxK.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structdNGVHIlzAj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structdNGVHIlzAj.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structdSftno00MK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structdSftno00MK.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structdXZpHpuk3x.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structdXZpHpuk3x.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structdXgIF94ebo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structdXgIF94ebo.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structdhEH1P8yDX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structdhEH1P8yDX.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structdq0ytTGdT7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structdq0ytTGdT7.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structdr28D0z5ZH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structdr28D0z5ZH.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structe4z2kYEwsw.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structe4z2kYEwsw.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structe79Za4b7Ml.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structe79Za4b7Ml.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structeJF56nvsEj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structeJF56nvsEj.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structeW6hiVZjD9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structeW6hiVZjD9.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structegI0J6pwbq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structegI0J6pwbq.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structemjd05RWc3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structemjd05RWc3.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structeqBjnWgb5P.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structeqBjnWgb5P.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structf0akg4gumK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structf0akg4gumK.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structf32Rx1NpEm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structf32Rx1NpEm.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structf3hg4Duqet.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structf3hg4Duqet.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structf74ThK893J.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structf74ThK893J.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structfBkGsQBirP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structfBkGsQBirP.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structfCVtyydYxM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structfCVtyydYxM.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structfCayR9pma6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structfCayR9pma6.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structfG4ASdjUC9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structfG4ASdjUC9.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structfJdkVlyVac.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structfJdkVlyVac.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structfNnOzIDYzL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structfNnOzIDYzL.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structfOOjVzFOC9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structfOOjVzFOC9.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structfTXY9OU4mh.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structfTXY9OU4mh.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structfWEUc1K6FG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structfWEUc1K6FG.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structfYJ2Mkk1al.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structfYJ2Mkk1al.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structfcg2UqwprF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structfcg2UqwprF.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structfd0mCQVHBl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structfd0mCQVHBl.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structfwecOIJDmQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structfwecOIJDmQ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structgBuG9DjtOU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structgBuG9DjtOU.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structgIAdPMClq9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structgIAdPMClq9.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structgJaEzQzHlG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structgJaEzQzHlG.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structgTI819u8oK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structgTI819u8oK.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structgaVRwvBYOY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structgaVRwvBYOY.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structgmDuxmO8uQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structgmDuxmO8uQ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structgnTh8YZCI4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structgnTh8YZCI4.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structgnzwfueLCU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structgnzwfueLCU.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structgodJTvsSrL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structgodJTvsSrL.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structgoyNOloADC.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structgoyNOloADC.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structgrMFKxp6Rp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structgrMFKxp6Rp.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structgu5AmoUnKH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structgu5AmoUnKH.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structgw0RpMV2f4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structgw0RpMV2f4.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structgzPFVO95T5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structgzPFVO95T5.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structh0wIvbjPFM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structh0wIvbjPFM.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structh0zYLuKys0.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structh0zYLuKys0.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structh4borQn8tt.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structh4borQn8tt.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structhEYyOpWNQA.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structhEYyOpWNQA.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structhKVOXTzhtj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structhKVOXTzhtj.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structhP7CI8CVIx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structhP7CI8CVIx.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structhRp6BjrXlq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structhRp6BjrXlq.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structhXluAaYGUP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structhXluAaYGUP.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structhc5U7IjcZc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structhc5U7IjcZc.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structhjYDoXKd1y.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structhjYDoXKd1y.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structhk5xXOFY3B.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structhk5xXOFY3B.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structhlXXNdntjL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structhlXXNdntjL.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structhnljKmvH1S.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structhnljKmvH1S.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structhsMP7WDnTb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structhsMP7WDnTb.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structi5tx16f99j.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structi5tx16f99j.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structi60i9flgEl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structi60i9flgEl.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structiGcBGhWkFg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structiGcBGhWkFg.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structiH2t1AudUv.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structiH2t1AudUv.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structiJO3yTUlA6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structiJO3yTUlA6.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structiMxQrDbyMm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structiMxQrDbyMm.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structiRTC8Ri5hh.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structiRTC8Ri5hh.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structiUTYiuw7nL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structiUTYiuw7nL.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structifVuZi4Efe.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structifVuZi4Efe.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structigySx6ywF4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structigySx6ywF4.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structimk6k6ZOQP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structimk6k6ZOQP.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structiyfYt6St4H.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structiyfYt6St4H.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structj0Jp6zlUkb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structj0Jp6zlUkb.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structj2noj6YBli.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structj2noj6YBli.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structj80X6OAWFM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structj80X6OAWFM.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structjATzvt82Yc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structjATzvt82Yc.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structjHYdKd1qGS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structjHYdKd1qGS.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structjIn9JVMI49.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structjIn9JVMI49.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structjKvkQzPnI2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structjKvkQzPnI2.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structjPeWDdzelT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structjPeWDdzelT.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structjVynlgrJOg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structjVynlgrJOg.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structjXzq5dAQfq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structjXzq5dAQfq.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structjlEQy1XgIm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structjlEQy1XgIm.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structjpZYztDGZv.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structjpZYztDGZv.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structjyzBmrWLpD.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structjyzBmrWLpD.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structjzLZ1Fd1su.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structjzLZ1Fd1su.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structk0RWOtD4Cb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structk0RWOtD4Cb.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structk5uhI551Ib.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structk5uhI551Ib.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structkBpo9DUgjg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structkBpo9DUgjg.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structkKCqpBwgSB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structkKCqpBwgSB.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structkMn4TDNnDw.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structkMn4TDNnDw.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structkTDa7zOTTq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structkTDa7zOTTq.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structkcnuBfgvqB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structkcnuBfgvqB.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structke5R4wNmaV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structke5R4wNmaV.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structkgOVznysHS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structkgOVznysHS.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structkjR2PqZPCx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structkjR2PqZPCx.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structkjvkPYElx2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structkjvkPYElx2.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structko3HKcubO4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structko3HKcubO4.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structl1rwee6A0W.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structl1rwee6A0W.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structl9GK15NFfI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structl9GK15NFfI.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structl9dEcAYjZX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structl9dEcAYjZX.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structlCbFTLeEcO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structlCbFTLeEcO.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structlFoUTH7TGY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structlFoUTH7TGY.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structlFuagxP4pj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structlFuagxP4pj.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structlKqlZNIiTG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structlKqlZNIiTG.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structlM9nCK9mVa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structlM9nCK9mVa.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structlNxcettVbW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structlNxcettVbW.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structlOMWejTcie.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structlOMWejTcie.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structlPPzP90v2M.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structlPPzP90v2M.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structlWE7ijbTPg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structlWE7ijbTPg.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structlWZpr8mFUz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structlWZpr8mFUz.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structlfb6Bcmyzv.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structlfb6Bcmyzv.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structliZR39PG4B.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structliZR39PG4B.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structlilo17vqrO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structlilo17vqrO.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structlmBHuI2CdK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structlmBHuI2CdK.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structlsRnaxudRi.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structlsRnaxudRi.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structlwBBVufID9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structlwBBVufID9.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structmE7fFfuHjx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structmE7fFfuHjx.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structmPX6OOh4Nl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structmPX6OOh4Nl.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structmR2t9GgAZ5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structmR2t9GgAZ5.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structmU9k8N2S1x.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structmU9k8N2S1x.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structmUQioQKiXp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structmUQioQKiXp.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structmWBF30udKT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structmWBF30udKT.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structmaUySacG7e.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structmaUySacG7e.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structmj4Oyb3GgX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structmj4Oyb3GgX.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structmuAhuD4KVQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structmuAhuD4KVQ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structmwjaO3Uyrs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structmwjaO3Uyrs.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structn5h1DHBxub.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structn5h1DHBxub.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structnAdqmBnbeg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structnAdqmBnbeg.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structnAvYhH07Gs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structnAvYhH07Gs.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structnHnX8P1WDq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structnHnX8P1WDq.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structnNkjJDcz0P.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structnNkjJDcz0P.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structnPwZk9I7YN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structnPwZk9I7YN.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structnUJfW4NMaA.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structnUJfW4NMaA.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structnXMZUp9V4V.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structnXMZUp9V4V.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structnjkuDZnOoQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structnjkuDZnOoQ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structnq8k7vNWX3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structnq8k7vNWX3.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structnrVsGpyHSB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structnrVsGpyHSB.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structnsGvdkMRFZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structnsGvdkMRFZ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structoAhXI74h9j.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structoAhXI74h9j.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structoahbTSUqku.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structoahbTSUqku.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structoiRn4GygF9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structoiRn4GygF9.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structov6aJQLXqu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structov6aJQLXqu.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structovm1h7N1tD.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structovm1h7N1tD.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structoypCXXMXYK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structoypCXXMXYK.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structp39x1W6Nmw.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structp39x1W6Nmw.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structp5F0SqEi1N.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structp5F0SqEi1N.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structpK1zdl2ooH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structpK1zdl2ooH.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structpLXABe2wJc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structpLXABe2wJc.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structpMr2v6juAQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structpMr2v6juAQ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structpXZA41Y8fK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structpXZA41Y8fK.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structpkIouuiKqe.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structpkIouuiKqe.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structpnMhTmK3QH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structpnMhTmK3QH.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structpuA2r64pbW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structpuA2r64pbW.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structpwCAT0hshK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structpwCAT0hshK.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structq1BEWkecYX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structq1BEWkecYX.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structq2gqs38KnH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structq2gqs38KnH.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structq5OjZ10BEs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structq5OjZ10BEs.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structqGa10MSSRs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structqGa10MSSRs.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structqGuE1lEn2E.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structqGuE1lEn2E.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structqK7XKTZI6a.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structqK7XKTZI6a.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structqRtOraogqy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structqRtOraogqy.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structqTdD25cQMq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structqTdD25cQMq.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structqVenFBZMmB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structqVenFBZMmB.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structqVymoyiTzO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structqVymoyiTzO.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structqYoMOdyW5o.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structqYoMOdyW5o.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structqZqGFZMAp0.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structqZqGFZMAp0.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structqceTFkotG1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structqceTFkotG1.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structqklsh0VtCj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structqklsh0VtCj.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structqkwGFodzYo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structqkwGFodzYo.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structqlynSYPIzj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structqlynSYPIzj.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structqmylEQUQxN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structqmylEQUQxN.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structqsdnJQvtod.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structqsdnJQvtod.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structr1IUWdH7kS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structr1IUWdH7kS.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structrDLhl5fFyI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structrDLhl5fFyI.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structrJ6A29EFD3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structrJ6A29EFD3.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structrLI0qkdwNT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structrLI0qkdwNT.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structrNNNMoMUX5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structrNNNMoMUX5.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structrQyjIvxeGC.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structrQyjIvxeGC.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structrUZIsQzLzo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structrUZIsQzLzo.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structrUrNNgGYxl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structrUrNNgGYxl.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structrZORE7saci.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structrZORE7saci.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structrnEvXbtOaJ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structrnEvXbtOaJ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structrv6cJ7e4eI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structrv6cJ7e4eI.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structrvnG4DB0O9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structrvnG4DB0O9.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structrxuRIzLrOd.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structrxuRIzLrOd.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structs0wKthNJDH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structs0wKthNJDH.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structs6tlj8Ujb6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structs6tlj8Ujb6.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structs81xiTr3V2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structs81xiTr3V2.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structs9FC686ssT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structs9FC686ssT.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structsU7ru1S3Bn.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structsU7ru1S3Bn.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structsconExg82n.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structsconExg82n.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structsnl6YWFzw6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structsnl6YWFzw6.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structsr11hihvVP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structsr11hihvVP.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structsrFnuySLJZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structsrFnuySLJZ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structsyMjE23XYL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structsyMjE23XYL.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structt1zhtoy3QG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structt1zhtoy3QG.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structt3vc10gLez.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structt3vc10gLez.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structt7Y6XwomUH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structt7Y6XwomUH.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structtFfTsyMFtj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structtFfTsyMFtj.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structtKTQH67TAx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structtKTQH67TAx.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structtRnRKY1Nt9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structtRnRKY1Nt9.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structtVv0gLLUw6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structtVv0gLLUw6.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structtdu9UH9BR6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structtdu9UH9BR6.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structtkLijaINDB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structtkLijaINDB.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structtmi3Y4xjWJ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structtmi3Y4xjWJ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structtoRHBeshpF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structtoRHBeshpF.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structtoojZOxzYL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structtoojZOxzYL.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structuEWock0xfg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structuEWock0xfg.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structuYFS57GpEz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structuYFS57GpEz.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structuZLTFqoTc9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structuZLTFqoTc9.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structuesCCsCmB9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structuesCCsCmB9.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structuk9n40Ba1s.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structuk9n40Ba1s.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structurOByRIJr5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structurOByRIJr5.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structusM7i9eFda.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structusM7i9eFda.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structuzTdZWiu60.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structuzTdZWiu60.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structv4jF52UQ9H.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structv4jF52UQ9H.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structv9bmg59CEV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structv9bmg59CEV.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structvE6YTruKB5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structvE6YTruKB5.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structvGYXxaXkfO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structvGYXxaXkfO.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structvIiPiag0AP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structvIiPiag0AP.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structvJXxV1TNGG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structvJXxV1TNGG.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structvLrhLw24Yo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structvLrhLw24Yo.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structvPLGLtUGvc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structvPLGLtUGvc.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structvQ4tBtsFIQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structvQ4tBtsFIQ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structvetTPo8phL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structvetTPo8phL.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structvh6HUMxCO1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structvh6HUMxCO1.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structvhPOJekCB6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structvhPOJekCB6.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structvqpjGCBNgC.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structvqpjGCBNgC.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structw1Jcuo2qcB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structw1Jcuo2qcB.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structw1LUTeHkEP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structw1LUTeHkEP.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structw704rOrUeD.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structw704rOrUeD.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structwAVE8pzuIw.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structwAVE8pzuIw.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structwE9USHmMoa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structwE9USHmMoa.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structwKyV6c3NXx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structwKyV6c3NXx.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structwNNWk20409.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structwNNWk20409.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structwPjsuxb7PR.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structwPjsuxb7PR.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structwquRams9Fs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structwquRams9Fs.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structwyz9cVcdwh.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structwyz9cVcdwh.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structx29mgYMw04.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structx29mgYMw04.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structx9kDs7ICzW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structx9kDs7ICzW.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structxFTWeVz86X.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structxFTWeVz86X.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structxI8aw5DOBf.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structxI8aw5DOBf.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structxKJxcMqgXp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structxKJxcMqgXp.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structxSyTOLVs2a.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structxSyTOLVs2a.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structxY83QlHYu8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structxY83QlHYu8.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structxatoIPHwut.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structxatoIPHwut.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structxayiSk9poY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structxayiSk9poY.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structxl0tHilNDj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structxl0tHilNDj.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structxpKM8hQmHX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structxpKM8hQmHX.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structxrKKgR1Fe1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structxrKKgR1Fe1.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structxsR9aAsAXm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structxsR9aAsAXm.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structxwNsI8Zdb1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structxwNsI8Zdb1.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structy2eHpFGRr5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structy2eHpFGRr5.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structy5X9cuxDIn.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structy5X9cuxDIn.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structy5wbr5f4bB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structy5wbr5f4bB.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structyAGnaq1EBc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structyAGnaq1EBc.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structyGjRe5am7c.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structyGjRe5am7c.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structyKsJfDGXaz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structyKsJfDGXaz.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structyNBvxKIcti.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structyNBvxKIcti.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structyPEdNMH6Lo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structyPEdNMH6Lo.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structyTmtkFKqd7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structyTmtkFKqd7.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structydbIqe0qPo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structydbIqe0qPo.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structyhDvAbXvCv.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structyhDvAbXvCv.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structynitZhhUeJ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structynitZhhUeJ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structyvVgkdYRXO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structyvVgkdYRXO.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structz1JgTXpAuI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structz1JgTXpAuI.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structz7dfzzL9Yk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structz7dfzzL9Yk.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structzIXefsJFSz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structzIXefsJFSz.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structzPWDt4oN6i.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structzPWDt4oN6i.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structzQUyc7Ws0e.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structzQUyc7Ws0e.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structzTIpN6ALMu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structzTIpN6ALMu.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structzYoD4xKxnZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structzYoD4xKxnZ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structzdXNEcof9V.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structzdXNEcof9V.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structzo3owhla9x.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structzo3owhla9x.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structzyowJj76a6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.6.1/readonly-partial-structzyowJj76a6.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct00oieaoYA5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct00oieaoYA5.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct05nZxSvOQy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct05nZxSvOQy.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct0CW6rWihRa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct0CW6rWihRa.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct0EiiHjJ0Jy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct0EiiHjJ0Jy.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct0HxVdkFuDk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct0HxVdkFuDk.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct0Sp8nFf9po.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct0Sp8nFf9po.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct0YOigHUonk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct0YOigHUonk.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct0mu68DyXFS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct0mu68DyXFS.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct0oZl05ifoL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct0oZl05ifoL.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct101P28DC6b.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct101P28DC6b.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct109xwVU7na.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct109xwVU7na.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct13ZLCuuDdg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct13ZLCuuDdg.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct164v5M7Oiu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct164v5M7Oiu.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct16i8Hnvzik.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct16i8Hnvzik.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct1B64P2KJTT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct1B64P2KJTT.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct1FLNprzFfg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct1FLNprzFfg.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct1Lodf8jQhi.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct1Lodf8jQhi.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct1NM3qeUh2p.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct1NM3qeUh2p.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct1QKloRyprM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct1QKloRyprM.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct1TeundtXb1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct1TeundtXb1.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct1e9vZ2ZVVl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct1e9vZ2ZVVl.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct1ibkpE2U9t.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct1ibkpE2U9t.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct1jAvJkz71q.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct1jAvJkz71q.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct1kIcXqyaMm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct1kIcXqyaMm.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct1kIjvNmL26.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct1kIjvNmL26.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct1nopkP9yWt.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct1nopkP9yWt.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct1q3mpvDeuG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct1q3mpvDeuG.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct1rwcZsOxGm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct1rwcZsOxGm.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct1shpv6NmPc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct1shpv6NmPc.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct1tertRu9Xm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct1tertRu9Xm.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct1xSlrFoiE2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct1xSlrFoiE2.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct1xjEjG8zge.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct1xjEjG8zge.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct1zEPcP8TZ0.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct1zEPcP8TZ0.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct22wFvfGOQe.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct22wFvfGOQe.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct23OaGTh97N.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct23OaGTh97N.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct2C0v3cLs4t.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct2C0v3cLs4t.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct2Ii6Pytw94.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct2Ii6Pytw94.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct2KJvO9ifSa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct2KJvO9ifSa.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct2Oea4qEuqL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct2Oea4qEuqL.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct2PRjv73LUz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct2PRjv73LUz.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct2PlWXW13Oo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct2PlWXW13Oo.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct2RjyXdbOmS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct2RjyXdbOmS.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct2WJXBATRow.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct2WJXBATRow.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct2ePshLeWkH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct2ePshLeWkH.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct2iRAZCo7L5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct2iRAZCo7L5.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct2l1qlatawT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct2l1qlatawT.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct2lPhMAoDBl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct2lPhMAoDBl.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct2mrBdiaAsD.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct2mrBdiaAsD.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct2yK9S7dzeX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct2yK9S7dzeX.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct2yeMfnvK5l.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct2yeMfnvK5l.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct34i0YswjFg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct34i0YswjFg.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct3AvV0e5RCv.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct3AvV0e5RCv.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct3Fkic0RvsS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct3Fkic0RvsS.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct3Q09CNhFqG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct3Q09CNhFqG.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct3W5X0ROtrE.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct3W5X0ROtrE.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct3YKEcUcTm6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct3YKEcUcTm6.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct3Ysql1aZTo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct3Ysql1aZTo.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct3aLcZ0Gzdp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct3aLcZ0Gzdp.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct3bQ2CbXXiG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct3bQ2CbXXiG.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct3hbQkh2oXr.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct3hbQkh2oXr.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct3o9W3tWIYr.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct3o9W3tWIYr.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct3oRAhgtPFs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct3oRAhgtPFs.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct3rEqyW20Ha.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct3rEqyW20Ha.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct3rh7agTF1u.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct3rh7agTF1u.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct3tAXhVgz0j.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct3tAXhVgz0j.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct3udOlsWezr.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct3udOlsWezr.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct3yavERh0QP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct3yavERh0QP.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct40R1V76roU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct40R1V76roU.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct44PftY660j.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct44PftY660j.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct46ykdVFGwG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct46ykdVFGwG.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct47pp9CzShs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct47pp9CzShs.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct49eWbTEG4e.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct49eWbTEG4e.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct4I0C5KiBcT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct4I0C5KiBcT.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct4NHzRc00m2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct4NHzRc00m2.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct4R1b3Sfk6J.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct4R1b3Sfk6J.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct4VkhuwJa8e.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct4VkhuwJa8e.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct4bA4rV4T7I.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct4bA4rV4T7I.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct4qOfIMBclV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct4qOfIMBclV.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct4tYHXfgnVZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct4tYHXfgnVZ.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct4xCfXxpvdy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct4xCfXxpvdy.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct4zYtkggxX9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct4zYtkggxX9.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct566AUa8c9w.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct566AUa8c9w.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct5B3Ki66g8U.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct5B3Ki66g8U.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct5GIHfCnyF0.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct5GIHfCnyF0.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct5GXqW1XpIl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct5GXqW1XpIl.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct5R3JtFMKyy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct5R3JtFMKyy.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct5WOnMXao7S.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct5WOnMXao7S.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct5WjoUCBC2W.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct5WjoUCBC2W.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct5YuboIIJis.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct5YuboIIJis.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct5coPgZ627S.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct5coPgZ627S.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct5nsLLrnYzS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct5nsLLrnYzS.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct5p0wzn3Twr.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct5p0wzn3Twr.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct5pUyGEiqRW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct5pUyGEiqRW.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct66VojQk1NI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct66VojQk1NI.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct67D9OX1YBs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct67D9OX1YBs.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct67XWJDtmLp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct67XWJDtmLp.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct6ACGifRdRw.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct6ACGifRdRw.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct6AkdgH06Lh.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct6AkdgH06Lh.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct6BWJO4ygCh.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct6BWJO4ygCh.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct6Eho6XNoOx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct6Eho6XNoOx.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct6Fnny4hIyl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct6Fnny4hIyl.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct6GnahT2THT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct6GnahT2THT.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct6Gy1eE7iFg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct6Gy1eE7iFg.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct6InhhK3Bnx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct6InhhK3Bnx.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct6KaWm2V4so.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct6KaWm2V4so.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct6NVZQs4UrE.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct6NVZQs4UrE.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct6PUxZ29VTq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct6PUxZ29VTq.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct6fce05Qu1f.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct6fce05Qu1f.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct6tzbdxQpL4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct6tzbdxQpL4.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct763ixhZiPg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct763ixhZiPg.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct79tZSSX75b.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct79tZSSX75b.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct7E3RzOaVF1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct7E3RzOaVF1.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct7Ev4ba5U4g.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct7Ev4ba5U4g.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct7FkotSk0XD.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct7FkotSk0XD.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct7MpRJpjzYV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct7MpRJpjzYV.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct7UAHrFSXgp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct7UAHrFSXgp.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct7ZDRFK7C6w.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct7ZDRFK7C6w.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct7hWyxK9Im1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct7hWyxK9Im1.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct7vhsXm5Sqy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct7vhsXm5Sqy.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct7vwzjN2hQB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct7vwzjN2hQB.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct7x47kTkDWA.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct7x47kTkDWA.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct814BQq200G.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct814BQq200G.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct84TN7zjoK9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct84TN7zjoK9.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct8CllamWxHF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct8CllamWxHF.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct8KGpb7sMhV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct8KGpb7sMhV.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct8P1XTIrmCU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct8P1XTIrmCU.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct8eGauAG2Iy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct8eGauAG2Iy.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct8hD3MVC60I.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct8hD3MVC60I.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct8q0Jpdjx8u.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct8q0Jpdjx8u.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct8qIwjmR7oN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct8qIwjmR7oN.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct8tbcftbwF8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct8tbcftbwF8.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct8txOZ8smgu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct8txOZ8smgu.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct8yaeAzdZUO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct8yaeAzdZUO.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct98nsmL4Uyu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct98nsmL4Uyu.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct9CTRHeV5gV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct9CTRHeV5gV.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct9E3xYWs4gr.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct9E3xYWs4gr.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct9FbBK7sAEy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct9FbBK7sAEy.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct9HOIXHYhP9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct9HOIXHYhP9.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct9IzMME36Bl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct9IzMME36Bl.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct9PLpEx4eEr.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct9PLpEx4eEr.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct9QX6aOMWmP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct9QX6aOMWmP.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct9XFvojKqS7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct9XFvojKqS7.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct9Z0NXJ0nuB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct9Z0NXJ0nuB.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct9cdQxj05PP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct9cdQxj05PP.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct9dJLrfdwrb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct9dJLrfdwrb.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct9fPHF2RcIG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct9fPHF2RcIG.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct9o9IQlJhfF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct9o9IQlJhfF.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct9rTJlJQ4St.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct9rTJlJQ4St.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct9tS75raz9v.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-struct9tS75raz9v.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structA0t67j1fxp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structA0t67j1fxp.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structA2y6S9lFjD.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structA2y6S9lFjD.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structA4N6i5eArl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structA4N6i5eArl.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structA6J9ouYjJm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structA6J9ouYjJm.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structAB03r2H43b.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structAB03r2H43b.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structADRxlKyBIl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structADRxlKyBIl.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structAE7oPkwYY6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structAE7oPkwYY6.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structAHdMDYZJaK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structAHdMDYZJaK.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structAK2drK1aH7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structAK2drK1aH7.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structAPZGaaiAsI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structAPZGaaiAsI.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structAQE2E9exgF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structAQE2E9exgF.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structAcoWvPhtlp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structAcoWvPhtlp.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structAiFfzJ9xOo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structAiFfzJ9xOo.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structAztsRhE0LF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structAztsRhE0LF.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structB9pN8GfUaU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structB9pN8GfUaU.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structBA8lKBvox6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structBA8lKBvox6.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structBBBafcZBl1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structBBBafcZBl1.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structBF8funmMCW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structBF8funmMCW.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structBNGrkk0Gq9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structBNGrkk0Gq9.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structBW4o7dJUoK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structBW4o7dJUoK.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structBWsRWzQ335.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structBWsRWzQ335.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structBfsVSixXGI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structBfsVSixXGI.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structBjERtQ98tj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structBjERtQ98tj.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structBjy5dZK2rM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structBjy5dZK2rM.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structBm7Ua0ACla.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structBm7Ua0ACla.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structBmz4OJxAlt.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structBmz4OJxAlt.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structBw3OKv2Qms.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structBw3OKv2Qms.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structBzSRBjnY22.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structBzSRBjnY22.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structC0g7V6d3fy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structC0g7V6d3fy.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structCBt0kIYRra.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structCBt0kIYRra.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structCOGSdZd0AL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structCOGSdZd0AL.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structCXeEkfG71q.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structCXeEkfG71q.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structCaHH2Xyhc7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structCaHH2Xyhc7.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structCcLnEruc0v.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structCcLnEruc0v.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structCfD3K5QvsN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structCfD3K5QvsN.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structCqQVJigrtI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structCqQVJigrtI.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structCzvlSZqJoZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structCzvlSZqJoZ.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structD2oQVW5tnq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structD2oQVW5tnq.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structD4YplBwWDi.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structD4YplBwWDi.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structD9gno8tRvF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structD9gno8tRvF.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structDACFSZmJCd.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structDACFSZmJCd.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structDVPBdDC863.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structDVPBdDC863.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structDXFa0e4ozX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structDXFa0e4ozX.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structDZZWeqhEZS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structDZZWeqhEZS.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structDhEKpPXtbG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structDhEKpPXtbG.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structDi88qmJim6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structDi88qmJim6.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structDrIOG3dy4E.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structDrIOG3dy4E.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structE1izflhe7m.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structE1izflhe7m.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structE7tbP2KegJ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structE7tbP2KegJ.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structECJjSKcI0x.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structECJjSKcI0x.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structECjdzNW2hb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structECjdzNW2hb.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structENNglh8DX6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structENNglh8DX6.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structEVUFJOsbyB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structEVUFJOsbyB.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structEa3Y8fmO5t.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structEa3Y8fmO5t.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structEbe6V1e8rk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structEbe6V1e8rk.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structEilgeng6RU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structEilgeng6RU.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structEjN7KM70nB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structEjN7KM70nB.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structEoc6yu6UZC.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structEoc6yu6UZC.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structEqZWhQIozu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structEqZWhQIozu.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structErRGvv06c5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structErRGvv06c5.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structEvFFf3fZGJ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structEvFFf3fZGJ.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structEx5206L0wV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structEx5206L0wV.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structF3dNExh2mR.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structF3dNExh2mR.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structF8DhNrWv7E.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structF8DhNrWv7E.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structF9RjQ90jnp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structF9RjQ90jnp.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structFI3w6VQMfO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structFI3w6VQMfO.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structFJsonz9Nyz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structFJsonz9Nyz.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structFR85FzqbWk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structFR85FzqbWk.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structFXxZeDtCw5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structFXxZeDtCw5.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structFaTXoezJTa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structFaTXoezJTa.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structFhwETmltur.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structFhwETmltur.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structFjGw1Sgvhj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structFjGw1Sgvhj.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structFq1hfAwgHs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structFq1hfAwgHs.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structFvR9kgHTwq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structFvR9kgHTwq.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structFx3ViT9W1l.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structFx3ViT9W1l.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structG23iNFg5pV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structG23iNFg5pV.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structG4WvAWeyY2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structG4WvAWeyY2.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structG5eiJlW14L.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structG5eiJlW14L.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structG7DG28rR3I.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structG7DG28rR3I.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structG8t7pJyR0P.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structG8t7pJyR0P.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structGAhk4JD5f5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structGAhk4JD5f5.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structGElc6so5Vx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structGElc6so5Vx.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structGL3ENulfXA.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structGL3ENulfXA.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structGPgos6Ga6k.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structGPgos6Ga6k.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structGVka0u9TDq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structGVka0u9TDq.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structGXNEUsfHGV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structGXNEUsfHGV.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structGajQGzODLb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structGajQGzODLb.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structGbvlSI6ZFM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structGbvlSI6ZFM.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structGgvsKvoP9v.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structGgvsKvoP9v.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structGiiPLasS8y.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structGiiPLasS8y.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structGlUP6EKlOZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structGlUP6EKlOZ.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structGmNuKgusEl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structGmNuKgusEl.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structGnndCPLSRE.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structGnndCPLSRE.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structGseI8AQPtb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structGseI8AQPtb.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structGyODqQmfLk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structGyODqQmfLk.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structH5eQeBi4oY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structH5eQeBi4oY.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structH6F7xwrgKM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structH6F7xwrgKM.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structHAW6jHGG5q.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structHAW6jHGG5q.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structHGMhtcP1Gs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structHGMhtcP1Gs.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structHNoL72ys27.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structHNoL72ys27.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structHOwIYbq2Gd.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structHOwIYbq2Gd.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structHQ1FzQOf8n.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structHQ1FzQOf8n.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structHQRXU94JgV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structHQRXU94JgV.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structHSN0q7oMVM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structHSN0q7oMVM.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structHYnhl5ltDv.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structHYnhl5ltDv.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structHcCEQbo9Zf.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structHcCEQbo9Zf.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structHfRiDfgqPK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structHfRiDfgqPK.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structHnGXhmegvA.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structHnGXhmegvA.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structHnNLvYqbMR.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structHnNLvYqbMR.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structHt9F9jtMD0.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structHt9F9jtMD0.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structHusaUbKJVm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structHusaUbKJVm.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structHvGrPaR9Bu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structHvGrPaR9Bu.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structHvI693MHyM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structHvI693MHyM.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structHyrFeqyBCY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structHyrFeqyBCY.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structHzJtxAljeg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structHzJtxAljeg.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structI2aSLtV0nK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structI2aSLtV0nK.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structI5QO2BUMxk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structI5QO2BUMxk.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structI6BZQjT6lx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structI6BZQjT6lx.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structICD2Fjdvwq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structICD2Fjdvwq.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structIHkMJI02Cs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structIHkMJI02Cs.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structIJpxdh5h1j.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structIJpxdh5h1j.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structIKVPnPqtVG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structIKVPnPqtVG.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structIODsh0cyAj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structIODsh0cyAj.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structIWnVfC7bMR.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structIWnVfC7bMR.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structIg48IJ1BGz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structIg48IJ1BGz.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structIjpYds4lWa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structIjpYds4lWa.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structImqfRF5u5d.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structImqfRF5u5d.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structIpNWKHAjIK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structIpNWKHAjIK.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structIq2IxAwTbz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structIq2IxAwTbz.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structIqjoEWN5a6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structIqjoEWN5a6.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structJ1WoVnmoNK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structJ1WoVnmoNK.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structJ4N4ApAuNd.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structJ4N4ApAuNd.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structJ4sxZ95hzs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structJ4sxZ95hzs.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structJ5ThymSmBk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structJ5ThymSmBk.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structJBdaFHCitX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structJBdaFHCitX.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structJBjYKH35Id.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structJBjYKH35Id.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structJEL7o5TRHh.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structJEL7o5TRHh.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structJFU1xlKVwi.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structJFU1xlKVwi.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structJIOp0LkuGx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structJIOp0LkuGx.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structJKSxRHdkgU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structJKSxRHdkgU.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structJLl1JS3EBA.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structJLl1JS3EBA.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structJPod17bl3h.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structJPod17bl3h.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structJSkoDJdEmy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structJSkoDJdEmy.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structJXZ8aT3Z1A.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structJXZ8aT3Z1A.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structJYFDwGezZu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structJYFDwGezZu.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structJZBOzjdChs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structJZBOzjdChs.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structJcJCwPR9O6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structJcJCwPR9O6.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structJdaXHv9XGK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structJdaXHv9XGK.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structJguJlpO2Zx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structJguJlpO2Zx.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structJjOrVxY09U.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structJjOrVxY09U.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structJmS6AEcW3Z.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structJmS6AEcW3Z.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structJmgvdzeb5n.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structJmgvdzeb5n.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structJt6jf8vpBs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structJt6jf8vpBs.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structJyoG3utfUF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structJyoG3utfUF.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structK17aJaWFKp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structK17aJaWFKp.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structK6zBHvtXEz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structK6zBHvtXEz.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structK8yLeG1Rq8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structK8yLeG1Rq8.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structKAGtyEb0Mc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structKAGtyEb0Mc.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structKBZsUWVDxs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structKBZsUWVDxs.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structKD97Jf4W3S.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structKD97Jf4W3S.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structKDBDsZNe9Z.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structKDBDsZNe9Z.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structKDWeAZ2IPn.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structKDWeAZ2IPn.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structKF4sn2PYXa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structKF4sn2PYXa.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structKHnzHYYQv9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structKHnzHYYQv9.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structKJhvJs3EGG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structKJhvJs3EGG.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structKLSPh0PXhl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structKLSPh0PXhl.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structKNZX9fxtdl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structKNZX9fxtdl.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structKS9Hbi6AwZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structKS9Hbi6AwZ.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structKVlfLjDmn1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structKVlfLjDmn1.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structKX2JHsJ0bd.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structKX2JHsJ0bd.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structKkESsYkID7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structKkESsYkID7.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structKkHcnJvU6l.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structKkHcnJvU6l.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structKkvn2ffBgz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structKkvn2ffBgz.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structKxmFSKOkr0.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structKxmFSKOkr0.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structL0iuHiXIxa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structL0iuHiXIxa.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structL28FwCaWlq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structL28FwCaWlq.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structL3YlcXIU3G.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structL3YlcXIU3G.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structL5PAA2Y49o.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structL5PAA2Y49o.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structL8rTw5Q3JI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structL8rTw5Q3JI.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structLJsbrcp1QV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structLJsbrcp1QV.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structLKxIRREq4D.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structLKxIRREq4D.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structLMQlSHV6GT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structLMQlSHV6GT.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structLV2nB9GvAz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structLV2nB9GvAz.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structLa1OJDLBp5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structLa1OJDLBp5.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structLcNNHqG92U.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structLcNNHqG92U.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structLnY2DL1Mbw.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structLnY2DL1Mbw.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structLpxoYUnOy7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structLpxoYUnOy7.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structLs7CLvlkgi.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structLs7CLvlkgi.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structLtMZ0XaStC.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structLtMZ0XaStC.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structLy4yvDjUuQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structLy4yvDjUuQ.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structM9DKZGOLDg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structM9DKZGOLDg.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structMBndhRFxei.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structMBndhRFxei.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structMEcvkINwlN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structMEcvkINwlN.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structMFY7puSlGX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structMFY7puSlGX.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structMQnq3Fo18k.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structMQnq3Fo18k.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structMRN9c8EZAu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structMRN9c8EZAu.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structMSaXkM98gx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structMSaXkM98gx.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structMe4GO0lmyL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structMe4GO0lmyL.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structMf7H2FRsCR.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structMf7H2FRsCR.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structMgFMQz9tN4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structMgFMQz9tN4.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structMhWZ76XLqK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structMhWZ76XLqK.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structMiv3889DlT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structMiv3889DlT.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structMkNnqyG9Tl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structMkNnqyG9Tl.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structMw7h6zUCoS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structMw7h6zUCoS.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structN5CGh6EWiK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structN5CGh6EWiK.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structN86zzxZWL3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structN86zzxZWL3.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structN9VLieAgkB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structN9VLieAgkB.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structNB005jf6q4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structNB005jf6q4.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structNW2O8zaFJU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structNW2O8zaFJU.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structNXVElSFyJY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structNXVElSFyJY.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structNXkTPXgNCQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structNXkTPXgNCQ.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structNYxtIN1k6X.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structNYxtIN1k6X.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structNcunqydrcp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structNcunqydrcp.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structNfG8poVmRX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structNfG8poVmRX.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structNpSaGkUh99.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structNpSaGkUh99.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structNphpYJarez.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structNphpYJarez.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structNq8WSpQa6r.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structNq8WSpQa6r.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structNuHNDIZUYr.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structNuHNDIZUYr.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structO4Kr2Vp6iB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structO4Kr2Vp6iB.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structO5SpO4Lmqy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structO5SpO4Lmqy.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structO6aBEtLHCl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structO6aBEtLHCl.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structO8aC92gkJu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structO8aC92gkJu.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structOAXjhVxHVW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structOAXjhVxHVW.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structOBggRrGGeA.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structOBggRrGGeA.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structOCKiZ8XvN4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structOCKiZ8XvN4.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structOTagHf6dta.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structOTagHf6dta.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structOmPR4GDmha.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structOmPR4GDmha.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structOnU7Y1iyOW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structOnU7Y1iyOW.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structOruSh6IU68.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structOruSh6IU68.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structP07kLcgWy2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structP07kLcgWy2.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structP0hi03Yr5J.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structP0hi03Yr5J.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structP51IT0iQls.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structP51IT0iQls.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structPC53CFAahl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structPC53CFAahl.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structPDETEBub2B.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structPDETEBub2B.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structPIEO17rXv3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structPIEO17rXv3.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structPL1Vy8gAQG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structPL1Vy8gAQG.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structPOAJbOn5yN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structPOAJbOn5yN.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structPWOGZtzGIy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structPWOGZtzGIy.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structPWOtvXxst0.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structPWOtvXxst0.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structPaMBWeOEZb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structPaMBWeOEZb.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structPbViqUkC9s.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structPbViqUkC9s.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structPjXLhVCSo2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structPjXLhVCSo2.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structPmsSWhVFlx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structPmsSWhVFlx.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structPvttwCSove.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structPvttwCSove.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structPy7auxT2wm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structPy7auxT2wm.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structPzKBHCX9aj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structPzKBHCX9aj.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structQ1lt85NZkv.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structQ1lt85NZkv.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structQ9W3v3dQYW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structQ9W3v3dQYW.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structQBpF2mc1un.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structQBpF2mc1un.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structQLoTxIicfl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structQLoTxIicfl.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structQNBjmFEISk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structQNBjmFEISk.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structQRNlszU7N1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structQRNlszU7N1.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structQRrZvgSvEl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structQRrZvgSvEl.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structQu8eKSWeIJ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structQu8eKSWeIJ.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structQwjx7jDCDX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structQwjx7jDCDX.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structQwri7Ax9TK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structQwri7Ax9TK.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structR4xaEYdpRY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structR4xaEYdpRY.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structR6bsgVIYE6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structR6bsgVIYE6.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structR6j965l6JZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structR6j965l6JZ.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structR6yPnOD0oz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structR6yPnOD0oz.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structR8eEQpI0YT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structR8eEQpI0YT.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structRBr9HNIGgm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structRBr9HNIGgm.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structRBwjivoMMP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structRBwjivoMMP.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structRFFK9pIT93.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structRFFK9pIT93.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structRJYj3K0a3c.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structRJYj3K0a3c.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structRLhaWW9haz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structRLhaWW9haz.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structRSckKIVPNO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structRSckKIVPNO.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structRX7hJYzEEc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structRX7hJYzEEc.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structRbEgtyrBAH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structRbEgtyrBAH.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structRbgB04HmL4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structRbgB04HmL4.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structRdgEVFWPU8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structRdgEVFWPU8.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structRjYd0rym9S.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structRjYd0rym9S.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structRpd0ErOBb6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structRpd0ErOBb6.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structRtcf0YV8fO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structRtcf0YV8fO.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structRtjThoUz7H.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structRtjThoUz7H.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structRyTk5RxJJO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structRyTk5RxJJO.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structS1RhuauboU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structS1RhuauboU.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structS6bmXaMMyl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structS6bmXaMMyl.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structSDPIMkAwH8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structSDPIMkAwH8.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structSEmAsgVkk9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structSEmAsgVkk9.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structSIfHQocAM7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structSIfHQocAM7.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structSL3XN9PByF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structSL3XN9PByF.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structSOJZorG6h4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structSOJZorG6h4.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structSOQ2b3Trj9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structSOQ2b3Trj9.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structSOcWqfVVcP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structSOcWqfVVcP.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structSUuI5kWBPQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structSUuI5kWBPQ.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structSWz0ZdY1fL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structSWz0ZdY1fL.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structSXB5wflpQj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structSXB5wflpQj.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structSaCKmxwW7X.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structSaCKmxwW7X.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structSkgZGVkxzj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structSkgZGVkxzj.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structSuSfIvUv2A.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structSuSfIvUv2A.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structSuaJbDOn73.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structSuaJbDOn73.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structSv55DLNwHy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structSv55DLNwHy.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structSvXjwmwWp8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structSvXjwmwWp8.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structT024qoIGBu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structT024qoIGBu.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structT396ygje53.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structT396ygje53.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structTA8Sp22K2U.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structTA8Sp22K2U.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structTGF07uM1y9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structTGF07uM1y9.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structTKbYYBx9QZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structTKbYYBx9QZ.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structTLyC86eODa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structTLyC86eODa.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structTSEu5hclTq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structTSEu5hclTq.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structTX5YCrOcOo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structTX5YCrOcOo.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structTX6rXf2RZh.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structTX6rXf2RZh.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structTaJbzfeDjo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structTaJbzfeDjo.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structTaYGLKdSM8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structTaYGLKdSM8.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structTgcZPmWOx2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structTgcZPmWOx2.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structTh5NbnUqzI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structTh5NbnUqzI.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structTknpxoQFvS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structTknpxoQFvS.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structTqu8KoZQjY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structTqu8KoZQjY.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structTuAcbBNnZm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structTuAcbBNnZm.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structTuWH3zeluv.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structTuWH3zeluv.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structTwjPuMKDiB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structTwjPuMKDiB.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structTxF88EuH4Q.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structTxF88EuH4Q.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structTzQ4rWvlZ3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structTzQ4rWvlZ3.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structU2kogkOlcf.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structU2kogkOlcf.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structU3dy6bkQcN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structU3dy6bkQcN.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structUA5Zgdsa4W.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structUA5Zgdsa4W.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structUC7urls6rG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structUC7urls6rG.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structUJ5RVg0xHN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structUJ5RVg0xHN.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structUL0XgKUiea.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structUL0XgKUiea.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structUYdnQvYvKk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structUYdnQvYvKk.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structUaTPRyIwWQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structUaTPRyIwWQ.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structUgp6Bg804O.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structUgp6Bg804O.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structUgsqUT0Fw8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structUgsqUT0Fw8.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structUomjJGDhS3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structUomjJGDhS3.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structUrJ7tMPYdi.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structUrJ7tMPYdi.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structUsGUm5feCJ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structUsGUm5feCJ.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structUx6sDnae6o.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structUx6sDnae6o.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structUyBELJkxhd.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structUyBELJkxhd.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structV1mFMqHDyz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structV1mFMqHDyz.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structV3DEOjYkAI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structV3DEOjYkAI.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structV4EcMh64Nu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structV4EcMh64Nu.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structVABFQlbdB8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structVABFQlbdB8.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structVCKWE5qXDQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structVCKWE5qXDQ.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structVF3eV6RT5A.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structVF3eV6RT5A.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structVGVFt2H4Jq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structVGVFt2H4Jq.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structVHmibu21U1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structVHmibu21U1.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structVJQMEbTTcW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structVJQMEbTTcW.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structVW9Wugrq8f.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structVW9Wugrq8f.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structVbui9U8nJN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structVbui9U8nJN.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structVqmZxmYjrS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structVqmZxmYjrS.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structVwumd12dMR.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structVwumd12dMR.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structW03TuqLzYH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structW03TuqLzYH.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structW6NGdR4FHA.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structW6NGdR4FHA.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structW8RwEte1K1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structW8RwEte1K1.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structWFr5O7xRwi.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structWFr5O7xRwi.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structWJw9ZLP7fK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structWJw9ZLP7fK.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structWODpD4eAmE.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structWODpD4eAmE.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structWOGNQBbIW7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structWOGNQBbIW7.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structWQN1KyUD5b.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structWQN1KyUD5b.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structWTDgYPieK1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structWTDgYPieK1.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structWVtboPH1aE.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structWVtboPH1aE.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structWiPM4vCvbR.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structWiPM4vCvbR.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structWk1zWo8r9K.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structWk1zWo8r9K.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structWkYOcVuG9r.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structWkYOcVuG9r.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structWqKLr6PuT3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structWqKLr6PuT3.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structWyFaNRxWDU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structWyFaNRxWDU.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structX0tLJiI6QS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structX0tLJiI6QS.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structX74WdLPgP3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structX74WdLPgP3.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structXLePVWtJFS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structXLePVWtJFS.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structXNJAbmwEpz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structXNJAbmwEpz.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structXOlFj8WTWU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structXOlFj8WTWU.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structXQpY9eJk4m.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structXQpY9eJk4m.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structXU2GzBHEnm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structXU2GzBHEnm.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structXWIUjIMjuc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structXWIUjIMjuc.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structXYOl2gpZhZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structXYOl2gpZhZ.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structXYrXq7Kz5O.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structXYrXq7Kz5O.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structXab1L6RKkc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structXab1L6RKkc.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structXcQSZS9Pq3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structXcQSZS9Pq3.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structXdOq3rooU7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structXdOq3rooU7.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structXpfvMzo3SU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structXpfvMzo3SU.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structXs0m0HB3Ve.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structXs0m0HB3Ve.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structXsoVym5xGF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structXsoVym5xGF.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structXxbrxyvfJK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structXxbrxyvfJK.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structY0sbuM1lf1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structY0sbuM1lf1.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structY2WI2qZBJc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structY2WI2qZBJc.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structY3MSP8GJLq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structY3MSP8GJLq.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structY7ZzgHzGVw.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structY7ZzgHzGVw.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structY8HkjRfwpg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structY8HkjRfwpg.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structYAzsftuDhx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structYAzsftuDhx.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structYE37gD7DoN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structYE37gD7DoN.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structYNODMJt0nI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structYNODMJt0nI.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structYOoQMQYEZo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structYOoQMQYEZo.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structYPtr2Dr86B.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structYPtr2Dr86B.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structYXRqKm5H9U.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structYXRqKm5H9U.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structYa2X1A0XlS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structYa2X1A0XlS.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structYj7TbLsdP4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structYj7TbLsdP4.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structYlF6RxCqVs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structYlF6RxCqVs.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structYo1jTzfuKl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structYo1jTzfuKl.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structYrew2qdBuH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structYrew2qdBuH.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structYwZwDfIvIG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structYwZwDfIvIG.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structZ3DY5gvzFY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structZ3DY5gvzFY.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structZBrvC38b8N.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structZBrvC38b8N.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structZC6ZaapQdD.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structZC6ZaapQdD.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structZGNK9Twr9S.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structZGNK9Twr9S.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structZGqp2bRDtx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structZGqp2bRDtx.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structZJSKolxfqc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structZJSKolxfqc.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structZR3LiJX7PO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structZR3LiJX7PO.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structZW26HGLchP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structZW26HGLchP.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structZi1RqmdSol.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structZi1RqmdSol.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structZoimFj6xEE.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structZoimFj6xEE.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structZpfDnRPksn.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structZpfDnRPksn.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structZr2k5TeLcE.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structZr2k5TeLcE.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structZtqbbnQjzj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structZtqbbnQjzj.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structZupKEHABUk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structZupKEHABUk.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structa0AhWFAoDG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structa0AhWFAoDG.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structa5eW784LQf.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structa5eW784LQf.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structa6BXYQAwEm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structa6BXYQAwEm.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structa6bL6toTDQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structa6bL6toTDQ.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structa85eS8wvGC.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structa85eS8wvGC.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structaBCMiwiL14.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structaBCMiwiL14.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structaCvUpfrOud.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structaCvUpfrOud.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structaMVAJ9INz0.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structaMVAJ9INz0.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structaNX02HPg7T.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structaNX02HPg7T.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structaacjP2BYDY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structaacjP2BYDY.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structafSLEQGtjb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structafSLEQGtjb.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structawZmlvXiXW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structawZmlvXiXW.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structaxV4fiWwZ7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structaxV4fiWwZ7.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structayNEhBBg4t.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structayNEhBBg4t.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structb265yb0csM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structb265yb0csM.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structb63fAzKNR7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structb63fAzKNR7.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structbBsug1Wd34.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structbBsug1Wd34.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structbNMyvNH8WM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structbNMyvNH8WM.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structbX4S27LXkH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structbX4S27LXkH.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structblpexlSs9M.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structblpexlSs9M.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structbmmnw9qu32.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structbmmnw9qu32.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structbsrrxTZOqn.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structbsrrxTZOqn.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structbtgnPXO5Rq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structbtgnPXO5Rq.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structbwtswCbHZn.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structbwtswCbHZn.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structc0ARtdYgED.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structc0ARtdYgED.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structc0K76QtGvt.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structc0K76QtGvt.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structc19BIAaEkY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structc19BIAaEkY.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structcIUFEZhrle.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structcIUFEZhrle.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structcU51DXcyE8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structcU51DXcyE8.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structcbnz0kvIwn.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structcbnz0kvIwn.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structcfbnUeCgbt.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structcfbnUeCgbt.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structcjMmD9Dwfx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structcjMmD9Dwfx.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structclmVkpAhb8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structclmVkpAhb8.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structcoAqE1boX6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structcoAqE1boX6.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structcormXUf4WS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structcormXUf4WS.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structcqdGRq2WNh.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structcqdGRq2WNh.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structczOiELiAB7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structczOiELiAB7.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structd2ojXxCaNW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structd2ojXxCaNW.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structd4OcbMDcGL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structd4OcbMDcGL.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structd9nB4x1U6u.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structd9nB4x1U6u.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structdEhJcrsORt.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structdEhJcrsORt.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structdKBNYvwyxK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structdKBNYvwyxK.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structdNGVHIlzAj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structdNGVHIlzAj.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structdSftno00MK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structdSftno00MK.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structdXZpHpuk3x.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structdXZpHpuk3x.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structdXgIF94ebo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structdXgIF94ebo.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structdhEH1P8yDX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structdhEH1P8yDX.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structdq0ytTGdT7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structdq0ytTGdT7.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structdr28D0z5ZH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structdr28D0z5ZH.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structe4z2kYEwsw.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structe4z2kYEwsw.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structe79Za4b7Ml.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structe79Za4b7Ml.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structeJF56nvsEj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structeJF56nvsEj.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structeW6hiVZjD9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structeW6hiVZjD9.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structegI0J6pwbq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structegI0J6pwbq.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structemjd05RWc3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structemjd05RWc3.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structeqBjnWgb5P.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structeqBjnWgb5P.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structf0akg4gumK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structf0akg4gumK.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structf32Rx1NpEm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structf32Rx1NpEm.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structf3hg4Duqet.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structf3hg4Duqet.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structf74ThK893J.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structf74ThK893J.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structfBkGsQBirP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structfBkGsQBirP.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structfCVtyydYxM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structfCVtyydYxM.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structfCayR9pma6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structfCayR9pma6.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structfG4ASdjUC9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structfG4ASdjUC9.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structfJdkVlyVac.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structfJdkVlyVac.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structfNnOzIDYzL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structfNnOzIDYzL.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structfOOjVzFOC9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structfOOjVzFOC9.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structfTXY9OU4mh.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structfTXY9OU4mh.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structfWEUc1K6FG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structfWEUc1K6FG.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structfYJ2Mkk1al.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structfYJ2Mkk1al.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structfcg2UqwprF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structfcg2UqwprF.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structfd0mCQVHBl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structfd0mCQVHBl.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structfwecOIJDmQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structfwecOIJDmQ.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structgBuG9DjtOU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structgBuG9DjtOU.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structgIAdPMClq9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structgIAdPMClq9.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structgJaEzQzHlG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structgJaEzQzHlG.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structgTI819u8oK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structgTI819u8oK.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structgaVRwvBYOY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structgaVRwvBYOY.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structgmDuxmO8uQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structgmDuxmO8uQ.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structgnTh8YZCI4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structgnTh8YZCI4.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structgnzwfueLCU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structgnzwfueLCU.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structgodJTvsSrL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structgodJTvsSrL.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structgoyNOloADC.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structgoyNOloADC.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structgrMFKxp6Rp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structgrMFKxp6Rp.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structgu5AmoUnKH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structgu5AmoUnKH.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structgw0RpMV2f4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structgw0RpMV2f4.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structgzPFVO95T5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structgzPFVO95T5.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structh0wIvbjPFM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structh0wIvbjPFM.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structh0zYLuKys0.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structh0zYLuKys0.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structh4borQn8tt.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structh4borQn8tt.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structhEYyOpWNQA.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structhEYyOpWNQA.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structhKVOXTzhtj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structhKVOXTzhtj.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structhP7CI8CVIx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structhP7CI8CVIx.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structhRp6BjrXlq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structhRp6BjrXlq.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structhXluAaYGUP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structhXluAaYGUP.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structhc5U7IjcZc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structhc5U7IjcZc.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structhjYDoXKd1y.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structhjYDoXKd1y.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structhk5xXOFY3B.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structhk5xXOFY3B.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structhlXXNdntjL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structhlXXNdntjL.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structhnljKmvH1S.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structhnljKmvH1S.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structhsMP7WDnTb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structhsMP7WDnTb.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structi5tx16f99j.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structi5tx16f99j.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structi60i9flgEl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structi60i9flgEl.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structiGcBGhWkFg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structiGcBGhWkFg.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structiH2t1AudUv.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structiH2t1AudUv.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structiJO3yTUlA6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structiJO3yTUlA6.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structiMxQrDbyMm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structiMxQrDbyMm.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structiRTC8Ri5hh.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structiRTC8Ri5hh.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structiUTYiuw7nL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structiUTYiuw7nL.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structifVuZi4Efe.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structifVuZi4Efe.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structigySx6ywF4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structigySx6ywF4.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structimk6k6ZOQP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structimk6k6ZOQP.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structiyfYt6St4H.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structiyfYt6St4H.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structj0Jp6zlUkb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structj0Jp6zlUkb.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structj2noj6YBli.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structj2noj6YBli.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structj80X6OAWFM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structj80X6OAWFM.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structjATzvt82Yc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structjATzvt82Yc.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structjHYdKd1qGS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structjHYdKd1qGS.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structjIn9JVMI49.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structjIn9JVMI49.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structjKvkQzPnI2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structjKvkQzPnI2.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structjPeWDdzelT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structjPeWDdzelT.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structjVynlgrJOg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structjVynlgrJOg.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structjXzq5dAQfq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structjXzq5dAQfq.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structjlEQy1XgIm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structjlEQy1XgIm.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structjpZYztDGZv.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structjpZYztDGZv.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structjyzBmrWLpD.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structjyzBmrWLpD.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structjzLZ1Fd1su.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structjzLZ1Fd1su.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structk0RWOtD4Cb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structk0RWOtD4Cb.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structk5uhI551Ib.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structk5uhI551Ib.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structkBpo9DUgjg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structkBpo9DUgjg.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structkKCqpBwgSB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structkKCqpBwgSB.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structkMn4TDNnDw.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structkMn4TDNnDw.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structkTDa7zOTTq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structkTDa7zOTTq.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structkcnuBfgvqB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structkcnuBfgvqB.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structke5R4wNmaV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structke5R4wNmaV.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structkgOVznysHS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structkgOVznysHS.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structkjR2PqZPCx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structkjR2PqZPCx.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structkjvkPYElx2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structkjvkPYElx2.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structko3HKcubO4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structko3HKcubO4.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structl1rwee6A0W.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structl1rwee6A0W.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structl9GK15NFfI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structl9GK15NFfI.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structl9dEcAYjZX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structl9dEcAYjZX.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structlCbFTLeEcO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structlCbFTLeEcO.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structlFoUTH7TGY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structlFoUTH7TGY.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structlFuagxP4pj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structlFuagxP4pj.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structlKqlZNIiTG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structlKqlZNIiTG.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structlM9nCK9mVa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structlM9nCK9mVa.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structlNxcettVbW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structlNxcettVbW.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structlOMWejTcie.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structlOMWejTcie.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structlPPzP90v2M.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structlPPzP90v2M.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structlWE7ijbTPg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structlWE7ijbTPg.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structlWZpr8mFUz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structlWZpr8mFUz.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structlfb6Bcmyzv.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structlfb6Bcmyzv.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structliZR39PG4B.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structliZR39PG4B.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structlilo17vqrO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structlilo17vqrO.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structlmBHuI2CdK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structlmBHuI2CdK.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structlsRnaxudRi.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structlsRnaxudRi.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structlwBBVufID9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structlwBBVufID9.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structmE7fFfuHjx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structmE7fFfuHjx.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structmPX6OOh4Nl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structmPX6OOh4Nl.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structmR2t9GgAZ5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structmR2t9GgAZ5.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structmU9k8N2S1x.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structmU9k8N2S1x.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structmUQioQKiXp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structmUQioQKiXp.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structmWBF30udKT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structmWBF30udKT.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structmaUySacG7e.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structmaUySacG7e.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structmj4Oyb3GgX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structmj4Oyb3GgX.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structmuAhuD4KVQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structmuAhuD4KVQ.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structmwjaO3Uyrs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structmwjaO3Uyrs.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structn5h1DHBxub.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structn5h1DHBxub.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structnAdqmBnbeg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structnAdqmBnbeg.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structnAvYhH07Gs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structnAvYhH07Gs.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structnHnX8P1WDq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structnHnX8P1WDq.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structnNkjJDcz0P.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structnNkjJDcz0P.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structnPwZk9I7YN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structnPwZk9I7YN.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structnUJfW4NMaA.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structnUJfW4NMaA.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structnXMZUp9V4V.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structnXMZUp9V4V.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structnjkuDZnOoQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structnjkuDZnOoQ.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structnq8k7vNWX3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structnq8k7vNWX3.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structnrVsGpyHSB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structnrVsGpyHSB.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structnsGvdkMRFZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structnsGvdkMRFZ.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structoAhXI74h9j.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structoAhXI74h9j.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structoahbTSUqku.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structoahbTSUqku.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structoiRn4GygF9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structoiRn4GygF9.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structov6aJQLXqu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structov6aJQLXqu.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structovm1h7N1tD.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structovm1h7N1tD.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structoypCXXMXYK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structoypCXXMXYK.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structp39x1W6Nmw.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structp39x1W6Nmw.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structp5F0SqEi1N.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structp5F0SqEi1N.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structpK1zdl2ooH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structpK1zdl2ooH.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structpLXABe2wJc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structpLXABe2wJc.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structpMr2v6juAQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structpMr2v6juAQ.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structpXZA41Y8fK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structpXZA41Y8fK.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structpkIouuiKqe.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structpkIouuiKqe.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structpnMhTmK3QH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structpnMhTmK3QH.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structpuA2r64pbW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structpuA2r64pbW.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structpwCAT0hshK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structpwCAT0hshK.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structq1BEWkecYX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structq1BEWkecYX.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structq2gqs38KnH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structq2gqs38KnH.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structq5OjZ10BEs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structq5OjZ10BEs.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structqGa10MSSRs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structqGa10MSSRs.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structqGuE1lEn2E.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structqGuE1lEn2E.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structqK7XKTZI6a.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structqK7XKTZI6a.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structqRtOraogqy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structqRtOraogqy.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structqTdD25cQMq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structqTdD25cQMq.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structqVenFBZMmB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structqVenFBZMmB.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structqVymoyiTzO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structqVymoyiTzO.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structqYoMOdyW5o.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structqYoMOdyW5o.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structqZqGFZMAp0.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structqZqGFZMAp0.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structqceTFkotG1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structqceTFkotG1.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structqklsh0VtCj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structqklsh0VtCj.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structqkwGFodzYo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structqkwGFodzYo.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structqlynSYPIzj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structqlynSYPIzj.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structqmylEQUQxN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structqmylEQUQxN.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structqsdnJQvtod.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structqsdnJQvtod.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structr1IUWdH7kS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structr1IUWdH7kS.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structrDLhl5fFyI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structrDLhl5fFyI.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structrJ6A29EFD3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structrJ6A29EFD3.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structrLI0qkdwNT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structrLI0qkdwNT.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structrNNNMoMUX5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structrNNNMoMUX5.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structrQyjIvxeGC.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structrQyjIvxeGC.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structrUZIsQzLzo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structrUZIsQzLzo.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structrUrNNgGYxl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structrUrNNgGYxl.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structrZORE7saci.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structrZORE7saci.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structrnEvXbtOaJ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structrnEvXbtOaJ.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structrv6cJ7e4eI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structrv6cJ7e4eI.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structrvnG4DB0O9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structrvnG4DB0O9.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structrxuRIzLrOd.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structrxuRIzLrOd.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structs0wKthNJDH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structs0wKthNJDH.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structs6tlj8Ujb6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structs6tlj8Ujb6.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structs81xiTr3V2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structs81xiTr3V2.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structs9FC686ssT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structs9FC686ssT.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structsU7ru1S3Bn.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structsU7ru1S3Bn.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structsconExg82n.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structsconExg82n.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structsnl6YWFzw6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structsnl6YWFzw6.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structsr11hihvVP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structsr11hihvVP.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structsrFnuySLJZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structsrFnuySLJZ.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structsyMjE23XYL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structsyMjE23XYL.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structt1zhtoy3QG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structt1zhtoy3QG.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structt3vc10gLez.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structt3vc10gLez.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structt7Y6XwomUH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structt7Y6XwomUH.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structtFfTsyMFtj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structtFfTsyMFtj.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structtKTQH67TAx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structtKTQH67TAx.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structtRnRKY1Nt9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structtRnRKY1Nt9.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structtVv0gLLUw6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structtVv0gLLUw6.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structtdu9UH9BR6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structtdu9UH9BR6.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structtkLijaINDB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structtkLijaINDB.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structtmi3Y4xjWJ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structtmi3Y4xjWJ.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structtoRHBeshpF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structtoRHBeshpF.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structtoojZOxzYL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structtoojZOxzYL.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structuEWock0xfg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structuEWock0xfg.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structuYFS57GpEz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structuYFS57GpEz.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structuZLTFqoTc9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structuZLTFqoTc9.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structuesCCsCmB9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structuesCCsCmB9.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structuk9n40Ba1s.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structuk9n40Ba1s.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structurOByRIJr5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structurOByRIJr5.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structusM7i9eFda.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structusM7i9eFda.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structuzTdZWiu60.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structuzTdZWiu60.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structv4jF52UQ9H.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structv4jF52UQ9H.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structv9bmg59CEV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structv9bmg59CEV.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structvE6YTruKB5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structvE6YTruKB5.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structvGYXxaXkfO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structvGYXxaXkfO.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structvIiPiag0AP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structvIiPiag0AP.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structvJXxV1TNGG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structvJXxV1TNGG.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structvLrhLw24Yo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structvLrhLw24Yo.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structvPLGLtUGvc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structvPLGLtUGvc.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structvQ4tBtsFIQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structvQ4tBtsFIQ.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structvetTPo8phL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structvetTPo8phL.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structvh6HUMxCO1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structvh6HUMxCO1.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structvhPOJekCB6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structvhPOJekCB6.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structvqpjGCBNgC.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structvqpjGCBNgC.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structw1Jcuo2qcB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structw1Jcuo2qcB.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structw1LUTeHkEP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structw1LUTeHkEP.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structw704rOrUeD.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structw704rOrUeD.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structwAVE8pzuIw.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structwAVE8pzuIw.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structwE9USHmMoa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structwE9USHmMoa.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structwKyV6c3NXx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structwKyV6c3NXx.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structwNNWk20409.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structwNNWk20409.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structwPjsuxb7PR.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structwPjsuxb7PR.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structwquRams9Fs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structwquRams9Fs.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structwyz9cVcdwh.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structwyz9cVcdwh.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structx29mgYMw04.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structx29mgYMw04.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structx9kDs7ICzW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structx9kDs7ICzW.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structxFTWeVz86X.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structxFTWeVz86X.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structxI8aw5DOBf.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structxI8aw5DOBf.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structxKJxcMqgXp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structxKJxcMqgXp.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structxSyTOLVs2a.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structxSyTOLVs2a.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structxY83QlHYu8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structxY83QlHYu8.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structxatoIPHwut.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structxatoIPHwut.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structxayiSk9poY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structxayiSk9poY.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structxl0tHilNDj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structxl0tHilNDj.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structxpKM8hQmHX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structxpKM8hQmHX.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structxrKKgR1Fe1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structxrKKgR1Fe1.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structxsR9aAsAXm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structxsR9aAsAXm.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structxwNsI8Zdb1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structxwNsI8Zdb1.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structy2eHpFGRr5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structy2eHpFGRr5.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structy5X9cuxDIn.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structy5X9cuxDIn.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structy5wbr5f4bB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structy5wbr5f4bB.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structyAGnaq1EBc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structyAGnaq1EBc.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structyGjRe5am7c.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structyGjRe5am7c.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structyKsJfDGXaz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structyKsJfDGXaz.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structyNBvxKIcti.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structyNBvxKIcti.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structyPEdNMH6Lo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structyPEdNMH6Lo.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structyTmtkFKqd7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structyTmtkFKqd7.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structydbIqe0qPo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structydbIqe0qPo.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structyhDvAbXvCv.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structyhDvAbXvCv.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structynitZhhUeJ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structynitZhhUeJ.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structyvVgkdYRXO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structyvVgkdYRXO.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structz1JgTXpAuI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structz1JgTXpAuI.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structz7dfzzL9Yk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structz7dfzzL9Yk.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structzIXefsJFSz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structzIXefsJFSz.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structzPWDt4oN6i.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structzPWDt4oN6i.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structzQUyc7Ws0e.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structzQUyc7Ws0e.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structzTIpN6ALMu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structzTIpN6ALMu.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structzYoD4xKxnZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structzYoD4xKxnZ.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structzdXNEcof9V.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structzdXNEcof9V.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structzo3owhla9x.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structzo3owhla9x.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structzyowJj76a6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/partial-structzyowJj76a6.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct00oieaoYA5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct00oieaoYA5.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct05nZxSvOQy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct05nZxSvOQy.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct0CW6rWihRa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct0CW6rWihRa.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct0EiiHjJ0Jy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct0EiiHjJ0Jy.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct0HxVdkFuDk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct0HxVdkFuDk.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct0Sp8nFf9po.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct0Sp8nFf9po.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct0YOigHUonk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct0YOigHUonk.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct0mu68DyXFS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct0mu68DyXFS.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct0oZl05ifoL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct0oZl05ifoL.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct101P28DC6b.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct101P28DC6b.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct109xwVU7na.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct109xwVU7na.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct13ZLCuuDdg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct13ZLCuuDdg.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct164v5M7Oiu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct164v5M7Oiu.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct16i8Hnvzik.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct16i8Hnvzik.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct1B64P2KJTT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct1B64P2KJTT.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct1FLNprzFfg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct1FLNprzFfg.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct1Lodf8jQhi.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct1Lodf8jQhi.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct1NM3qeUh2p.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct1NM3qeUh2p.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct1QKloRyprM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct1QKloRyprM.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct1TeundtXb1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct1TeundtXb1.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct1e9vZ2ZVVl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct1e9vZ2ZVVl.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct1ibkpE2U9t.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct1ibkpE2U9t.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct1jAvJkz71q.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct1jAvJkz71q.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct1kIcXqyaMm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct1kIcXqyaMm.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct1kIjvNmL26.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct1kIjvNmL26.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct1nopkP9yWt.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct1nopkP9yWt.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct1q3mpvDeuG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct1q3mpvDeuG.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct1rwcZsOxGm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct1rwcZsOxGm.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct1shpv6NmPc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct1shpv6NmPc.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct1tertRu9Xm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct1tertRu9Xm.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct1xSlrFoiE2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct1xSlrFoiE2.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct1xjEjG8zge.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct1xjEjG8zge.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct1zEPcP8TZ0.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct1zEPcP8TZ0.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct22wFvfGOQe.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct22wFvfGOQe.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct23OaGTh97N.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct23OaGTh97N.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct2C0v3cLs4t.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct2C0v3cLs4t.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct2Ii6Pytw94.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct2Ii6Pytw94.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct2KJvO9ifSa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct2KJvO9ifSa.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct2Oea4qEuqL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct2Oea4qEuqL.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct2PRjv73LUz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct2PRjv73LUz.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct2PlWXW13Oo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct2PlWXW13Oo.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct2RjyXdbOmS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct2RjyXdbOmS.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct2WJXBATRow.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct2WJXBATRow.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct2ePshLeWkH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct2ePshLeWkH.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct2iRAZCo7L5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct2iRAZCo7L5.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct2l1qlatawT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct2l1qlatawT.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct2lPhMAoDBl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct2lPhMAoDBl.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct2mrBdiaAsD.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct2mrBdiaAsD.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct2yK9S7dzeX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct2yK9S7dzeX.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct2yeMfnvK5l.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct2yeMfnvK5l.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct34i0YswjFg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct34i0YswjFg.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct3AvV0e5RCv.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct3AvV0e5RCv.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct3Fkic0RvsS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct3Fkic0RvsS.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct3Q09CNhFqG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct3Q09CNhFqG.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct3W5X0ROtrE.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct3W5X0ROtrE.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct3YKEcUcTm6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct3YKEcUcTm6.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct3Ysql1aZTo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct3Ysql1aZTo.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct3aLcZ0Gzdp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct3aLcZ0Gzdp.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct3bQ2CbXXiG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct3bQ2CbXXiG.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct3hbQkh2oXr.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct3hbQkh2oXr.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct3o9W3tWIYr.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct3o9W3tWIYr.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct3oRAhgtPFs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct3oRAhgtPFs.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct3rEqyW20Ha.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct3rEqyW20Ha.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct3rh7agTF1u.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct3rh7agTF1u.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct3tAXhVgz0j.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct3tAXhVgz0j.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct3udOlsWezr.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct3udOlsWezr.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct3yavERh0QP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct3yavERh0QP.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct40R1V76roU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct40R1V76roU.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct44PftY660j.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct44PftY660j.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct46ykdVFGwG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct46ykdVFGwG.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct47pp9CzShs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct47pp9CzShs.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct49eWbTEG4e.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct49eWbTEG4e.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct4I0C5KiBcT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct4I0C5KiBcT.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct4NHzRc00m2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct4NHzRc00m2.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct4R1b3Sfk6J.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct4R1b3Sfk6J.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct4VkhuwJa8e.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct4VkhuwJa8e.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct4bA4rV4T7I.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct4bA4rV4T7I.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct4qOfIMBclV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct4qOfIMBclV.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct4tYHXfgnVZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct4tYHXfgnVZ.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct4xCfXxpvdy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct4xCfXxpvdy.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct4zYtkggxX9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct4zYtkggxX9.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct566AUa8c9w.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct566AUa8c9w.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct5B3Ki66g8U.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct5B3Ki66g8U.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct5GIHfCnyF0.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct5GIHfCnyF0.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct5GXqW1XpIl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct5GXqW1XpIl.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct5R3JtFMKyy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct5R3JtFMKyy.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct5WOnMXao7S.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct5WOnMXao7S.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct5WjoUCBC2W.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct5WjoUCBC2W.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct5YuboIIJis.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct5YuboIIJis.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct5coPgZ627S.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct5coPgZ627S.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct5nsLLrnYzS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct5nsLLrnYzS.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct5p0wzn3Twr.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct5p0wzn3Twr.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct5pUyGEiqRW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct5pUyGEiqRW.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct66VojQk1NI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct66VojQk1NI.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct67D9OX1YBs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct67D9OX1YBs.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct67XWJDtmLp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct67XWJDtmLp.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct6ACGifRdRw.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct6ACGifRdRw.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct6AkdgH06Lh.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct6AkdgH06Lh.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct6BWJO4ygCh.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct6BWJO4ygCh.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct6Eho6XNoOx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct6Eho6XNoOx.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct6Fnny4hIyl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct6Fnny4hIyl.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct6GnahT2THT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct6GnahT2THT.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct6Gy1eE7iFg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct6Gy1eE7iFg.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct6InhhK3Bnx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct6InhhK3Bnx.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct6KaWm2V4so.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct6KaWm2V4so.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct6NVZQs4UrE.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct6NVZQs4UrE.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct6PUxZ29VTq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct6PUxZ29VTq.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct6fce05Qu1f.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct6fce05Qu1f.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct6tzbdxQpL4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct6tzbdxQpL4.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct763ixhZiPg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct763ixhZiPg.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct79tZSSX75b.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct79tZSSX75b.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct7E3RzOaVF1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct7E3RzOaVF1.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct7Ev4ba5U4g.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct7Ev4ba5U4g.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct7FkotSk0XD.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct7FkotSk0XD.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct7MpRJpjzYV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct7MpRJpjzYV.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct7UAHrFSXgp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct7UAHrFSXgp.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct7ZDRFK7C6w.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct7ZDRFK7C6w.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct7hWyxK9Im1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct7hWyxK9Im1.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct7vhsXm5Sqy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct7vhsXm5Sqy.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct7vwzjN2hQB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct7vwzjN2hQB.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct7x47kTkDWA.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct7x47kTkDWA.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct814BQq200G.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct814BQq200G.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct84TN7zjoK9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct84TN7zjoK9.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct8CllamWxHF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct8CllamWxHF.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct8KGpb7sMhV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct8KGpb7sMhV.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct8P1XTIrmCU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct8P1XTIrmCU.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct8eGauAG2Iy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct8eGauAG2Iy.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct8hD3MVC60I.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct8hD3MVC60I.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct8q0Jpdjx8u.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct8q0Jpdjx8u.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct8qIwjmR7oN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct8qIwjmR7oN.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct8tbcftbwF8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct8tbcftbwF8.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct8txOZ8smgu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct8txOZ8smgu.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct8yaeAzdZUO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct8yaeAzdZUO.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct98nsmL4Uyu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct98nsmL4Uyu.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct9CTRHeV5gV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct9CTRHeV5gV.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct9E3xYWs4gr.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct9E3xYWs4gr.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct9FbBK7sAEy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct9FbBK7sAEy.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct9HOIXHYhP9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct9HOIXHYhP9.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct9IzMME36Bl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct9IzMME36Bl.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct9PLpEx4eEr.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct9PLpEx4eEr.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct9QX6aOMWmP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct9QX6aOMWmP.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct9XFvojKqS7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct9XFvojKqS7.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct9Z0NXJ0nuB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct9Z0NXJ0nuB.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct9cdQxj05PP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct9cdQxj05PP.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct9dJLrfdwrb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct9dJLrfdwrb.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct9fPHF2RcIG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct9fPHF2RcIG.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct9o9IQlJhfF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct9o9IQlJhfF.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct9rTJlJQ4St.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct9rTJlJQ4St.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct9tS75raz9v.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-struct9tS75raz9v.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structA0t67j1fxp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structA0t67j1fxp.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structA2y6S9lFjD.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structA2y6S9lFjD.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structA4N6i5eArl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structA4N6i5eArl.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structA6J9ouYjJm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structA6J9ouYjJm.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structAB03r2H43b.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structAB03r2H43b.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structADRxlKyBIl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structADRxlKyBIl.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structAE7oPkwYY6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structAE7oPkwYY6.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structAHdMDYZJaK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structAHdMDYZJaK.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structAK2drK1aH7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structAK2drK1aH7.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structAPZGaaiAsI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structAPZGaaiAsI.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structAQE2E9exgF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structAQE2E9exgF.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structAcoWvPhtlp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structAcoWvPhtlp.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structAiFfzJ9xOo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structAiFfzJ9xOo.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structAztsRhE0LF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structAztsRhE0LF.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structB9pN8GfUaU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structB9pN8GfUaU.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structBA8lKBvox6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structBA8lKBvox6.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structBBBafcZBl1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structBBBafcZBl1.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structBF8funmMCW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structBF8funmMCW.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structBNGrkk0Gq9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structBNGrkk0Gq9.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structBW4o7dJUoK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structBW4o7dJUoK.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structBWsRWzQ335.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structBWsRWzQ335.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structBfsVSixXGI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structBfsVSixXGI.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structBjERtQ98tj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structBjERtQ98tj.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structBjy5dZK2rM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structBjy5dZK2rM.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structBm7Ua0ACla.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structBm7Ua0ACla.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structBmz4OJxAlt.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structBmz4OJxAlt.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structBw3OKv2Qms.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structBw3OKv2Qms.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structBzSRBjnY22.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structBzSRBjnY22.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structC0g7V6d3fy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structC0g7V6d3fy.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structCBt0kIYRra.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structCBt0kIYRra.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structCOGSdZd0AL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structCOGSdZd0AL.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structCXeEkfG71q.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structCXeEkfG71q.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structCaHH2Xyhc7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structCaHH2Xyhc7.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structCcLnEruc0v.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structCcLnEruc0v.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structCfD3K5QvsN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structCfD3K5QvsN.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structCqQVJigrtI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structCqQVJigrtI.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structCzvlSZqJoZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structCzvlSZqJoZ.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structD2oQVW5tnq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structD2oQVW5tnq.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structD4YplBwWDi.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structD4YplBwWDi.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structD9gno8tRvF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structD9gno8tRvF.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structDACFSZmJCd.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structDACFSZmJCd.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structDVPBdDC863.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structDVPBdDC863.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structDXFa0e4ozX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structDXFa0e4ozX.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structDZZWeqhEZS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structDZZWeqhEZS.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structDhEKpPXtbG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structDhEKpPXtbG.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structDi88qmJim6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structDi88qmJim6.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structDrIOG3dy4E.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structDrIOG3dy4E.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structE1izflhe7m.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structE1izflhe7m.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structE7tbP2KegJ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structE7tbP2KegJ.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structECJjSKcI0x.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structECJjSKcI0x.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structECjdzNW2hb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structECjdzNW2hb.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structENNglh8DX6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structENNglh8DX6.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structEVUFJOsbyB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structEVUFJOsbyB.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structEa3Y8fmO5t.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structEa3Y8fmO5t.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structEbe6V1e8rk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structEbe6V1e8rk.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structEilgeng6RU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structEilgeng6RU.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structEjN7KM70nB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structEjN7KM70nB.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structEoc6yu6UZC.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structEoc6yu6UZC.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structEqZWhQIozu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structEqZWhQIozu.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structErRGvv06c5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structErRGvv06c5.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structEvFFf3fZGJ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structEvFFf3fZGJ.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structEx5206L0wV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structEx5206L0wV.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structF3dNExh2mR.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structF3dNExh2mR.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structF8DhNrWv7E.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structF8DhNrWv7E.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structF9RjQ90jnp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structF9RjQ90jnp.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structFI3w6VQMfO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structFI3w6VQMfO.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structFJsonz9Nyz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structFJsonz9Nyz.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structFR85FzqbWk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structFR85FzqbWk.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structFXxZeDtCw5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structFXxZeDtCw5.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structFaTXoezJTa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structFaTXoezJTa.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structFhwETmltur.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structFhwETmltur.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structFjGw1Sgvhj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structFjGw1Sgvhj.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structFq1hfAwgHs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structFq1hfAwgHs.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structFvR9kgHTwq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structFvR9kgHTwq.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structFx3ViT9W1l.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structFx3ViT9W1l.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structG23iNFg5pV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structG23iNFg5pV.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structG4WvAWeyY2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structG4WvAWeyY2.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structG5eiJlW14L.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structG5eiJlW14L.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structG7DG28rR3I.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structG7DG28rR3I.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structG8t7pJyR0P.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structG8t7pJyR0P.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structGAhk4JD5f5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structGAhk4JD5f5.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structGElc6so5Vx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structGElc6so5Vx.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structGL3ENulfXA.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structGL3ENulfXA.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structGPgos6Ga6k.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structGPgos6Ga6k.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structGVka0u9TDq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structGVka0u9TDq.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structGXNEUsfHGV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structGXNEUsfHGV.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structGajQGzODLb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structGajQGzODLb.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structGbvlSI6ZFM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structGbvlSI6ZFM.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structGgvsKvoP9v.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structGgvsKvoP9v.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structGiiPLasS8y.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structGiiPLasS8y.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structGlUP6EKlOZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structGlUP6EKlOZ.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structGmNuKgusEl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structGmNuKgusEl.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structGnndCPLSRE.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structGnndCPLSRE.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structGseI8AQPtb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structGseI8AQPtb.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structGyODqQmfLk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structGyODqQmfLk.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structH5eQeBi4oY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structH5eQeBi4oY.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structH6F7xwrgKM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structH6F7xwrgKM.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structHAW6jHGG5q.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structHAW6jHGG5q.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structHGMhtcP1Gs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structHGMhtcP1Gs.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structHNoL72ys27.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structHNoL72ys27.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structHOwIYbq2Gd.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structHOwIYbq2Gd.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structHQ1FzQOf8n.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structHQ1FzQOf8n.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structHQRXU94JgV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structHQRXU94JgV.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structHSN0q7oMVM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structHSN0q7oMVM.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structHYnhl5ltDv.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structHYnhl5ltDv.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structHcCEQbo9Zf.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structHcCEQbo9Zf.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structHfRiDfgqPK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structHfRiDfgqPK.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structHnGXhmegvA.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structHnGXhmegvA.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structHnNLvYqbMR.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structHnNLvYqbMR.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structHt9F9jtMD0.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structHt9F9jtMD0.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structHusaUbKJVm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structHusaUbKJVm.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structHvGrPaR9Bu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structHvGrPaR9Bu.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structHvI693MHyM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structHvI693MHyM.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structHyrFeqyBCY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structHyrFeqyBCY.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structHzJtxAljeg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structHzJtxAljeg.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structI2aSLtV0nK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structI2aSLtV0nK.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structI5QO2BUMxk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structI5QO2BUMxk.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structI6BZQjT6lx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structI6BZQjT6lx.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structICD2Fjdvwq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structICD2Fjdvwq.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structIHkMJI02Cs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structIHkMJI02Cs.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structIJpxdh5h1j.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structIJpxdh5h1j.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structIKVPnPqtVG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structIKVPnPqtVG.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structIODsh0cyAj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structIODsh0cyAj.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structIWnVfC7bMR.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structIWnVfC7bMR.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structIg48IJ1BGz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structIg48IJ1BGz.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structIjpYds4lWa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structIjpYds4lWa.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structImqfRF5u5d.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structImqfRF5u5d.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structIpNWKHAjIK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structIpNWKHAjIK.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structIq2IxAwTbz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structIq2IxAwTbz.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structIqjoEWN5a6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structIqjoEWN5a6.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structJ1WoVnmoNK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structJ1WoVnmoNK.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structJ4N4ApAuNd.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structJ4N4ApAuNd.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structJ4sxZ95hzs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structJ4sxZ95hzs.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structJ5ThymSmBk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structJ5ThymSmBk.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structJBdaFHCitX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structJBdaFHCitX.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structJBjYKH35Id.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structJBjYKH35Id.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structJEL7o5TRHh.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structJEL7o5TRHh.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structJFU1xlKVwi.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structJFU1xlKVwi.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structJIOp0LkuGx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structJIOp0LkuGx.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structJKSxRHdkgU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structJKSxRHdkgU.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structJLl1JS3EBA.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structJLl1JS3EBA.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structJPod17bl3h.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structJPod17bl3h.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structJSkoDJdEmy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structJSkoDJdEmy.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structJXZ8aT3Z1A.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structJXZ8aT3Z1A.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structJYFDwGezZu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structJYFDwGezZu.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structJZBOzjdChs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structJZBOzjdChs.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structJcJCwPR9O6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structJcJCwPR9O6.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structJdaXHv9XGK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structJdaXHv9XGK.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structJguJlpO2Zx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structJguJlpO2Zx.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structJjOrVxY09U.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structJjOrVxY09U.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structJmS6AEcW3Z.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structJmS6AEcW3Z.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structJmgvdzeb5n.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structJmgvdzeb5n.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structJt6jf8vpBs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structJt6jf8vpBs.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structJyoG3utfUF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structJyoG3utfUF.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structK17aJaWFKp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structK17aJaWFKp.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structK6zBHvtXEz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structK6zBHvtXEz.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structK8yLeG1Rq8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structK8yLeG1Rq8.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structKAGtyEb0Mc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structKAGtyEb0Mc.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structKBZsUWVDxs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structKBZsUWVDxs.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structKD97Jf4W3S.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structKD97Jf4W3S.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structKDBDsZNe9Z.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structKDBDsZNe9Z.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structKDWeAZ2IPn.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structKDWeAZ2IPn.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structKF4sn2PYXa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structKF4sn2PYXa.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structKHnzHYYQv9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structKHnzHYYQv9.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structKJhvJs3EGG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structKJhvJs3EGG.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structKLSPh0PXhl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structKLSPh0PXhl.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structKNZX9fxtdl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structKNZX9fxtdl.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structKS9Hbi6AwZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structKS9Hbi6AwZ.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structKVlfLjDmn1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structKVlfLjDmn1.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structKX2JHsJ0bd.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structKX2JHsJ0bd.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structKkESsYkID7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structKkESsYkID7.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structKkHcnJvU6l.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structKkHcnJvU6l.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structKkvn2ffBgz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structKkvn2ffBgz.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structKxmFSKOkr0.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structKxmFSKOkr0.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structL0iuHiXIxa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structL0iuHiXIxa.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structL28FwCaWlq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structL28FwCaWlq.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structL3YlcXIU3G.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structL3YlcXIU3G.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structL5PAA2Y49o.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structL5PAA2Y49o.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structL8rTw5Q3JI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structL8rTw5Q3JI.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structLJsbrcp1QV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structLJsbrcp1QV.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structLKxIRREq4D.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structLKxIRREq4D.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structLMQlSHV6GT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structLMQlSHV6GT.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structLV2nB9GvAz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structLV2nB9GvAz.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structLa1OJDLBp5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structLa1OJDLBp5.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structLcNNHqG92U.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structLcNNHqG92U.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structLnY2DL1Mbw.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structLnY2DL1Mbw.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structLpxoYUnOy7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structLpxoYUnOy7.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structLs7CLvlkgi.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structLs7CLvlkgi.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structLtMZ0XaStC.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structLtMZ0XaStC.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structLy4yvDjUuQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structLy4yvDjUuQ.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structM9DKZGOLDg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structM9DKZGOLDg.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structMBndhRFxei.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structMBndhRFxei.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structMEcvkINwlN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structMEcvkINwlN.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structMFY7puSlGX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structMFY7puSlGX.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structMQnq3Fo18k.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structMQnq3Fo18k.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structMRN9c8EZAu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structMRN9c8EZAu.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structMSaXkM98gx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structMSaXkM98gx.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structMe4GO0lmyL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structMe4GO0lmyL.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structMf7H2FRsCR.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structMf7H2FRsCR.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structMgFMQz9tN4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structMgFMQz9tN4.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structMhWZ76XLqK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structMhWZ76XLqK.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structMiv3889DlT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structMiv3889DlT.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structMkNnqyG9Tl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structMkNnqyG9Tl.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structMw7h6zUCoS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structMw7h6zUCoS.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structN5CGh6EWiK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structN5CGh6EWiK.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structN86zzxZWL3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structN86zzxZWL3.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structN9VLieAgkB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structN9VLieAgkB.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structNB005jf6q4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structNB005jf6q4.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structNW2O8zaFJU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structNW2O8zaFJU.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structNXVElSFyJY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structNXVElSFyJY.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structNXkTPXgNCQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structNXkTPXgNCQ.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structNYxtIN1k6X.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structNYxtIN1k6X.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structNcunqydrcp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structNcunqydrcp.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structNfG8poVmRX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structNfG8poVmRX.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structNpSaGkUh99.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structNpSaGkUh99.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structNphpYJarez.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structNphpYJarez.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structNq8WSpQa6r.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structNq8WSpQa6r.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structNuHNDIZUYr.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structNuHNDIZUYr.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structO4Kr2Vp6iB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structO4Kr2Vp6iB.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structO5SpO4Lmqy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structO5SpO4Lmqy.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structO6aBEtLHCl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structO6aBEtLHCl.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structO8aC92gkJu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structO8aC92gkJu.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structOAXjhVxHVW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structOAXjhVxHVW.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structOBggRrGGeA.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structOBggRrGGeA.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structOCKiZ8XvN4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structOCKiZ8XvN4.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structOTagHf6dta.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structOTagHf6dta.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structOmPR4GDmha.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structOmPR4GDmha.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structOnU7Y1iyOW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structOnU7Y1iyOW.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structOruSh6IU68.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structOruSh6IU68.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structP07kLcgWy2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structP07kLcgWy2.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structP0hi03Yr5J.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structP0hi03Yr5J.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structP51IT0iQls.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structP51IT0iQls.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structPC53CFAahl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structPC53CFAahl.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structPDETEBub2B.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structPDETEBub2B.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structPIEO17rXv3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structPIEO17rXv3.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structPL1Vy8gAQG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structPL1Vy8gAQG.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structPOAJbOn5yN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structPOAJbOn5yN.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structPWOGZtzGIy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structPWOGZtzGIy.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structPWOtvXxst0.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structPWOtvXxst0.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structPaMBWeOEZb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structPaMBWeOEZb.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structPbViqUkC9s.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structPbViqUkC9s.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structPjXLhVCSo2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structPjXLhVCSo2.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structPmsSWhVFlx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structPmsSWhVFlx.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structPvttwCSove.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structPvttwCSove.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structPy7auxT2wm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structPy7auxT2wm.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structPzKBHCX9aj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structPzKBHCX9aj.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structQ1lt85NZkv.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structQ1lt85NZkv.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structQ9W3v3dQYW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structQ9W3v3dQYW.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structQBpF2mc1un.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structQBpF2mc1un.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structQLoTxIicfl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structQLoTxIicfl.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structQNBjmFEISk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structQNBjmFEISk.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structQRNlszU7N1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structQRNlszU7N1.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structQRrZvgSvEl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structQRrZvgSvEl.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structQu8eKSWeIJ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structQu8eKSWeIJ.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structQwjx7jDCDX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structQwjx7jDCDX.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structQwri7Ax9TK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structQwri7Ax9TK.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structR4xaEYdpRY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structR4xaEYdpRY.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structR6bsgVIYE6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structR6bsgVIYE6.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structR6j965l6JZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structR6j965l6JZ.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structR6yPnOD0oz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structR6yPnOD0oz.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structR8eEQpI0YT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structR8eEQpI0YT.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structRBr9HNIGgm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structRBr9HNIGgm.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structRBwjivoMMP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structRBwjivoMMP.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structRFFK9pIT93.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structRFFK9pIT93.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structRJYj3K0a3c.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structRJYj3K0a3c.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structRLhaWW9haz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structRLhaWW9haz.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structRSckKIVPNO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structRSckKIVPNO.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structRX7hJYzEEc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structRX7hJYzEEc.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structRbEgtyrBAH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structRbEgtyrBAH.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structRbgB04HmL4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structRbgB04HmL4.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structRdgEVFWPU8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structRdgEVFWPU8.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structRjYd0rym9S.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structRjYd0rym9S.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structRpd0ErOBb6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structRpd0ErOBb6.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structRtcf0YV8fO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structRtcf0YV8fO.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structRtjThoUz7H.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structRtjThoUz7H.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structRyTk5RxJJO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structRyTk5RxJJO.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structS1RhuauboU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structS1RhuauboU.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structS6bmXaMMyl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structS6bmXaMMyl.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structSDPIMkAwH8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structSDPIMkAwH8.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structSEmAsgVkk9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structSEmAsgVkk9.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structSIfHQocAM7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structSIfHQocAM7.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structSL3XN9PByF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structSL3XN9PByF.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structSOJZorG6h4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structSOJZorG6h4.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structSOQ2b3Trj9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structSOQ2b3Trj9.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structSOcWqfVVcP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structSOcWqfVVcP.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structSUuI5kWBPQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structSUuI5kWBPQ.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structSWz0ZdY1fL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structSWz0ZdY1fL.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structSXB5wflpQj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structSXB5wflpQj.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structSaCKmxwW7X.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structSaCKmxwW7X.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structSkgZGVkxzj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structSkgZGVkxzj.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structSuSfIvUv2A.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structSuSfIvUv2A.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structSuaJbDOn73.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structSuaJbDOn73.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structSv55DLNwHy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structSv55DLNwHy.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structSvXjwmwWp8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structSvXjwmwWp8.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structT024qoIGBu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structT024qoIGBu.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structT396ygje53.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structT396ygje53.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structTA8Sp22K2U.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structTA8Sp22K2U.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structTGF07uM1y9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structTGF07uM1y9.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structTKbYYBx9QZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structTKbYYBx9QZ.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structTLyC86eODa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structTLyC86eODa.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structTSEu5hclTq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structTSEu5hclTq.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structTX5YCrOcOo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structTX5YCrOcOo.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structTX6rXf2RZh.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structTX6rXf2RZh.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structTaJbzfeDjo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structTaJbzfeDjo.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structTaYGLKdSM8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structTaYGLKdSM8.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structTgcZPmWOx2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structTgcZPmWOx2.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structTh5NbnUqzI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structTh5NbnUqzI.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structTknpxoQFvS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structTknpxoQFvS.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structTqu8KoZQjY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structTqu8KoZQjY.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structTuAcbBNnZm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structTuAcbBNnZm.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structTuWH3zeluv.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structTuWH3zeluv.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structTwjPuMKDiB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structTwjPuMKDiB.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structTxF88EuH4Q.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structTxF88EuH4Q.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structTzQ4rWvlZ3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structTzQ4rWvlZ3.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structU2kogkOlcf.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structU2kogkOlcf.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structU3dy6bkQcN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structU3dy6bkQcN.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structUA5Zgdsa4W.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structUA5Zgdsa4W.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structUC7urls6rG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structUC7urls6rG.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structUJ5RVg0xHN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structUJ5RVg0xHN.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structUL0XgKUiea.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structUL0XgKUiea.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structUYdnQvYvKk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structUYdnQvYvKk.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structUaTPRyIwWQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structUaTPRyIwWQ.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structUgp6Bg804O.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structUgp6Bg804O.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structUgsqUT0Fw8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structUgsqUT0Fw8.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structUomjJGDhS3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structUomjJGDhS3.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structUrJ7tMPYdi.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structUrJ7tMPYdi.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structUsGUm5feCJ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structUsGUm5feCJ.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structUx6sDnae6o.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structUx6sDnae6o.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structUyBELJkxhd.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structUyBELJkxhd.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structV1mFMqHDyz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structV1mFMqHDyz.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structV3DEOjYkAI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structV3DEOjYkAI.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structV4EcMh64Nu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structV4EcMh64Nu.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structVABFQlbdB8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structVABFQlbdB8.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structVCKWE5qXDQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structVCKWE5qXDQ.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structVF3eV6RT5A.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structVF3eV6RT5A.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structVGVFt2H4Jq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structVGVFt2H4Jq.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structVHmibu21U1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structVHmibu21U1.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structVJQMEbTTcW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structVJQMEbTTcW.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structVW9Wugrq8f.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structVW9Wugrq8f.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structVbui9U8nJN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structVbui9U8nJN.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structVqmZxmYjrS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structVqmZxmYjrS.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structVwumd12dMR.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structVwumd12dMR.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structW03TuqLzYH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structW03TuqLzYH.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structW6NGdR4FHA.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structW6NGdR4FHA.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structW8RwEte1K1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structW8RwEte1K1.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structWFr5O7xRwi.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structWFr5O7xRwi.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structWJw9ZLP7fK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structWJw9ZLP7fK.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structWODpD4eAmE.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structWODpD4eAmE.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structWOGNQBbIW7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structWOGNQBbIW7.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structWQN1KyUD5b.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structWQN1KyUD5b.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structWTDgYPieK1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structWTDgYPieK1.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structWVtboPH1aE.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structWVtboPH1aE.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structWiPM4vCvbR.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structWiPM4vCvbR.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structWk1zWo8r9K.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structWk1zWo8r9K.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structWkYOcVuG9r.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structWkYOcVuG9r.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structWqKLr6PuT3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structWqKLr6PuT3.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structWyFaNRxWDU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structWyFaNRxWDU.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structX0tLJiI6QS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structX0tLJiI6QS.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structX74WdLPgP3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structX74WdLPgP3.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structXLePVWtJFS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structXLePVWtJFS.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structXNJAbmwEpz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structXNJAbmwEpz.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structXOlFj8WTWU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structXOlFj8WTWU.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structXQpY9eJk4m.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structXQpY9eJk4m.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structXU2GzBHEnm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structXU2GzBHEnm.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structXWIUjIMjuc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structXWIUjIMjuc.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structXYOl2gpZhZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structXYOl2gpZhZ.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structXYrXq7Kz5O.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structXYrXq7Kz5O.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structXab1L6RKkc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structXab1L6RKkc.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structXcQSZS9Pq3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structXcQSZS9Pq3.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structXdOq3rooU7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structXdOq3rooU7.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structXpfvMzo3SU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structXpfvMzo3SU.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structXs0m0HB3Ve.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structXs0m0HB3Ve.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structXsoVym5xGF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structXsoVym5xGF.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structXxbrxyvfJK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structXxbrxyvfJK.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structY0sbuM1lf1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structY0sbuM1lf1.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structY2WI2qZBJc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structY2WI2qZBJc.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structY3MSP8GJLq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structY3MSP8GJLq.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structY7ZzgHzGVw.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structY7ZzgHzGVw.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structY8HkjRfwpg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structY8HkjRfwpg.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structYAzsftuDhx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structYAzsftuDhx.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structYE37gD7DoN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structYE37gD7DoN.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structYNODMJt0nI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structYNODMJt0nI.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structYOoQMQYEZo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structYOoQMQYEZo.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structYPtr2Dr86B.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structYPtr2Dr86B.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structYXRqKm5H9U.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structYXRqKm5H9U.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structYa2X1A0XlS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structYa2X1A0XlS.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structYj7TbLsdP4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structYj7TbLsdP4.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structYlF6RxCqVs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structYlF6RxCqVs.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structYo1jTzfuKl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structYo1jTzfuKl.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structYrew2qdBuH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structYrew2qdBuH.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structYwZwDfIvIG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structYwZwDfIvIG.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structZ3DY5gvzFY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structZ3DY5gvzFY.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structZBrvC38b8N.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structZBrvC38b8N.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structZC6ZaapQdD.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structZC6ZaapQdD.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structZGNK9Twr9S.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structZGNK9Twr9S.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structZGqp2bRDtx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structZGqp2bRDtx.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structZJSKolxfqc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structZJSKolxfqc.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structZR3LiJX7PO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structZR3LiJX7PO.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structZW26HGLchP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structZW26HGLchP.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structZi1RqmdSol.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structZi1RqmdSol.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structZoimFj6xEE.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structZoimFj6xEE.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structZpfDnRPksn.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structZpfDnRPksn.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structZr2k5TeLcE.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structZr2k5TeLcE.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structZtqbbnQjzj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structZtqbbnQjzj.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structZupKEHABUk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structZupKEHABUk.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structa0AhWFAoDG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structa0AhWFAoDG.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structa5eW784LQf.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structa5eW784LQf.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structa6BXYQAwEm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structa6BXYQAwEm.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structa6bL6toTDQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structa6bL6toTDQ.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structa85eS8wvGC.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structa85eS8wvGC.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structaBCMiwiL14.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structaBCMiwiL14.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structaCvUpfrOud.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structaCvUpfrOud.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structaMVAJ9INz0.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structaMVAJ9INz0.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structaNX02HPg7T.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structaNX02HPg7T.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structaacjP2BYDY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structaacjP2BYDY.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structafSLEQGtjb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structafSLEQGtjb.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structawZmlvXiXW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structawZmlvXiXW.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structaxV4fiWwZ7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structaxV4fiWwZ7.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structayNEhBBg4t.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structayNEhBBg4t.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structb265yb0csM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structb265yb0csM.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structb63fAzKNR7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structb63fAzKNR7.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structbBsug1Wd34.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structbBsug1Wd34.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structbNMyvNH8WM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structbNMyvNH8WM.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structbX4S27LXkH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structbX4S27LXkH.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structblpexlSs9M.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structblpexlSs9M.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structbmmnw9qu32.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structbmmnw9qu32.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structbsrrxTZOqn.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structbsrrxTZOqn.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structbtgnPXO5Rq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structbtgnPXO5Rq.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structbwtswCbHZn.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structbwtswCbHZn.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structc0ARtdYgED.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structc0ARtdYgED.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structc0K76QtGvt.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structc0K76QtGvt.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structc19BIAaEkY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structc19BIAaEkY.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structcIUFEZhrle.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structcIUFEZhrle.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structcU51DXcyE8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structcU51DXcyE8.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structcbnz0kvIwn.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structcbnz0kvIwn.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structcfbnUeCgbt.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structcfbnUeCgbt.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structcjMmD9Dwfx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structcjMmD9Dwfx.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structclmVkpAhb8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structclmVkpAhb8.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structcoAqE1boX6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structcoAqE1boX6.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structcormXUf4WS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structcormXUf4WS.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structcqdGRq2WNh.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structcqdGRq2WNh.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structczOiELiAB7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structczOiELiAB7.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structd2ojXxCaNW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structd2ojXxCaNW.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structd4OcbMDcGL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structd4OcbMDcGL.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structd9nB4x1U6u.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structd9nB4x1U6u.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structdEhJcrsORt.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structdEhJcrsORt.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structdKBNYvwyxK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structdKBNYvwyxK.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structdNGVHIlzAj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structdNGVHIlzAj.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structdSftno00MK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structdSftno00MK.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structdXZpHpuk3x.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structdXZpHpuk3x.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structdXgIF94ebo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structdXgIF94ebo.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structdhEH1P8yDX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structdhEH1P8yDX.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structdq0ytTGdT7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structdq0ytTGdT7.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structdr28D0z5ZH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structdr28D0z5ZH.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structe4z2kYEwsw.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structe4z2kYEwsw.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structe79Za4b7Ml.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structe79Za4b7Ml.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structeJF56nvsEj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structeJF56nvsEj.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structeW6hiVZjD9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structeW6hiVZjD9.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structegI0J6pwbq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structegI0J6pwbq.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structemjd05RWc3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structemjd05RWc3.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structeqBjnWgb5P.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structeqBjnWgb5P.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structf0akg4gumK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structf0akg4gumK.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structf32Rx1NpEm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structf32Rx1NpEm.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structf3hg4Duqet.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structf3hg4Duqet.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structf74ThK893J.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structf74ThK893J.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structfBkGsQBirP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structfBkGsQBirP.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structfCVtyydYxM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structfCVtyydYxM.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structfCayR9pma6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structfCayR9pma6.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structfG4ASdjUC9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structfG4ASdjUC9.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structfJdkVlyVac.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structfJdkVlyVac.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structfNnOzIDYzL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structfNnOzIDYzL.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structfOOjVzFOC9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structfOOjVzFOC9.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structfTXY9OU4mh.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structfTXY9OU4mh.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structfWEUc1K6FG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structfWEUc1K6FG.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structfYJ2Mkk1al.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structfYJ2Mkk1al.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structfcg2UqwprF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structfcg2UqwprF.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structfd0mCQVHBl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structfd0mCQVHBl.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structfwecOIJDmQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structfwecOIJDmQ.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structgBuG9DjtOU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structgBuG9DjtOU.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structgIAdPMClq9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structgIAdPMClq9.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structgJaEzQzHlG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structgJaEzQzHlG.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structgTI819u8oK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structgTI819u8oK.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structgaVRwvBYOY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structgaVRwvBYOY.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structgmDuxmO8uQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structgmDuxmO8uQ.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structgnTh8YZCI4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structgnTh8YZCI4.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structgnzwfueLCU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structgnzwfueLCU.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structgodJTvsSrL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structgodJTvsSrL.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structgoyNOloADC.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structgoyNOloADC.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structgrMFKxp6Rp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structgrMFKxp6Rp.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structgu5AmoUnKH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structgu5AmoUnKH.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structgw0RpMV2f4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structgw0RpMV2f4.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structgzPFVO95T5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structgzPFVO95T5.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structh0wIvbjPFM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structh0wIvbjPFM.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structh0zYLuKys0.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structh0zYLuKys0.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structh4borQn8tt.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structh4borQn8tt.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structhEYyOpWNQA.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structhEYyOpWNQA.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structhKVOXTzhtj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structhKVOXTzhtj.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structhP7CI8CVIx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structhP7CI8CVIx.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structhRp6BjrXlq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structhRp6BjrXlq.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structhXluAaYGUP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structhXluAaYGUP.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structhc5U7IjcZc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structhc5U7IjcZc.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structhjYDoXKd1y.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structhjYDoXKd1y.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structhk5xXOFY3B.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structhk5xXOFY3B.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structhlXXNdntjL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structhlXXNdntjL.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structhnljKmvH1S.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structhnljKmvH1S.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structhsMP7WDnTb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structhsMP7WDnTb.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structi5tx16f99j.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structi5tx16f99j.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structi60i9flgEl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structi60i9flgEl.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structiGcBGhWkFg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structiGcBGhWkFg.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structiH2t1AudUv.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structiH2t1AudUv.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structiJO3yTUlA6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structiJO3yTUlA6.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structiMxQrDbyMm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structiMxQrDbyMm.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structiRTC8Ri5hh.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structiRTC8Ri5hh.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structiUTYiuw7nL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structiUTYiuw7nL.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structifVuZi4Efe.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structifVuZi4Efe.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structigySx6ywF4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structigySx6ywF4.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structimk6k6ZOQP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structimk6k6ZOQP.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structiyfYt6St4H.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structiyfYt6St4H.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structj0Jp6zlUkb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structj0Jp6zlUkb.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structj2noj6YBli.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structj2noj6YBli.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structj80X6OAWFM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structj80X6OAWFM.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structjATzvt82Yc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structjATzvt82Yc.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structjHYdKd1qGS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structjHYdKd1qGS.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structjIn9JVMI49.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structjIn9JVMI49.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structjKvkQzPnI2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structjKvkQzPnI2.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structjPeWDdzelT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structjPeWDdzelT.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structjVynlgrJOg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structjVynlgrJOg.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structjXzq5dAQfq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structjXzq5dAQfq.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structjlEQy1XgIm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structjlEQy1XgIm.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structjpZYztDGZv.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structjpZYztDGZv.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structjyzBmrWLpD.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structjyzBmrWLpD.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structjzLZ1Fd1su.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structjzLZ1Fd1su.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structk0RWOtD4Cb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structk0RWOtD4Cb.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structk5uhI551Ib.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structk5uhI551Ib.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structkBpo9DUgjg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structkBpo9DUgjg.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structkKCqpBwgSB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structkKCqpBwgSB.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structkMn4TDNnDw.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structkMn4TDNnDw.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structkTDa7zOTTq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structkTDa7zOTTq.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structkcnuBfgvqB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structkcnuBfgvqB.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structke5R4wNmaV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structke5R4wNmaV.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structkgOVznysHS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structkgOVznysHS.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structkjR2PqZPCx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structkjR2PqZPCx.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structkjvkPYElx2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structkjvkPYElx2.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structko3HKcubO4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structko3HKcubO4.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structl1rwee6A0W.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structl1rwee6A0W.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structl9GK15NFfI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structl9GK15NFfI.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structl9dEcAYjZX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structl9dEcAYjZX.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structlCbFTLeEcO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structlCbFTLeEcO.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structlFoUTH7TGY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structlFoUTH7TGY.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structlFuagxP4pj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structlFuagxP4pj.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structlKqlZNIiTG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structlKqlZNIiTG.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structlM9nCK9mVa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structlM9nCK9mVa.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structlNxcettVbW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structlNxcettVbW.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structlOMWejTcie.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structlOMWejTcie.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structlPPzP90v2M.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structlPPzP90v2M.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structlWE7ijbTPg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structlWE7ijbTPg.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structlWZpr8mFUz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structlWZpr8mFUz.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structlfb6Bcmyzv.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structlfb6Bcmyzv.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structliZR39PG4B.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structliZR39PG4B.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structlilo17vqrO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structlilo17vqrO.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structlmBHuI2CdK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structlmBHuI2CdK.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structlsRnaxudRi.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structlsRnaxudRi.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structlwBBVufID9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structlwBBVufID9.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structmE7fFfuHjx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structmE7fFfuHjx.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structmPX6OOh4Nl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structmPX6OOh4Nl.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structmR2t9GgAZ5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structmR2t9GgAZ5.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structmU9k8N2S1x.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structmU9k8N2S1x.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structmUQioQKiXp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structmUQioQKiXp.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structmWBF30udKT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structmWBF30udKT.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structmaUySacG7e.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structmaUySacG7e.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structmj4Oyb3GgX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structmj4Oyb3GgX.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structmuAhuD4KVQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structmuAhuD4KVQ.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structmwjaO3Uyrs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structmwjaO3Uyrs.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structn5h1DHBxub.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structn5h1DHBxub.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structnAdqmBnbeg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structnAdqmBnbeg.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structnAvYhH07Gs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structnAvYhH07Gs.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structnHnX8P1WDq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structnHnX8P1WDq.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structnNkjJDcz0P.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structnNkjJDcz0P.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structnPwZk9I7YN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structnPwZk9I7YN.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structnUJfW4NMaA.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structnUJfW4NMaA.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structnXMZUp9V4V.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structnXMZUp9V4V.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structnjkuDZnOoQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structnjkuDZnOoQ.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structnq8k7vNWX3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structnq8k7vNWX3.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structnrVsGpyHSB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structnrVsGpyHSB.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structnsGvdkMRFZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structnsGvdkMRFZ.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structoAhXI74h9j.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structoAhXI74h9j.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structoahbTSUqku.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structoahbTSUqku.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structoiRn4GygF9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structoiRn4GygF9.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structov6aJQLXqu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structov6aJQLXqu.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structovm1h7N1tD.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structovm1h7N1tD.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structoypCXXMXYK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structoypCXXMXYK.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structp39x1W6Nmw.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structp39x1W6Nmw.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structp5F0SqEi1N.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structp5F0SqEi1N.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structpK1zdl2ooH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structpK1zdl2ooH.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structpLXABe2wJc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structpLXABe2wJc.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structpMr2v6juAQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structpMr2v6juAQ.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structpXZA41Y8fK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structpXZA41Y8fK.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structpkIouuiKqe.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structpkIouuiKqe.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structpnMhTmK3QH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structpnMhTmK3QH.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structpuA2r64pbW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structpuA2r64pbW.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structpwCAT0hshK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structpwCAT0hshK.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structq1BEWkecYX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structq1BEWkecYX.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structq2gqs38KnH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structq2gqs38KnH.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structq5OjZ10BEs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structq5OjZ10BEs.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structqGa10MSSRs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structqGa10MSSRs.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structqGuE1lEn2E.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structqGuE1lEn2E.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structqK7XKTZI6a.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structqK7XKTZI6a.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structqRtOraogqy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structqRtOraogqy.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structqTdD25cQMq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structqTdD25cQMq.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structqVenFBZMmB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structqVenFBZMmB.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structqVymoyiTzO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structqVymoyiTzO.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structqYoMOdyW5o.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structqYoMOdyW5o.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structqZqGFZMAp0.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structqZqGFZMAp0.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structqceTFkotG1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structqceTFkotG1.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structqklsh0VtCj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structqklsh0VtCj.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structqkwGFodzYo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structqkwGFodzYo.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structqlynSYPIzj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structqlynSYPIzj.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structqmylEQUQxN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structqmylEQUQxN.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structqsdnJQvtod.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structqsdnJQvtod.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structr1IUWdH7kS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structr1IUWdH7kS.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structrDLhl5fFyI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structrDLhl5fFyI.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structrJ6A29EFD3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structrJ6A29EFD3.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structrLI0qkdwNT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structrLI0qkdwNT.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structrNNNMoMUX5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structrNNNMoMUX5.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structrQyjIvxeGC.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structrQyjIvxeGC.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structrUZIsQzLzo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structrUZIsQzLzo.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structrUrNNgGYxl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structrUrNNgGYxl.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structrZORE7saci.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structrZORE7saci.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structrnEvXbtOaJ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structrnEvXbtOaJ.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structrv6cJ7e4eI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structrv6cJ7e4eI.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structrvnG4DB0O9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structrvnG4DB0O9.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structrxuRIzLrOd.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structrxuRIzLrOd.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structs0wKthNJDH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structs0wKthNJDH.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structs6tlj8Ujb6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structs6tlj8Ujb6.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structs81xiTr3V2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structs81xiTr3V2.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structs9FC686ssT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structs9FC686ssT.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structsU7ru1S3Bn.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structsU7ru1S3Bn.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structsconExg82n.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structsconExg82n.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structsnl6YWFzw6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structsnl6YWFzw6.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structsr11hihvVP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structsr11hihvVP.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structsrFnuySLJZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structsrFnuySLJZ.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structsyMjE23XYL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structsyMjE23XYL.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structt1zhtoy3QG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structt1zhtoy3QG.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structt3vc10gLez.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structt3vc10gLez.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structt7Y6XwomUH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structt7Y6XwomUH.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structtFfTsyMFtj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structtFfTsyMFtj.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structtKTQH67TAx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structtKTQH67TAx.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structtRnRKY1Nt9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structtRnRKY1Nt9.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structtVv0gLLUw6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structtVv0gLLUw6.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structtdu9UH9BR6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structtdu9UH9BR6.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structtkLijaINDB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structtkLijaINDB.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structtmi3Y4xjWJ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structtmi3Y4xjWJ.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structtoRHBeshpF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structtoRHBeshpF.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structtoojZOxzYL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structtoojZOxzYL.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structuEWock0xfg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structuEWock0xfg.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structuYFS57GpEz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structuYFS57GpEz.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structuZLTFqoTc9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structuZLTFqoTc9.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structuesCCsCmB9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structuesCCsCmB9.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structuk9n40Ba1s.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structuk9n40Ba1s.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structurOByRIJr5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structurOByRIJr5.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structusM7i9eFda.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structusM7i9eFda.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structuzTdZWiu60.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structuzTdZWiu60.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structv4jF52UQ9H.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structv4jF52UQ9H.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structv9bmg59CEV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structv9bmg59CEV.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structvE6YTruKB5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structvE6YTruKB5.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structvGYXxaXkfO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structvGYXxaXkfO.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structvIiPiag0AP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structvIiPiag0AP.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structvJXxV1TNGG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structvJXxV1TNGG.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structvLrhLw24Yo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structvLrhLw24Yo.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structvPLGLtUGvc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structvPLGLtUGvc.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structvQ4tBtsFIQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structvQ4tBtsFIQ.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structvetTPo8phL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structvetTPo8phL.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structvh6HUMxCO1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structvh6HUMxCO1.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structvhPOJekCB6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structvhPOJekCB6.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structvqpjGCBNgC.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structvqpjGCBNgC.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structw1Jcuo2qcB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structw1Jcuo2qcB.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structw1LUTeHkEP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structw1LUTeHkEP.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structw704rOrUeD.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structw704rOrUeD.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structwAVE8pzuIw.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structwAVE8pzuIw.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structwE9USHmMoa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structwE9USHmMoa.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structwKyV6c3NXx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structwKyV6c3NXx.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structwNNWk20409.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structwNNWk20409.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structwPjsuxb7PR.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structwPjsuxb7PR.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structwquRams9Fs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structwquRams9Fs.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structwyz9cVcdwh.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structwyz9cVcdwh.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structx29mgYMw04.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structx29mgYMw04.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structx9kDs7ICzW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structx9kDs7ICzW.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structxFTWeVz86X.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structxFTWeVz86X.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structxI8aw5DOBf.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structxI8aw5DOBf.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structxKJxcMqgXp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structxKJxcMqgXp.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structxSyTOLVs2a.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structxSyTOLVs2a.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structxY83QlHYu8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structxY83QlHYu8.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structxatoIPHwut.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structxatoIPHwut.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structxayiSk9poY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structxayiSk9poY.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structxl0tHilNDj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structxl0tHilNDj.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structxpKM8hQmHX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structxpKM8hQmHX.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structxrKKgR1Fe1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structxrKKgR1Fe1.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structxsR9aAsAXm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structxsR9aAsAXm.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structxwNsI8Zdb1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structxwNsI8Zdb1.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structy2eHpFGRr5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structy2eHpFGRr5.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structy5X9cuxDIn.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structy5X9cuxDIn.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structy5wbr5f4bB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structy5wbr5f4bB.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structyAGnaq1EBc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structyAGnaq1EBc.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structyGjRe5am7c.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structyGjRe5am7c.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structyKsJfDGXaz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structyKsJfDGXaz.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structyNBvxKIcti.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structyNBvxKIcti.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structyPEdNMH6Lo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structyPEdNMH6Lo.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structyTmtkFKqd7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structyTmtkFKqd7.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structydbIqe0qPo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structydbIqe0qPo.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structyhDvAbXvCv.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structyhDvAbXvCv.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structynitZhhUeJ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structynitZhhUeJ.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structyvVgkdYRXO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structyvVgkdYRXO.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structz1JgTXpAuI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structz1JgTXpAuI.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structz7dfzzL9Yk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structz7dfzzL9Yk.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structzIXefsJFSz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structzIXefsJFSz.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structzPWDt4oN6i.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structzPWDt4oN6i.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structzQUyc7Ws0e.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structzQUyc7Ws0e.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structzTIpN6ALMu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structzTIpN6ALMu.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structzYoD4xKxnZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structzYoD4xKxnZ.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structzdXNEcof9V.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structzdXNEcof9V.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structzo3owhla9x.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structzo3owhla9x.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structzyowJj76a6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v4.8/readonly-partial-structzyowJj76a6.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct00oieaoYA5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct00oieaoYA5.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct05nZxSvOQy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct05nZxSvOQy.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct0CW6rWihRa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct0CW6rWihRa.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct0EiiHjJ0Jy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct0EiiHjJ0Jy.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct0HxVdkFuDk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct0HxVdkFuDk.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct0Sp8nFf9po.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct0Sp8nFf9po.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct0YOigHUonk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct0YOigHUonk.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct0mu68DyXFS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct0mu68DyXFS.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct0oZl05ifoL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct0oZl05ifoL.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct101P28DC6b.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct101P28DC6b.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct109xwVU7na.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct109xwVU7na.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct13ZLCuuDdg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct13ZLCuuDdg.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct164v5M7Oiu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct164v5M7Oiu.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct16i8Hnvzik.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct16i8Hnvzik.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct1B64P2KJTT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct1B64P2KJTT.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct1FLNprzFfg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct1FLNprzFfg.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct1Lodf8jQhi.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct1Lodf8jQhi.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct1NM3qeUh2p.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct1NM3qeUh2p.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct1QKloRyprM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct1QKloRyprM.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct1TeundtXb1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct1TeundtXb1.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct1e9vZ2ZVVl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct1e9vZ2ZVVl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct1ibkpE2U9t.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct1ibkpE2U9t.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct1jAvJkz71q.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct1jAvJkz71q.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct1kIcXqyaMm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct1kIcXqyaMm.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct1kIjvNmL26.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct1kIjvNmL26.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct1nopkP9yWt.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct1nopkP9yWt.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct1q3mpvDeuG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct1q3mpvDeuG.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct1rwcZsOxGm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct1rwcZsOxGm.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct1shpv6NmPc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct1shpv6NmPc.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct1tertRu9Xm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct1tertRu9Xm.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct1xSlrFoiE2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct1xSlrFoiE2.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct1xjEjG8zge.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct1xjEjG8zge.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct1zEPcP8TZ0.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct1zEPcP8TZ0.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct22wFvfGOQe.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct22wFvfGOQe.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct23OaGTh97N.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct23OaGTh97N.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct2C0v3cLs4t.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct2C0v3cLs4t.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct2Ii6Pytw94.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct2Ii6Pytw94.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct2KJvO9ifSa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct2KJvO9ifSa.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct2Oea4qEuqL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct2Oea4qEuqL.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct2PRjv73LUz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct2PRjv73LUz.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct2PlWXW13Oo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct2PlWXW13Oo.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct2RjyXdbOmS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct2RjyXdbOmS.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct2WJXBATRow.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct2WJXBATRow.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct2ePshLeWkH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct2ePshLeWkH.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct2iRAZCo7L5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct2iRAZCo7L5.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct2l1qlatawT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct2l1qlatawT.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct2lPhMAoDBl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct2lPhMAoDBl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct2mrBdiaAsD.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct2mrBdiaAsD.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct2yK9S7dzeX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct2yK9S7dzeX.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct2yeMfnvK5l.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct2yeMfnvK5l.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct34i0YswjFg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct34i0YswjFg.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct3AvV0e5RCv.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct3AvV0e5RCv.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct3Fkic0RvsS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct3Fkic0RvsS.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct3Q09CNhFqG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct3Q09CNhFqG.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct3W5X0ROtrE.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct3W5X0ROtrE.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct3YKEcUcTm6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct3YKEcUcTm6.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct3Ysql1aZTo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct3Ysql1aZTo.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct3aLcZ0Gzdp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct3aLcZ0Gzdp.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct3bQ2CbXXiG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct3bQ2CbXXiG.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct3hbQkh2oXr.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct3hbQkh2oXr.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct3o9W3tWIYr.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct3o9W3tWIYr.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct3oRAhgtPFs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct3oRAhgtPFs.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct3rEqyW20Ha.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct3rEqyW20Ha.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct3rh7agTF1u.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct3rh7agTF1u.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct3tAXhVgz0j.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct3tAXhVgz0j.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct3udOlsWezr.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct3udOlsWezr.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct3yavERh0QP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct3yavERh0QP.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct40R1V76roU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct40R1V76roU.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct44PftY660j.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct44PftY660j.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct46ykdVFGwG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct46ykdVFGwG.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct47pp9CzShs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct47pp9CzShs.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct49eWbTEG4e.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct49eWbTEG4e.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct4I0C5KiBcT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct4I0C5KiBcT.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct4NHzRc00m2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct4NHzRc00m2.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct4R1b3Sfk6J.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct4R1b3Sfk6J.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct4VkhuwJa8e.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct4VkhuwJa8e.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct4bA4rV4T7I.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct4bA4rV4T7I.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct4qOfIMBclV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct4qOfIMBclV.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct4tYHXfgnVZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct4tYHXfgnVZ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct4xCfXxpvdy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct4xCfXxpvdy.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct4zYtkggxX9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct4zYtkggxX9.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct566AUa8c9w.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct566AUa8c9w.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct5B3Ki66g8U.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct5B3Ki66g8U.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct5GIHfCnyF0.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct5GIHfCnyF0.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct5GXqW1XpIl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct5GXqW1XpIl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct5R3JtFMKyy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct5R3JtFMKyy.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct5WOnMXao7S.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct5WOnMXao7S.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct5WjoUCBC2W.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct5WjoUCBC2W.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct5YuboIIJis.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct5YuboIIJis.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct5coPgZ627S.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct5coPgZ627S.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct5nsLLrnYzS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct5nsLLrnYzS.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct5p0wzn3Twr.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct5p0wzn3Twr.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct5pUyGEiqRW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct5pUyGEiqRW.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct66VojQk1NI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct66VojQk1NI.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct67D9OX1YBs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct67D9OX1YBs.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct67XWJDtmLp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct67XWJDtmLp.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct6ACGifRdRw.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct6ACGifRdRw.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct6AkdgH06Lh.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct6AkdgH06Lh.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct6BWJO4ygCh.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct6BWJO4ygCh.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct6Eho6XNoOx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct6Eho6XNoOx.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct6Fnny4hIyl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct6Fnny4hIyl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct6GnahT2THT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct6GnahT2THT.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct6Gy1eE7iFg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct6Gy1eE7iFg.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct6InhhK3Bnx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct6InhhK3Bnx.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct6KaWm2V4so.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct6KaWm2V4so.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct6NVZQs4UrE.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct6NVZQs4UrE.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct6PUxZ29VTq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct6PUxZ29VTq.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct6fce05Qu1f.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct6fce05Qu1f.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct6tzbdxQpL4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct6tzbdxQpL4.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct763ixhZiPg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct763ixhZiPg.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct79tZSSX75b.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct79tZSSX75b.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct7E3RzOaVF1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct7E3RzOaVF1.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct7Ev4ba5U4g.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct7Ev4ba5U4g.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct7FkotSk0XD.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct7FkotSk0XD.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct7MpRJpjzYV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct7MpRJpjzYV.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct7UAHrFSXgp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct7UAHrFSXgp.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct7ZDRFK7C6w.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct7ZDRFK7C6w.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct7hWyxK9Im1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct7hWyxK9Im1.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct7vhsXm5Sqy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct7vhsXm5Sqy.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct7vwzjN2hQB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct7vwzjN2hQB.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct7x47kTkDWA.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct7x47kTkDWA.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct814BQq200G.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct814BQq200G.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct84TN7zjoK9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct84TN7zjoK9.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct8CllamWxHF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct8CllamWxHF.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct8KGpb7sMhV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct8KGpb7sMhV.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct8P1XTIrmCU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct8P1XTIrmCU.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct8eGauAG2Iy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct8eGauAG2Iy.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct8hD3MVC60I.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct8hD3MVC60I.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct8q0Jpdjx8u.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct8q0Jpdjx8u.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct8qIwjmR7oN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct8qIwjmR7oN.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct8tbcftbwF8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct8tbcftbwF8.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct8txOZ8smgu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct8txOZ8smgu.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct8yaeAzdZUO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct8yaeAzdZUO.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct98nsmL4Uyu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct98nsmL4Uyu.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct9CTRHeV5gV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct9CTRHeV5gV.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct9E3xYWs4gr.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct9E3xYWs4gr.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct9FbBK7sAEy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct9FbBK7sAEy.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct9HOIXHYhP9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct9HOIXHYhP9.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct9IzMME36Bl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct9IzMME36Bl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct9PLpEx4eEr.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct9PLpEx4eEr.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct9QX6aOMWmP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct9QX6aOMWmP.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct9XFvojKqS7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct9XFvojKqS7.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct9Z0NXJ0nuB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct9Z0NXJ0nuB.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct9cdQxj05PP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct9cdQxj05PP.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct9dJLrfdwrb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct9dJLrfdwrb.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct9fPHF2RcIG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct9fPHF2RcIG.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct9o9IQlJhfF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct9o9IQlJhfF.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct9rTJlJQ4St.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct9rTJlJQ4St.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct9tS75raz9v.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-struct9tS75raz9v.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structA0t67j1fxp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structA0t67j1fxp.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structA2y6S9lFjD.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structA2y6S9lFjD.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structA4N6i5eArl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structA4N6i5eArl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structA6J9ouYjJm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structA6J9ouYjJm.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structAB03r2H43b.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structAB03r2H43b.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structADRxlKyBIl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structADRxlKyBIl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structAE7oPkwYY6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structAE7oPkwYY6.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structAHdMDYZJaK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structAHdMDYZJaK.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structAK2drK1aH7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structAK2drK1aH7.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structAPZGaaiAsI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structAPZGaaiAsI.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structAQE2E9exgF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structAQE2E9exgF.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structAcoWvPhtlp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structAcoWvPhtlp.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structAiFfzJ9xOo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structAiFfzJ9xOo.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structAztsRhE0LF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structAztsRhE0LF.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structB9pN8GfUaU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structB9pN8GfUaU.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structBA8lKBvox6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structBA8lKBvox6.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structBBBafcZBl1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structBBBafcZBl1.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structBF8funmMCW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structBF8funmMCW.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structBNGrkk0Gq9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structBNGrkk0Gq9.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structBW4o7dJUoK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structBW4o7dJUoK.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structBWsRWzQ335.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structBWsRWzQ335.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structBfsVSixXGI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structBfsVSixXGI.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structBjERtQ98tj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structBjERtQ98tj.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structBjy5dZK2rM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structBjy5dZK2rM.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structBm7Ua0ACla.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structBm7Ua0ACla.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structBmz4OJxAlt.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structBmz4OJxAlt.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structBw3OKv2Qms.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structBw3OKv2Qms.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structBzSRBjnY22.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structBzSRBjnY22.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structC0g7V6d3fy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structC0g7V6d3fy.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structCBt0kIYRra.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structCBt0kIYRra.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structCOGSdZd0AL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structCOGSdZd0AL.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structCXeEkfG71q.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structCXeEkfG71q.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structCaHH2Xyhc7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structCaHH2Xyhc7.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structCcLnEruc0v.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structCcLnEruc0v.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structCfD3K5QvsN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structCfD3K5QvsN.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structCqQVJigrtI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structCqQVJigrtI.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structCzvlSZqJoZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structCzvlSZqJoZ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structD2oQVW5tnq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structD2oQVW5tnq.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structD4YplBwWDi.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structD4YplBwWDi.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structD9gno8tRvF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structD9gno8tRvF.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structDACFSZmJCd.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structDACFSZmJCd.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structDVPBdDC863.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structDVPBdDC863.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structDXFa0e4ozX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structDXFa0e4ozX.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structDZZWeqhEZS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structDZZWeqhEZS.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structDhEKpPXtbG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structDhEKpPXtbG.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structDi88qmJim6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structDi88qmJim6.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structDrIOG3dy4E.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structDrIOG3dy4E.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structE1izflhe7m.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structE1izflhe7m.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structE7tbP2KegJ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structE7tbP2KegJ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structECJjSKcI0x.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structECJjSKcI0x.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structECjdzNW2hb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structECjdzNW2hb.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structENNglh8DX6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structENNglh8DX6.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structEVUFJOsbyB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structEVUFJOsbyB.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structEa3Y8fmO5t.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structEa3Y8fmO5t.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structEbe6V1e8rk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structEbe6V1e8rk.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structEilgeng6RU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structEilgeng6RU.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structEjN7KM70nB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structEjN7KM70nB.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structEoc6yu6UZC.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structEoc6yu6UZC.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structEqZWhQIozu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structEqZWhQIozu.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structErRGvv06c5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structErRGvv06c5.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structEvFFf3fZGJ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structEvFFf3fZGJ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structEx5206L0wV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structEx5206L0wV.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structF3dNExh2mR.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structF3dNExh2mR.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structF8DhNrWv7E.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structF8DhNrWv7E.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structF9RjQ90jnp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structF9RjQ90jnp.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structFI3w6VQMfO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structFI3w6VQMfO.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structFJsonz9Nyz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structFJsonz9Nyz.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structFR85FzqbWk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structFR85FzqbWk.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structFXxZeDtCw5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structFXxZeDtCw5.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structFaTXoezJTa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structFaTXoezJTa.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structFhwETmltur.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structFhwETmltur.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structFjGw1Sgvhj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structFjGw1Sgvhj.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structFq1hfAwgHs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structFq1hfAwgHs.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structFvR9kgHTwq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structFvR9kgHTwq.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structFx3ViT9W1l.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structFx3ViT9W1l.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structG23iNFg5pV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structG23iNFg5pV.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structG4WvAWeyY2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structG4WvAWeyY2.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structG5eiJlW14L.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structG5eiJlW14L.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structG7DG28rR3I.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structG7DG28rR3I.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structG8t7pJyR0P.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structG8t7pJyR0P.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structGAhk4JD5f5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structGAhk4JD5f5.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structGElc6so5Vx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structGElc6so5Vx.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structGL3ENulfXA.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structGL3ENulfXA.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structGPgos6Ga6k.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structGPgos6Ga6k.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structGVka0u9TDq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structGVka0u9TDq.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structGXNEUsfHGV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structGXNEUsfHGV.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structGajQGzODLb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structGajQGzODLb.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structGbvlSI6ZFM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structGbvlSI6ZFM.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structGgvsKvoP9v.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structGgvsKvoP9v.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structGiiPLasS8y.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structGiiPLasS8y.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structGlUP6EKlOZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structGlUP6EKlOZ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structGmNuKgusEl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structGmNuKgusEl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structGnndCPLSRE.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structGnndCPLSRE.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structGseI8AQPtb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structGseI8AQPtb.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structGyODqQmfLk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structGyODqQmfLk.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structH5eQeBi4oY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structH5eQeBi4oY.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structH6F7xwrgKM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structH6F7xwrgKM.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structHAW6jHGG5q.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structHAW6jHGG5q.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structHGMhtcP1Gs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structHGMhtcP1Gs.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structHNoL72ys27.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structHNoL72ys27.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structHOwIYbq2Gd.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structHOwIYbq2Gd.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structHQ1FzQOf8n.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structHQ1FzQOf8n.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structHQRXU94JgV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structHQRXU94JgV.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structHSN0q7oMVM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structHSN0q7oMVM.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structHYnhl5ltDv.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structHYnhl5ltDv.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structHcCEQbo9Zf.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structHcCEQbo9Zf.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structHfRiDfgqPK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structHfRiDfgqPK.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structHnGXhmegvA.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structHnGXhmegvA.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structHnNLvYqbMR.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structHnNLvYqbMR.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structHt9F9jtMD0.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structHt9F9jtMD0.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structHusaUbKJVm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structHusaUbKJVm.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structHvGrPaR9Bu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structHvGrPaR9Bu.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structHvI693MHyM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structHvI693MHyM.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structHyrFeqyBCY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structHyrFeqyBCY.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structHzJtxAljeg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structHzJtxAljeg.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structI2aSLtV0nK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structI2aSLtV0nK.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structI5QO2BUMxk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structI5QO2BUMxk.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structI6BZQjT6lx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structI6BZQjT6lx.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structICD2Fjdvwq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structICD2Fjdvwq.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structIHkMJI02Cs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structIHkMJI02Cs.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structIJpxdh5h1j.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structIJpxdh5h1j.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structIKVPnPqtVG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structIKVPnPqtVG.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structIODsh0cyAj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structIODsh0cyAj.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structIWnVfC7bMR.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structIWnVfC7bMR.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structIg48IJ1BGz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structIg48IJ1BGz.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structIjpYds4lWa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structIjpYds4lWa.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structImqfRF5u5d.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structImqfRF5u5d.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structIpNWKHAjIK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structIpNWKHAjIK.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structIq2IxAwTbz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structIq2IxAwTbz.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structIqjoEWN5a6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structIqjoEWN5a6.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structJ1WoVnmoNK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structJ1WoVnmoNK.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structJ4N4ApAuNd.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structJ4N4ApAuNd.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structJ4sxZ95hzs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structJ4sxZ95hzs.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structJ5ThymSmBk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structJ5ThymSmBk.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structJBdaFHCitX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structJBdaFHCitX.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structJBjYKH35Id.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structJBjYKH35Id.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structJEL7o5TRHh.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structJEL7o5TRHh.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structJFU1xlKVwi.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structJFU1xlKVwi.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structJIOp0LkuGx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structJIOp0LkuGx.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structJKSxRHdkgU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structJKSxRHdkgU.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structJLl1JS3EBA.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structJLl1JS3EBA.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structJPod17bl3h.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structJPod17bl3h.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structJSkoDJdEmy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structJSkoDJdEmy.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structJXZ8aT3Z1A.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structJXZ8aT3Z1A.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structJYFDwGezZu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structJYFDwGezZu.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structJZBOzjdChs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structJZBOzjdChs.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structJcJCwPR9O6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structJcJCwPR9O6.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structJdaXHv9XGK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structJdaXHv9XGK.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structJguJlpO2Zx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structJguJlpO2Zx.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structJjOrVxY09U.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structJjOrVxY09U.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structJmS6AEcW3Z.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structJmS6AEcW3Z.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structJmgvdzeb5n.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structJmgvdzeb5n.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structJt6jf8vpBs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structJt6jf8vpBs.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structJyoG3utfUF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structJyoG3utfUF.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structK17aJaWFKp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structK17aJaWFKp.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structK6zBHvtXEz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structK6zBHvtXEz.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structK8yLeG1Rq8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structK8yLeG1Rq8.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structKAGtyEb0Mc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structKAGtyEb0Mc.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structKBZsUWVDxs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structKBZsUWVDxs.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structKD97Jf4W3S.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structKD97Jf4W3S.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structKDBDsZNe9Z.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structKDBDsZNe9Z.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structKDWeAZ2IPn.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structKDWeAZ2IPn.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structKF4sn2PYXa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structKF4sn2PYXa.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structKHnzHYYQv9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structKHnzHYYQv9.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structKJhvJs3EGG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structKJhvJs3EGG.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structKLSPh0PXhl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structKLSPh0PXhl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structKNZX9fxtdl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structKNZX9fxtdl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structKS9Hbi6AwZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structKS9Hbi6AwZ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structKVlfLjDmn1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structKVlfLjDmn1.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structKX2JHsJ0bd.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structKX2JHsJ0bd.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structKkESsYkID7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structKkESsYkID7.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structKkHcnJvU6l.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structKkHcnJvU6l.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structKkvn2ffBgz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structKkvn2ffBgz.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structKxmFSKOkr0.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structKxmFSKOkr0.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structL0iuHiXIxa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structL0iuHiXIxa.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structL28FwCaWlq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structL28FwCaWlq.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structL3YlcXIU3G.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structL3YlcXIU3G.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structL5PAA2Y49o.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structL5PAA2Y49o.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structL8rTw5Q3JI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structL8rTw5Q3JI.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structLJsbrcp1QV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structLJsbrcp1QV.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structLKxIRREq4D.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structLKxIRREq4D.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structLMQlSHV6GT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structLMQlSHV6GT.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structLV2nB9GvAz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structLV2nB9GvAz.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structLa1OJDLBp5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structLa1OJDLBp5.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structLcNNHqG92U.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structLcNNHqG92U.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structLnY2DL1Mbw.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structLnY2DL1Mbw.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structLpxoYUnOy7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structLpxoYUnOy7.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structLs7CLvlkgi.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structLs7CLvlkgi.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structLtMZ0XaStC.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structLtMZ0XaStC.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structLy4yvDjUuQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structLy4yvDjUuQ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structM9DKZGOLDg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structM9DKZGOLDg.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structMBndhRFxei.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structMBndhRFxei.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structMEcvkINwlN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structMEcvkINwlN.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structMFY7puSlGX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structMFY7puSlGX.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structMQnq3Fo18k.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structMQnq3Fo18k.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structMRN9c8EZAu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structMRN9c8EZAu.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structMSaXkM98gx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structMSaXkM98gx.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structMe4GO0lmyL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structMe4GO0lmyL.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structMf7H2FRsCR.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structMf7H2FRsCR.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structMgFMQz9tN4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structMgFMQz9tN4.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structMhWZ76XLqK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structMhWZ76XLqK.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structMiv3889DlT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structMiv3889DlT.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structMkNnqyG9Tl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structMkNnqyG9Tl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structMw7h6zUCoS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structMw7h6zUCoS.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structN5CGh6EWiK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structN5CGh6EWiK.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structN86zzxZWL3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structN86zzxZWL3.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structN9VLieAgkB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structN9VLieAgkB.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structNB005jf6q4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structNB005jf6q4.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structNW2O8zaFJU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structNW2O8zaFJU.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structNXVElSFyJY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structNXVElSFyJY.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structNXkTPXgNCQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structNXkTPXgNCQ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structNYxtIN1k6X.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structNYxtIN1k6X.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structNcunqydrcp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structNcunqydrcp.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structNfG8poVmRX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structNfG8poVmRX.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structNpSaGkUh99.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structNpSaGkUh99.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structNphpYJarez.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structNphpYJarez.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structNq8WSpQa6r.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structNq8WSpQa6r.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structNuHNDIZUYr.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structNuHNDIZUYr.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structO4Kr2Vp6iB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structO4Kr2Vp6iB.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structO5SpO4Lmqy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structO5SpO4Lmqy.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structO6aBEtLHCl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structO6aBEtLHCl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structO8aC92gkJu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structO8aC92gkJu.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structOAXjhVxHVW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structOAXjhVxHVW.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structOBggRrGGeA.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structOBggRrGGeA.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structOCKiZ8XvN4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structOCKiZ8XvN4.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structOTagHf6dta.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structOTagHf6dta.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structOmPR4GDmha.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structOmPR4GDmha.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structOnU7Y1iyOW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structOnU7Y1iyOW.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structOruSh6IU68.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structOruSh6IU68.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structP07kLcgWy2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structP07kLcgWy2.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structP0hi03Yr5J.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structP0hi03Yr5J.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structP51IT0iQls.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structP51IT0iQls.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structPC53CFAahl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structPC53CFAahl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structPDETEBub2B.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structPDETEBub2B.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structPIEO17rXv3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structPIEO17rXv3.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structPL1Vy8gAQG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structPL1Vy8gAQG.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structPOAJbOn5yN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structPOAJbOn5yN.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structPWOGZtzGIy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structPWOGZtzGIy.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structPWOtvXxst0.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structPWOtvXxst0.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structPaMBWeOEZb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structPaMBWeOEZb.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structPbViqUkC9s.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structPbViqUkC9s.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structPjXLhVCSo2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structPjXLhVCSo2.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structPmsSWhVFlx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structPmsSWhVFlx.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structPvttwCSove.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structPvttwCSove.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structPy7auxT2wm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structPy7auxT2wm.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structPzKBHCX9aj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structPzKBHCX9aj.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structQ1lt85NZkv.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structQ1lt85NZkv.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structQ9W3v3dQYW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structQ9W3v3dQYW.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structQBpF2mc1un.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structQBpF2mc1un.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structQLoTxIicfl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structQLoTxIicfl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structQNBjmFEISk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structQNBjmFEISk.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structQRNlszU7N1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structQRNlszU7N1.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structQRrZvgSvEl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structQRrZvgSvEl.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structQu8eKSWeIJ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structQu8eKSWeIJ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structQwjx7jDCDX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structQwjx7jDCDX.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structQwri7Ax9TK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structQwri7Ax9TK.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structR4xaEYdpRY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structR4xaEYdpRY.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structR6bsgVIYE6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structR6bsgVIYE6.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structR6j965l6JZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structR6j965l6JZ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structR6yPnOD0oz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structR6yPnOD0oz.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structR8eEQpI0YT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structR8eEQpI0YT.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structRBr9HNIGgm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structRBr9HNIGgm.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structRBwjivoMMP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structRBwjivoMMP.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structRFFK9pIT93.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structRFFK9pIT93.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structRJYj3K0a3c.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structRJYj3K0a3c.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structRLhaWW9haz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structRLhaWW9haz.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structRSckKIVPNO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structRSckKIVPNO.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structRX7hJYzEEc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structRX7hJYzEEc.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structRbEgtyrBAH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structRbEgtyrBAH.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structRbgB04HmL4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structRbgB04HmL4.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structRdgEVFWPU8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structRdgEVFWPU8.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structRjYd0rym9S.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structRjYd0rym9S.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structRpd0ErOBb6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structRpd0ErOBb6.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structRtcf0YV8fO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structRtcf0YV8fO.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structRtjThoUz7H.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structRtjThoUz7H.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structRyTk5RxJJO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structRyTk5RxJJO.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structS1RhuauboU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structS1RhuauboU.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structS6bmXaMMyl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structS6bmXaMMyl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structSDPIMkAwH8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structSDPIMkAwH8.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structSEmAsgVkk9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structSEmAsgVkk9.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structSIfHQocAM7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structSIfHQocAM7.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structSL3XN9PByF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structSL3XN9PByF.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structSOJZorG6h4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structSOJZorG6h4.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structSOQ2b3Trj9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structSOQ2b3Trj9.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structSOcWqfVVcP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structSOcWqfVVcP.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structSUuI5kWBPQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structSUuI5kWBPQ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structSWz0ZdY1fL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structSWz0ZdY1fL.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structSXB5wflpQj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structSXB5wflpQj.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structSaCKmxwW7X.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structSaCKmxwW7X.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structSkgZGVkxzj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structSkgZGVkxzj.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structSuSfIvUv2A.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structSuSfIvUv2A.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structSuaJbDOn73.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structSuaJbDOn73.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structSv55DLNwHy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structSv55DLNwHy.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structSvXjwmwWp8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structSvXjwmwWp8.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structT024qoIGBu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structT024qoIGBu.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structT396ygje53.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structT396ygje53.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structTA8Sp22K2U.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structTA8Sp22K2U.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structTGF07uM1y9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structTGF07uM1y9.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structTKbYYBx9QZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structTKbYYBx9QZ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structTLyC86eODa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structTLyC86eODa.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structTSEu5hclTq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structTSEu5hclTq.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structTX5YCrOcOo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structTX5YCrOcOo.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structTX6rXf2RZh.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structTX6rXf2RZh.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structTaJbzfeDjo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structTaJbzfeDjo.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structTaYGLKdSM8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structTaYGLKdSM8.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structTgcZPmWOx2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structTgcZPmWOx2.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structTh5NbnUqzI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structTh5NbnUqzI.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structTknpxoQFvS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structTknpxoQFvS.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structTqu8KoZQjY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structTqu8KoZQjY.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structTuAcbBNnZm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structTuAcbBNnZm.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structTuWH3zeluv.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structTuWH3zeluv.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structTwjPuMKDiB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structTwjPuMKDiB.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structTxF88EuH4Q.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structTxF88EuH4Q.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structTzQ4rWvlZ3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structTzQ4rWvlZ3.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structU2kogkOlcf.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structU2kogkOlcf.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structU3dy6bkQcN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structU3dy6bkQcN.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structUA5Zgdsa4W.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structUA5Zgdsa4W.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structUC7urls6rG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structUC7urls6rG.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structUJ5RVg0xHN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structUJ5RVg0xHN.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structUL0XgKUiea.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structUL0XgKUiea.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structUYdnQvYvKk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structUYdnQvYvKk.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structUaTPRyIwWQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structUaTPRyIwWQ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structUgp6Bg804O.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structUgp6Bg804O.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structUgsqUT0Fw8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structUgsqUT0Fw8.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structUomjJGDhS3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structUomjJGDhS3.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structUrJ7tMPYdi.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structUrJ7tMPYdi.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structUsGUm5feCJ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structUsGUm5feCJ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structUx6sDnae6o.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structUx6sDnae6o.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structUyBELJkxhd.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structUyBELJkxhd.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structV1mFMqHDyz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structV1mFMqHDyz.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structV3DEOjYkAI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structV3DEOjYkAI.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structV4EcMh64Nu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structV4EcMh64Nu.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structVABFQlbdB8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structVABFQlbdB8.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structVCKWE5qXDQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structVCKWE5qXDQ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structVF3eV6RT5A.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structVF3eV6RT5A.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structVGVFt2H4Jq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structVGVFt2H4Jq.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structVHmibu21U1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structVHmibu21U1.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structVJQMEbTTcW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structVJQMEbTTcW.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structVW9Wugrq8f.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structVW9Wugrq8f.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structVbui9U8nJN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structVbui9U8nJN.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structVqmZxmYjrS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structVqmZxmYjrS.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structVwumd12dMR.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structVwumd12dMR.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structW03TuqLzYH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structW03TuqLzYH.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structW6NGdR4FHA.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structW6NGdR4FHA.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structW8RwEte1K1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structW8RwEte1K1.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structWFr5O7xRwi.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structWFr5O7xRwi.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structWJw9ZLP7fK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structWJw9ZLP7fK.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structWODpD4eAmE.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structWODpD4eAmE.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structWOGNQBbIW7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structWOGNQBbIW7.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structWQN1KyUD5b.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structWQN1KyUD5b.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structWTDgYPieK1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structWTDgYPieK1.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structWVtboPH1aE.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structWVtboPH1aE.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structWiPM4vCvbR.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structWiPM4vCvbR.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structWk1zWo8r9K.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structWk1zWo8r9K.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structWkYOcVuG9r.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structWkYOcVuG9r.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structWqKLr6PuT3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structWqKLr6PuT3.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structWyFaNRxWDU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structWyFaNRxWDU.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structX0tLJiI6QS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structX0tLJiI6QS.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structX74WdLPgP3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structX74WdLPgP3.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structXLePVWtJFS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structXLePVWtJFS.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structXNJAbmwEpz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structXNJAbmwEpz.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structXOlFj8WTWU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structXOlFj8WTWU.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structXQpY9eJk4m.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structXQpY9eJk4m.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structXU2GzBHEnm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structXU2GzBHEnm.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structXWIUjIMjuc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structXWIUjIMjuc.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structXYOl2gpZhZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structXYOl2gpZhZ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structXYrXq7Kz5O.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structXYrXq7Kz5O.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structXab1L6RKkc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structXab1L6RKkc.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structXcQSZS9Pq3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structXcQSZS9Pq3.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structXdOq3rooU7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structXdOq3rooU7.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structXpfvMzo3SU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structXpfvMzo3SU.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structXs0m0HB3Ve.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structXs0m0HB3Ve.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structXsoVym5xGF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structXsoVym5xGF.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structXxbrxyvfJK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structXxbrxyvfJK.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structY0sbuM1lf1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structY0sbuM1lf1.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structY2WI2qZBJc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structY2WI2qZBJc.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structY3MSP8GJLq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structY3MSP8GJLq.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structY7ZzgHzGVw.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structY7ZzgHzGVw.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structY8HkjRfwpg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structY8HkjRfwpg.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structYAzsftuDhx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structYAzsftuDhx.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structYE37gD7DoN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structYE37gD7DoN.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structYNODMJt0nI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structYNODMJt0nI.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structYOoQMQYEZo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structYOoQMQYEZo.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structYPtr2Dr86B.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structYPtr2Dr86B.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structYXRqKm5H9U.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structYXRqKm5H9U.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structYa2X1A0XlS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structYa2X1A0XlS.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structYj7TbLsdP4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structYj7TbLsdP4.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structYlF6RxCqVs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structYlF6RxCqVs.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structYo1jTzfuKl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structYo1jTzfuKl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structYrew2qdBuH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structYrew2qdBuH.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structYwZwDfIvIG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structYwZwDfIvIG.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structZ3DY5gvzFY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structZ3DY5gvzFY.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structZBrvC38b8N.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structZBrvC38b8N.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structZC6ZaapQdD.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structZC6ZaapQdD.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structZGNK9Twr9S.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structZGNK9Twr9S.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structZGqp2bRDtx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structZGqp2bRDtx.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structZJSKolxfqc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structZJSKolxfqc.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structZR3LiJX7PO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structZR3LiJX7PO.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structZW26HGLchP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structZW26HGLchP.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structZi1RqmdSol.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structZi1RqmdSol.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structZoimFj6xEE.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structZoimFj6xEE.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structZpfDnRPksn.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structZpfDnRPksn.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structZr2k5TeLcE.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structZr2k5TeLcE.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structZtqbbnQjzj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structZtqbbnQjzj.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structZupKEHABUk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structZupKEHABUk.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structa0AhWFAoDG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structa0AhWFAoDG.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structa5eW784LQf.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structa5eW784LQf.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structa6BXYQAwEm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structa6BXYQAwEm.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structa6bL6toTDQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structa6bL6toTDQ.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structa85eS8wvGC.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structa85eS8wvGC.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structaBCMiwiL14.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structaBCMiwiL14.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structaCvUpfrOud.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structaCvUpfrOud.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structaMVAJ9INz0.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structaMVAJ9INz0.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structaNX02HPg7T.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structaNX02HPg7T.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structaacjP2BYDY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structaacjP2BYDY.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structafSLEQGtjb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structafSLEQGtjb.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structawZmlvXiXW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structawZmlvXiXW.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structaxV4fiWwZ7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structaxV4fiWwZ7.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structayNEhBBg4t.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structayNEhBBg4t.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structb265yb0csM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structb265yb0csM.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structb63fAzKNR7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structb63fAzKNR7.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structbBsug1Wd34.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structbBsug1Wd34.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structbNMyvNH8WM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structbNMyvNH8WM.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structbX4S27LXkH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structbX4S27LXkH.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structblpexlSs9M.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structblpexlSs9M.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structbmmnw9qu32.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structbmmnw9qu32.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structbsrrxTZOqn.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structbsrrxTZOqn.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structbtgnPXO5Rq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structbtgnPXO5Rq.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structbwtswCbHZn.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structbwtswCbHZn.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structc0ARtdYgED.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structc0ARtdYgED.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structc0K76QtGvt.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structc0K76QtGvt.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structc19BIAaEkY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structc19BIAaEkY.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structcIUFEZhrle.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structcIUFEZhrle.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structcU51DXcyE8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structcU51DXcyE8.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structcbnz0kvIwn.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structcbnz0kvIwn.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structcfbnUeCgbt.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structcfbnUeCgbt.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structcjMmD9Dwfx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structcjMmD9Dwfx.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structclmVkpAhb8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structclmVkpAhb8.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structcoAqE1boX6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structcoAqE1boX6.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structcormXUf4WS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structcormXUf4WS.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structcqdGRq2WNh.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structcqdGRq2WNh.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structczOiELiAB7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structczOiELiAB7.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structd2ojXxCaNW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structd2ojXxCaNW.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structd4OcbMDcGL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structd4OcbMDcGL.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structd9nB4x1U6u.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structd9nB4x1U6u.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structdEhJcrsORt.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structdEhJcrsORt.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structdKBNYvwyxK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structdKBNYvwyxK.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structdNGVHIlzAj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structdNGVHIlzAj.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structdSftno00MK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structdSftno00MK.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structdXZpHpuk3x.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structdXZpHpuk3x.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structdXgIF94ebo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structdXgIF94ebo.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structdhEH1P8yDX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structdhEH1P8yDX.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structdq0ytTGdT7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structdq0ytTGdT7.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structdr28D0z5ZH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structdr28D0z5ZH.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structe4z2kYEwsw.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structe4z2kYEwsw.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structe79Za4b7Ml.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structe79Za4b7Ml.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structeJF56nvsEj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structeJF56nvsEj.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structeW6hiVZjD9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structeW6hiVZjD9.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structegI0J6pwbq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structegI0J6pwbq.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structemjd05RWc3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structemjd05RWc3.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structeqBjnWgb5P.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structeqBjnWgb5P.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structf0akg4gumK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structf0akg4gumK.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structf32Rx1NpEm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structf32Rx1NpEm.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structf3hg4Duqet.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structf3hg4Duqet.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structf74ThK893J.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structf74ThK893J.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structfBkGsQBirP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structfBkGsQBirP.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structfCVtyydYxM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structfCVtyydYxM.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structfCayR9pma6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structfCayR9pma6.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structfG4ASdjUC9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structfG4ASdjUC9.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structfJdkVlyVac.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structfJdkVlyVac.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structfNnOzIDYzL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structfNnOzIDYzL.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structfOOjVzFOC9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structfOOjVzFOC9.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structfTXY9OU4mh.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structfTXY9OU4mh.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structfWEUc1K6FG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structfWEUc1K6FG.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structfYJ2Mkk1al.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structfYJ2Mkk1al.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structfcg2UqwprF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structfcg2UqwprF.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structfd0mCQVHBl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structfd0mCQVHBl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structfwecOIJDmQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structfwecOIJDmQ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structgBuG9DjtOU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structgBuG9DjtOU.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structgIAdPMClq9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structgIAdPMClq9.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structgJaEzQzHlG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structgJaEzQzHlG.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structgTI819u8oK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structgTI819u8oK.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structgaVRwvBYOY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structgaVRwvBYOY.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structgmDuxmO8uQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structgmDuxmO8uQ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structgnTh8YZCI4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structgnTh8YZCI4.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structgnzwfueLCU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structgnzwfueLCU.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structgodJTvsSrL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structgodJTvsSrL.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structgoyNOloADC.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structgoyNOloADC.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structgrMFKxp6Rp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structgrMFKxp6Rp.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structgu5AmoUnKH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structgu5AmoUnKH.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structgw0RpMV2f4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structgw0RpMV2f4.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structgzPFVO95T5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structgzPFVO95T5.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structh0wIvbjPFM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structh0wIvbjPFM.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structh0zYLuKys0.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structh0zYLuKys0.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structh4borQn8tt.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structh4borQn8tt.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structhEYyOpWNQA.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structhEYyOpWNQA.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structhKVOXTzhtj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structhKVOXTzhtj.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structhP7CI8CVIx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structhP7CI8CVIx.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structhRp6BjrXlq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structhRp6BjrXlq.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structhXluAaYGUP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structhXluAaYGUP.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structhc5U7IjcZc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structhc5U7IjcZc.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structhjYDoXKd1y.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structhjYDoXKd1y.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structhk5xXOFY3B.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structhk5xXOFY3B.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structhlXXNdntjL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structhlXXNdntjL.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structhnljKmvH1S.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structhnljKmvH1S.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structhsMP7WDnTb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structhsMP7WDnTb.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structi5tx16f99j.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structi5tx16f99j.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structi60i9flgEl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structi60i9flgEl.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structiGcBGhWkFg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structiGcBGhWkFg.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structiH2t1AudUv.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structiH2t1AudUv.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structiJO3yTUlA6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structiJO3yTUlA6.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structiMxQrDbyMm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structiMxQrDbyMm.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structiRTC8Ri5hh.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structiRTC8Ri5hh.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structiUTYiuw7nL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structiUTYiuw7nL.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structifVuZi4Efe.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structifVuZi4Efe.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structigySx6ywF4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structigySx6ywF4.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structimk6k6ZOQP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structimk6k6ZOQP.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structiyfYt6St4H.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structiyfYt6St4H.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structj0Jp6zlUkb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structj0Jp6zlUkb.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structj2noj6YBli.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structj2noj6YBli.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structj80X6OAWFM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structj80X6OAWFM.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structjATzvt82Yc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structjATzvt82Yc.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structjHYdKd1qGS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structjHYdKd1qGS.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structjIn9JVMI49.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structjIn9JVMI49.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structjKvkQzPnI2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structjKvkQzPnI2.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structjPeWDdzelT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structjPeWDdzelT.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structjVynlgrJOg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structjVynlgrJOg.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structjXzq5dAQfq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structjXzq5dAQfq.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structjlEQy1XgIm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structjlEQy1XgIm.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structjpZYztDGZv.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structjpZYztDGZv.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structjyzBmrWLpD.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structjyzBmrWLpD.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structjzLZ1Fd1su.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structjzLZ1Fd1su.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structk0RWOtD4Cb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structk0RWOtD4Cb.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structk5uhI551Ib.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structk5uhI551Ib.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structkBpo9DUgjg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structkBpo9DUgjg.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structkKCqpBwgSB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structkKCqpBwgSB.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structkMn4TDNnDw.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structkMn4TDNnDw.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structkTDa7zOTTq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structkTDa7zOTTq.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structkcnuBfgvqB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structkcnuBfgvqB.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structke5R4wNmaV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structke5R4wNmaV.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structkgOVznysHS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structkgOVznysHS.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structkjR2PqZPCx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structkjR2PqZPCx.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structkjvkPYElx2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structkjvkPYElx2.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structko3HKcubO4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structko3HKcubO4.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structl1rwee6A0W.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structl1rwee6A0W.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structl9GK15NFfI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structl9GK15NFfI.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structl9dEcAYjZX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structl9dEcAYjZX.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structlCbFTLeEcO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structlCbFTLeEcO.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structlFoUTH7TGY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structlFoUTH7TGY.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structlFuagxP4pj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structlFuagxP4pj.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structlKqlZNIiTG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structlKqlZNIiTG.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structlM9nCK9mVa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structlM9nCK9mVa.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structlNxcettVbW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structlNxcettVbW.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structlOMWejTcie.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structlOMWejTcie.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structlPPzP90v2M.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structlPPzP90v2M.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structlWE7ijbTPg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structlWE7ijbTPg.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structlWZpr8mFUz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structlWZpr8mFUz.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structlfb6Bcmyzv.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structlfb6Bcmyzv.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structliZR39PG4B.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structliZR39PG4B.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structlilo17vqrO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structlilo17vqrO.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structlmBHuI2CdK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structlmBHuI2CdK.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structlsRnaxudRi.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structlsRnaxudRi.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structlwBBVufID9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structlwBBVufID9.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structmE7fFfuHjx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structmE7fFfuHjx.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structmPX6OOh4Nl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structmPX6OOh4Nl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structmR2t9GgAZ5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structmR2t9GgAZ5.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structmU9k8N2S1x.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structmU9k8N2S1x.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structmUQioQKiXp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structmUQioQKiXp.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structmWBF30udKT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structmWBF30udKT.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structmaUySacG7e.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structmaUySacG7e.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structmj4Oyb3GgX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structmj4Oyb3GgX.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structmuAhuD4KVQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structmuAhuD4KVQ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structmwjaO3Uyrs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structmwjaO3Uyrs.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structn5h1DHBxub.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structn5h1DHBxub.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structnAdqmBnbeg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structnAdqmBnbeg.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structnAvYhH07Gs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structnAvYhH07Gs.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structnHnX8P1WDq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structnHnX8P1WDq.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structnNkjJDcz0P.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structnNkjJDcz0P.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structnPwZk9I7YN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structnPwZk9I7YN.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structnUJfW4NMaA.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structnUJfW4NMaA.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structnXMZUp9V4V.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structnXMZUp9V4V.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structnjkuDZnOoQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structnjkuDZnOoQ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structnq8k7vNWX3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structnq8k7vNWX3.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structnrVsGpyHSB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structnrVsGpyHSB.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structnsGvdkMRFZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structnsGvdkMRFZ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structoAhXI74h9j.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structoAhXI74h9j.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structoahbTSUqku.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structoahbTSUqku.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structoiRn4GygF9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structoiRn4GygF9.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structov6aJQLXqu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structov6aJQLXqu.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structovm1h7N1tD.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structovm1h7N1tD.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structoypCXXMXYK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structoypCXXMXYK.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structp39x1W6Nmw.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structp39x1W6Nmw.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structp5F0SqEi1N.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structp5F0SqEi1N.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structpK1zdl2ooH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structpK1zdl2ooH.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structpLXABe2wJc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structpLXABe2wJc.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structpMr2v6juAQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structpMr2v6juAQ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structpXZA41Y8fK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structpXZA41Y8fK.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structpkIouuiKqe.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structpkIouuiKqe.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structpnMhTmK3QH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structpnMhTmK3QH.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structpuA2r64pbW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structpuA2r64pbW.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structpwCAT0hshK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structpwCAT0hshK.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structq1BEWkecYX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structq1BEWkecYX.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structq2gqs38KnH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structq2gqs38KnH.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structq5OjZ10BEs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structq5OjZ10BEs.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structqGa10MSSRs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structqGa10MSSRs.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structqGuE1lEn2E.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structqGuE1lEn2E.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structqK7XKTZI6a.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structqK7XKTZI6a.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structqRtOraogqy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structqRtOraogqy.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structqTdD25cQMq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structqTdD25cQMq.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structqVenFBZMmB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structqVenFBZMmB.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structqVymoyiTzO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structqVymoyiTzO.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structqYoMOdyW5o.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structqYoMOdyW5o.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structqZqGFZMAp0.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structqZqGFZMAp0.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structqceTFkotG1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structqceTFkotG1.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structqklsh0VtCj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structqklsh0VtCj.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structqkwGFodzYo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structqkwGFodzYo.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structqlynSYPIzj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structqlynSYPIzj.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structqmylEQUQxN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structqmylEQUQxN.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structqsdnJQvtod.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structqsdnJQvtod.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structr1IUWdH7kS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structr1IUWdH7kS.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structrDLhl5fFyI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structrDLhl5fFyI.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structrJ6A29EFD3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structrJ6A29EFD3.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structrLI0qkdwNT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structrLI0qkdwNT.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structrNNNMoMUX5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structrNNNMoMUX5.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structrQyjIvxeGC.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structrQyjIvxeGC.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structrUZIsQzLzo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structrUZIsQzLzo.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structrUrNNgGYxl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structrUrNNgGYxl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structrZORE7saci.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structrZORE7saci.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structrnEvXbtOaJ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structrnEvXbtOaJ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structrv6cJ7e4eI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structrv6cJ7e4eI.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structrvnG4DB0O9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structrvnG4DB0O9.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structrxuRIzLrOd.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structrxuRIzLrOd.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structs0wKthNJDH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structs0wKthNJDH.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structs6tlj8Ujb6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structs6tlj8Ujb6.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structs81xiTr3V2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structs81xiTr3V2.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structs9FC686ssT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structs9FC686ssT.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structsU7ru1S3Bn.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structsU7ru1S3Bn.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structsconExg82n.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structsconExg82n.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structsnl6YWFzw6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structsnl6YWFzw6.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structsr11hihvVP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structsr11hihvVP.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structsrFnuySLJZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structsrFnuySLJZ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structsyMjE23XYL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structsyMjE23XYL.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structt1zhtoy3QG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structt1zhtoy3QG.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structt3vc10gLez.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structt3vc10gLez.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structt7Y6XwomUH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structt7Y6XwomUH.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structtFfTsyMFtj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structtFfTsyMFtj.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structtKTQH67TAx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structtKTQH67TAx.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structtRnRKY1Nt9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structtRnRKY1Nt9.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structtVv0gLLUw6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structtVv0gLLUw6.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structtdu9UH9BR6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structtdu9UH9BR6.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structtkLijaINDB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structtkLijaINDB.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structtmi3Y4xjWJ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structtmi3Y4xjWJ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structtoRHBeshpF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structtoRHBeshpF.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structtoojZOxzYL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structtoojZOxzYL.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structuEWock0xfg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structuEWock0xfg.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structuYFS57GpEz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structuYFS57GpEz.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structuZLTFqoTc9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structuZLTFqoTc9.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structuesCCsCmB9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structuesCCsCmB9.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structuk9n40Ba1s.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structuk9n40Ba1s.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structurOByRIJr5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structurOByRIJr5.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structusM7i9eFda.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structusM7i9eFda.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structuzTdZWiu60.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structuzTdZWiu60.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structv4jF52UQ9H.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structv4jF52UQ9H.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structv9bmg59CEV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structv9bmg59CEV.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structvE6YTruKB5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structvE6YTruKB5.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structvGYXxaXkfO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structvGYXxaXkfO.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structvIiPiag0AP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structvIiPiag0AP.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structvJXxV1TNGG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structvJXxV1TNGG.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structvLrhLw24Yo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structvLrhLw24Yo.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structvPLGLtUGvc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structvPLGLtUGvc.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structvQ4tBtsFIQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structvQ4tBtsFIQ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structvetTPo8phL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structvetTPo8phL.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structvh6HUMxCO1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structvh6HUMxCO1.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structvhPOJekCB6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structvhPOJekCB6.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structvqpjGCBNgC.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structvqpjGCBNgC.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structw1Jcuo2qcB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structw1Jcuo2qcB.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structw1LUTeHkEP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structw1LUTeHkEP.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structw704rOrUeD.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structw704rOrUeD.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structwAVE8pzuIw.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structwAVE8pzuIw.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structwE9USHmMoa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structwE9USHmMoa.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structwKyV6c3NXx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structwKyV6c3NXx.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structwNNWk20409.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structwNNWk20409.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structwPjsuxb7PR.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structwPjsuxb7PR.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structwquRams9Fs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structwquRams9Fs.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structwyz9cVcdwh.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structwyz9cVcdwh.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structx29mgYMw04.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structx29mgYMw04.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structx9kDs7ICzW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structx9kDs7ICzW.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structxFTWeVz86X.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structxFTWeVz86X.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structxI8aw5DOBf.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structxI8aw5DOBf.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structxKJxcMqgXp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structxKJxcMqgXp.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structxSyTOLVs2a.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structxSyTOLVs2a.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structxY83QlHYu8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structxY83QlHYu8.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structxatoIPHwut.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structxatoIPHwut.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structxayiSk9poY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structxayiSk9poY.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structxl0tHilNDj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structxl0tHilNDj.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structxpKM8hQmHX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structxpKM8hQmHX.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structxrKKgR1Fe1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structxrKKgR1Fe1.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structxsR9aAsAXm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structxsR9aAsAXm.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structxwNsI8Zdb1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structxwNsI8Zdb1.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structy2eHpFGRr5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structy2eHpFGRr5.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structy5X9cuxDIn.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structy5X9cuxDIn.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structy5wbr5f4bB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structy5wbr5f4bB.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structyAGnaq1EBc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structyAGnaq1EBc.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structyGjRe5am7c.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structyGjRe5am7c.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structyKsJfDGXaz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structyKsJfDGXaz.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structyNBvxKIcti.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structyNBvxKIcti.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structyPEdNMH6Lo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structyPEdNMH6Lo.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structyTmtkFKqd7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structyTmtkFKqd7.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structydbIqe0qPo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structydbIqe0qPo.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structyhDvAbXvCv.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structyhDvAbXvCv.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structynitZhhUeJ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structynitZhhUeJ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structyvVgkdYRXO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structyvVgkdYRXO.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structz1JgTXpAuI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structz1JgTXpAuI.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structz7dfzzL9Yk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structz7dfzzL9Yk.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structzIXefsJFSz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structzIXefsJFSz.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structzPWDt4oN6i.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structzPWDt4oN6i.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structzQUyc7Ws0e.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structzQUyc7Ws0e.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structzTIpN6ALMu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structzTIpN6ALMu.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structzYoD4xKxnZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structzYoD4xKxnZ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structzdXNEcof9V.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structzdXNEcof9V.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structzo3owhla9x.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structzo3owhla9x.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structzyowJj76a6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/partial-structzyowJj76a6.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct00oieaoYA5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct00oieaoYA5.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct05nZxSvOQy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct05nZxSvOQy.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct0CW6rWihRa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct0CW6rWihRa.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct0EiiHjJ0Jy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct0EiiHjJ0Jy.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct0HxVdkFuDk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct0HxVdkFuDk.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct0Sp8nFf9po.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct0Sp8nFf9po.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct0YOigHUonk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct0YOigHUonk.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct0mu68DyXFS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct0mu68DyXFS.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct0oZl05ifoL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct0oZl05ifoL.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct101P28DC6b.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct101P28DC6b.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct109xwVU7na.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct109xwVU7na.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct13ZLCuuDdg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct13ZLCuuDdg.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct164v5M7Oiu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct164v5M7Oiu.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct16i8Hnvzik.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct16i8Hnvzik.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct1B64P2KJTT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct1B64P2KJTT.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct1FLNprzFfg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct1FLNprzFfg.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct1Lodf8jQhi.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct1Lodf8jQhi.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct1NM3qeUh2p.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct1NM3qeUh2p.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct1QKloRyprM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct1QKloRyprM.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct1TeundtXb1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct1TeundtXb1.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct1e9vZ2ZVVl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct1e9vZ2ZVVl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct1ibkpE2U9t.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct1ibkpE2U9t.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct1jAvJkz71q.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct1jAvJkz71q.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct1kIcXqyaMm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct1kIcXqyaMm.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct1kIjvNmL26.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct1kIjvNmL26.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct1nopkP9yWt.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct1nopkP9yWt.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct1q3mpvDeuG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct1q3mpvDeuG.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct1rwcZsOxGm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct1rwcZsOxGm.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct1shpv6NmPc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct1shpv6NmPc.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct1tertRu9Xm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct1tertRu9Xm.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct1xSlrFoiE2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct1xSlrFoiE2.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct1xjEjG8zge.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct1xjEjG8zge.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct1zEPcP8TZ0.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct1zEPcP8TZ0.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct22wFvfGOQe.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct22wFvfGOQe.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct23OaGTh97N.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct23OaGTh97N.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct2C0v3cLs4t.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct2C0v3cLs4t.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct2Ii6Pytw94.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct2Ii6Pytw94.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct2KJvO9ifSa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct2KJvO9ifSa.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct2Oea4qEuqL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct2Oea4qEuqL.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct2PRjv73LUz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct2PRjv73LUz.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct2PlWXW13Oo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct2PlWXW13Oo.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct2RjyXdbOmS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct2RjyXdbOmS.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct2WJXBATRow.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct2WJXBATRow.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct2ePshLeWkH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct2ePshLeWkH.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct2iRAZCo7L5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct2iRAZCo7L5.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct2l1qlatawT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct2l1qlatawT.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct2lPhMAoDBl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct2lPhMAoDBl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct2mrBdiaAsD.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct2mrBdiaAsD.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct2yK9S7dzeX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct2yK9S7dzeX.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct2yeMfnvK5l.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct2yeMfnvK5l.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct34i0YswjFg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct34i0YswjFg.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct3AvV0e5RCv.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct3AvV0e5RCv.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct3Fkic0RvsS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct3Fkic0RvsS.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct3Q09CNhFqG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct3Q09CNhFqG.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct3W5X0ROtrE.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct3W5X0ROtrE.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct3YKEcUcTm6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct3YKEcUcTm6.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct3Ysql1aZTo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct3Ysql1aZTo.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct3aLcZ0Gzdp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct3aLcZ0Gzdp.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct3bQ2CbXXiG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct3bQ2CbXXiG.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct3hbQkh2oXr.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct3hbQkh2oXr.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct3o9W3tWIYr.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct3o9W3tWIYr.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct3oRAhgtPFs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct3oRAhgtPFs.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct3rEqyW20Ha.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct3rEqyW20Ha.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct3rh7agTF1u.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct3rh7agTF1u.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct3tAXhVgz0j.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct3tAXhVgz0j.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct3udOlsWezr.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct3udOlsWezr.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct3yavERh0QP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct3yavERh0QP.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct40R1V76roU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct40R1V76roU.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct44PftY660j.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct44PftY660j.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct46ykdVFGwG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct46ykdVFGwG.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct47pp9CzShs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct47pp9CzShs.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct49eWbTEG4e.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct49eWbTEG4e.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct4I0C5KiBcT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct4I0C5KiBcT.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct4NHzRc00m2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct4NHzRc00m2.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct4R1b3Sfk6J.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct4R1b3Sfk6J.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct4VkhuwJa8e.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct4VkhuwJa8e.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct4bA4rV4T7I.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct4bA4rV4T7I.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct4qOfIMBclV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct4qOfIMBclV.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct4tYHXfgnVZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct4tYHXfgnVZ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct4xCfXxpvdy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct4xCfXxpvdy.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct4zYtkggxX9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct4zYtkggxX9.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct566AUa8c9w.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct566AUa8c9w.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct5B3Ki66g8U.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct5B3Ki66g8U.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct5GIHfCnyF0.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct5GIHfCnyF0.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct5GXqW1XpIl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct5GXqW1XpIl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct5R3JtFMKyy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct5R3JtFMKyy.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct5WOnMXao7S.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct5WOnMXao7S.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct5WjoUCBC2W.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct5WjoUCBC2W.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct5YuboIIJis.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct5YuboIIJis.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct5coPgZ627S.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct5coPgZ627S.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct5nsLLrnYzS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct5nsLLrnYzS.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct5p0wzn3Twr.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct5p0wzn3Twr.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct5pUyGEiqRW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct5pUyGEiqRW.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct66VojQk1NI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct66VojQk1NI.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct67D9OX1YBs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct67D9OX1YBs.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct67XWJDtmLp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct67XWJDtmLp.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct6ACGifRdRw.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct6ACGifRdRw.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct6AkdgH06Lh.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct6AkdgH06Lh.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct6BWJO4ygCh.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct6BWJO4ygCh.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct6Eho6XNoOx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct6Eho6XNoOx.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct6Fnny4hIyl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct6Fnny4hIyl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct6GnahT2THT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct6GnahT2THT.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct6Gy1eE7iFg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct6Gy1eE7iFg.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct6InhhK3Bnx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct6InhhK3Bnx.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct6KaWm2V4so.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct6KaWm2V4so.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct6NVZQs4UrE.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct6NVZQs4UrE.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct6PUxZ29VTq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct6PUxZ29VTq.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct6fce05Qu1f.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct6fce05Qu1f.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct6tzbdxQpL4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct6tzbdxQpL4.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct763ixhZiPg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct763ixhZiPg.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct79tZSSX75b.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct79tZSSX75b.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct7E3RzOaVF1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct7E3RzOaVF1.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct7Ev4ba5U4g.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct7Ev4ba5U4g.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct7FkotSk0XD.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct7FkotSk0XD.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct7MpRJpjzYV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct7MpRJpjzYV.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct7UAHrFSXgp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct7UAHrFSXgp.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct7ZDRFK7C6w.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct7ZDRFK7C6w.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct7hWyxK9Im1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct7hWyxK9Im1.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct7vhsXm5Sqy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct7vhsXm5Sqy.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct7vwzjN2hQB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct7vwzjN2hQB.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct7x47kTkDWA.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct7x47kTkDWA.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct814BQq200G.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct814BQq200G.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct84TN7zjoK9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct84TN7zjoK9.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct8CllamWxHF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct8CllamWxHF.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct8KGpb7sMhV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct8KGpb7sMhV.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct8P1XTIrmCU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct8P1XTIrmCU.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct8eGauAG2Iy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct8eGauAG2Iy.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct8hD3MVC60I.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct8hD3MVC60I.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct8q0Jpdjx8u.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct8q0Jpdjx8u.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct8qIwjmR7oN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct8qIwjmR7oN.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct8tbcftbwF8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct8tbcftbwF8.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct8txOZ8smgu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct8txOZ8smgu.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct8yaeAzdZUO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct8yaeAzdZUO.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct98nsmL4Uyu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct98nsmL4Uyu.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct9CTRHeV5gV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct9CTRHeV5gV.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct9E3xYWs4gr.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct9E3xYWs4gr.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct9FbBK7sAEy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct9FbBK7sAEy.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct9HOIXHYhP9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct9HOIXHYhP9.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct9IzMME36Bl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct9IzMME36Bl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct9PLpEx4eEr.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct9PLpEx4eEr.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct9QX6aOMWmP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct9QX6aOMWmP.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct9XFvojKqS7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct9XFvojKqS7.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct9Z0NXJ0nuB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct9Z0NXJ0nuB.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct9cdQxj05PP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct9cdQxj05PP.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct9dJLrfdwrb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct9dJLrfdwrb.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct9fPHF2RcIG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct9fPHF2RcIG.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct9o9IQlJhfF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct9o9IQlJhfF.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct9rTJlJQ4St.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct9rTJlJQ4St.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct9tS75raz9v.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-struct9tS75raz9v.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structA0t67j1fxp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structA0t67j1fxp.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structA2y6S9lFjD.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structA2y6S9lFjD.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structA4N6i5eArl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structA4N6i5eArl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structA6J9ouYjJm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structA6J9ouYjJm.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structAB03r2H43b.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structAB03r2H43b.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structADRxlKyBIl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structADRxlKyBIl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structAE7oPkwYY6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structAE7oPkwYY6.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structAHdMDYZJaK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structAHdMDYZJaK.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structAK2drK1aH7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structAK2drK1aH7.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structAPZGaaiAsI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structAPZGaaiAsI.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structAQE2E9exgF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structAQE2E9exgF.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structAcoWvPhtlp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structAcoWvPhtlp.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structAiFfzJ9xOo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structAiFfzJ9xOo.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structAztsRhE0LF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structAztsRhE0LF.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structB9pN8GfUaU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structB9pN8GfUaU.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structBA8lKBvox6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structBA8lKBvox6.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structBBBafcZBl1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structBBBafcZBl1.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structBF8funmMCW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structBF8funmMCW.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structBNGrkk0Gq9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structBNGrkk0Gq9.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structBW4o7dJUoK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structBW4o7dJUoK.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structBWsRWzQ335.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structBWsRWzQ335.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structBfsVSixXGI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structBfsVSixXGI.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structBjERtQ98tj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structBjERtQ98tj.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structBjy5dZK2rM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structBjy5dZK2rM.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structBm7Ua0ACla.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structBm7Ua0ACla.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structBmz4OJxAlt.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structBmz4OJxAlt.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structBw3OKv2Qms.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structBw3OKv2Qms.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structBzSRBjnY22.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structBzSRBjnY22.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structC0g7V6d3fy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structC0g7V6d3fy.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structCBt0kIYRra.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structCBt0kIYRra.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structCOGSdZd0AL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structCOGSdZd0AL.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structCXeEkfG71q.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structCXeEkfG71q.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structCaHH2Xyhc7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structCaHH2Xyhc7.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structCcLnEruc0v.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structCcLnEruc0v.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structCfD3K5QvsN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structCfD3K5QvsN.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structCqQVJigrtI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structCqQVJigrtI.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structCzvlSZqJoZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structCzvlSZqJoZ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structD2oQVW5tnq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structD2oQVW5tnq.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structD4YplBwWDi.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structD4YplBwWDi.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structD9gno8tRvF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structD9gno8tRvF.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structDACFSZmJCd.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structDACFSZmJCd.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structDVPBdDC863.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structDVPBdDC863.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structDXFa0e4ozX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structDXFa0e4ozX.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structDZZWeqhEZS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structDZZWeqhEZS.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structDhEKpPXtbG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structDhEKpPXtbG.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structDi88qmJim6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structDi88qmJim6.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structDrIOG3dy4E.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structDrIOG3dy4E.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structE1izflhe7m.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structE1izflhe7m.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structE7tbP2KegJ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structE7tbP2KegJ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structECJjSKcI0x.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structECJjSKcI0x.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structECjdzNW2hb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structECjdzNW2hb.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structENNglh8DX6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structENNglh8DX6.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structEVUFJOsbyB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structEVUFJOsbyB.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structEa3Y8fmO5t.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structEa3Y8fmO5t.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structEbe6V1e8rk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structEbe6V1e8rk.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structEilgeng6RU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structEilgeng6RU.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structEjN7KM70nB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structEjN7KM70nB.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structEoc6yu6UZC.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structEoc6yu6UZC.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structEqZWhQIozu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structEqZWhQIozu.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structErRGvv06c5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structErRGvv06c5.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structEvFFf3fZGJ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structEvFFf3fZGJ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structEx5206L0wV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structEx5206L0wV.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structF3dNExh2mR.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structF3dNExh2mR.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structF8DhNrWv7E.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structF8DhNrWv7E.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structF9RjQ90jnp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structF9RjQ90jnp.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structFI3w6VQMfO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structFI3w6VQMfO.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structFJsonz9Nyz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structFJsonz9Nyz.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structFR85FzqbWk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structFR85FzqbWk.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structFXxZeDtCw5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structFXxZeDtCw5.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structFaTXoezJTa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structFaTXoezJTa.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structFhwETmltur.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structFhwETmltur.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structFjGw1Sgvhj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structFjGw1Sgvhj.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structFq1hfAwgHs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structFq1hfAwgHs.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structFvR9kgHTwq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structFvR9kgHTwq.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structFx3ViT9W1l.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structFx3ViT9W1l.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structG23iNFg5pV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structG23iNFg5pV.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structG4WvAWeyY2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structG4WvAWeyY2.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structG5eiJlW14L.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structG5eiJlW14L.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structG7DG28rR3I.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structG7DG28rR3I.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structG8t7pJyR0P.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structG8t7pJyR0P.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structGAhk4JD5f5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structGAhk4JD5f5.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structGElc6so5Vx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structGElc6so5Vx.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structGL3ENulfXA.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structGL3ENulfXA.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structGPgos6Ga6k.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structGPgos6Ga6k.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structGVka0u9TDq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structGVka0u9TDq.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structGXNEUsfHGV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structGXNEUsfHGV.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structGajQGzODLb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structGajQGzODLb.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structGbvlSI6ZFM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structGbvlSI6ZFM.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structGgvsKvoP9v.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structGgvsKvoP9v.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structGiiPLasS8y.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structGiiPLasS8y.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structGlUP6EKlOZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structGlUP6EKlOZ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structGmNuKgusEl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structGmNuKgusEl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structGnndCPLSRE.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structGnndCPLSRE.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structGseI8AQPtb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structGseI8AQPtb.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structGyODqQmfLk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structGyODqQmfLk.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structH5eQeBi4oY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structH5eQeBi4oY.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structH6F7xwrgKM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structH6F7xwrgKM.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structHAW6jHGG5q.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structHAW6jHGG5q.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structHGMhtcP1Gs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structHGMhtcP1Gs.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structHNoL72ys27.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structHNoL72ys27.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structHOwIYbq2Gd.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structHOwIYbq2Gd.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structHQ1FzQOf8n.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structHQ1FzQOf8n.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structHQRXU94JgV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structHQRXU94JgV.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structHSN0q7oMVM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structHSN0q7oMVM.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structHYnhl5ltDv.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structHYnhl5ltDv.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structHcCEQbo9Zf.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structHcCEQbo9Zf.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structHfRiDfgqPK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structHfRiDfgqPK.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structHnGXhmegvA.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structHnGXhmegvA.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structHnNLvYqbMR.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structHnNLvYqbMR.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structHt9F9jtMD0.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structHt9F9jtMD0.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structHusaUbKJVm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structHusaUbKJVm.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structHvGrPaR9Bu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structHvGrPaR9Bu.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structHvI693MHyM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structHvI693MHyM.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structHyrFeqyBCY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structHyrFeqyBCY.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structHzJtxAljeg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structHzJtxAljeg.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structI2aSLtV0nK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structI2aSLtV0nK.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structI5QO2BUMxk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structI5QO2BUMxk.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structI6BZQjT6lx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structI6BZQjT6lx.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structICD2Fjdvwq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structICD2Fjdvwq.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structIHkMJI02Cs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structIHkMJI02Cs.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structIJpxdh5h1j.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structIJpxdh5h1j.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structIKVPnPqtVG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structIKVPnPqtVG.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structIODsh0cyAj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structIODsh0cyAj.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structIWnVfC7bMR.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structIWnVfC7bMR.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structIg48IJ1BGz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structIg48IJ1BGz.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structIjpYds4lWa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structIjpYds4lWa.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structImqfRF5u5d.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structImqfRF5u5d.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structIpNWKHAjIK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structIpNWKHAjIK.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structIq2IxAwTbz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structIq2IxAwTbz.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structIqjoEWN5a6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structIqjoEWN5a6.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structJ1WoVnmoNK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structJ1WoVnmoNK.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structJ4N4ApAuNd.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structJ4N4ApAuNd.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structJ4sxZ95hzs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structJ4sxZ95hzs.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structJ5ThymSmBk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structJ5ThymSmBk.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structJBdaFHCitX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structJBdaFHCitX.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structJBjYKH35Id.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structJBjYKH35Id.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structJEL7o5TRHh.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structJEL7o5TRHh.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structJFU1xlKVwi.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structJFU1xlKVwi.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structJIOp0LkuGx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structJIOp0LkuGx.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structJKSxRHdkgU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structJKSxRHdkgU.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structJLl1JS3EBA.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structJLl1JS3EBA.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structJPod17bl3h.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structJPod17bl3h.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structJSkoDJdEmy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structJSkoDJdEmy.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structJXZ8aT3Z1A.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structJXZ8aT3Z1A.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structJYFDwGezZu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structJYFDwGezZu.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structJZBOzjdChs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structJZBOzjdChs.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structJcJCwPR9O6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structJcJCwPR9O6.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structJdaXHv9XGK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structJdaXHv9XGK.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structJguJlpO2Zx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structJguJlpO2Zx.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structJjOrVxY09U.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structJjOrVxY09U.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structJmS6AEcW3Z.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structJmS6AEcW3Z.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structJmgvdzeb5n.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structJmgvdzeb5n.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structJt6jf8vpBs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structJt6jf8vpBs.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structJyoG3utfUF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structJyoG3utfUF.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structK17aJaWFKp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structK17aJaWFKp.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structK6zBHvtXEz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structK6zBHvtXEz.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structK8yLeG1Rq8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structK8yLeG1Rq8.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structKAGtyEb0Mc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structKAGtyEb0Mc.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structKBZsUWVDxs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structKBZsUWVDxs.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structKD97Jf4W3S.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structKD97Jf4W3S.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structKDBDsZNe9Z.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structKDBDsZNe9Z.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structKDWeAZ2IPn.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structKDWeAZ2IPn.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structKF4sn2PYXa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structKF4sn2PYXa.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structKHnzHYYQv9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structKHnzHYYQv9.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structKJhvJs3EGG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structKJhvJs3EGG.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structKLSPh0PXhl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structKLSPh0PXhl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structKNZX9fxtdl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structKNZX9fxtdl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structKS9Hbi6AwZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structKS9Hbi6AwZ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structKVlfLjDmn1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structKVlfLjDmn1.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structKX2JHsJ0bd.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structKX2JHsJ0bd.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structKkESsYkID7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structKkESsYkID7.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structKkHcnJvU6l.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structKkHcnJvU6l.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structKkvn2ffBgz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structKkvn2ffBgz.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structKxmFSKOkr0.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structKxmFSKOkr0.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structL0iuHiXIxa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structL0iuHiXIxa.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structL28FwCaWlq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structL28FwCaWlq.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structL3YlcXIU3G.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structL3YlcXIU3G.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structL5PAA2Y49o.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structL5PAA2Y49o.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structL8rTw5Q3JI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structL8rTw5Q3JI.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structLJsbrcp1QV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structLJsbrcp1QV.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structLKxIRREq4D.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structLKxIRREq4D.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structLMQlSHV6GT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structLMQlSHV6GT.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structLV2nB9GvAz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structLV2nB9GvAz.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structLa1OJDLBp5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structLa1OJDLBp5.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structLcNNHqG92U.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structLcNNHqG92U.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structLnY2DL1Mbw.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structLnY2DL1Mbw.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structLpxoYUnOy7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structLpxoYUnOy7.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structLs7CLvlkgi.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structLs7CLvlkgi.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structLtMZ0XaStC.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structLtMZ0XaStC.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structLy4yvDjUuQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structLy4yvDjUuQ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structM9DKZGOLDg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structM9DKZGOLDg.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structMBndhRFxei.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structMBndhRFxei.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structMEcvkINwlN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structMEcvkINwlN.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structMFY7puSlGX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structMFY7puSlGX.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structMQnq3Fo18k.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structMQnq3Fo18k.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structMRN9c8EZAu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structMRN9c8EZAu.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structMSaXkM98gx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structMSaXkM98gx.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structMe4GO0lmyL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structMe4GO0lmyL.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structMf7H2FRsCR.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structMf7H2FRsCR.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structMgFMQz9tN4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structMgFMQz9tN4.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structMhWZ76XLqK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structMhWZ76XLqK.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structMiv3889DlT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structMiv3889DlT.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structMkNnqyG9Tl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structMkNnqyG9Tl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structMw7h6zUCoS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structMw7h6zUCoS.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structN5CGh6EWiK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structN5CGh6EWiK.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structN86zzxZWL3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structN86zzxZWL3.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structN9VLieAgkB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structN9VLieAgkB.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structNB005jf6q4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structNB005jf6q4.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structNW2O8zaFJU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structNW2O8zaFJU.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structNXVElSFyJY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structNXVElSFyJY.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structNXkTPXgNCQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structNXkTPXgNCQ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structNYxtIN1k6X.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structNYxtIN1k6X.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structNcunqydrcp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structNcunqydrcp.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structNfG8poVmRX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structNfG8poVmRX.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structNpSaGkUh99.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structNpSaGkUh99.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structNphpYJarez.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structNphpYJarez.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structNq8WSpQa6r.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structNq8WSpQa6r.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structNuHNDIZUYr.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structNuHNDIZUYr.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structO4Kr2Vp6iB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structO4Kr2Vp6iB.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structO5SpO4Lmqy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structO5SpO4Lmqy.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structO6aBEtLHCl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structO6aBEtLHCl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structO8aC92gkJu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structO8aC92gkJu.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structOAXjhVxHVW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structOAXjhVxHVW.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structOBggRrGGeA.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structOBggRrGGeA.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structOCKiZ8XvN4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structOCKiZ8XvN4.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structOTagHf6dta.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structOTagHf6dta.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structOmPR4GDmha.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structOmPR4GDmha.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structOnU7Y1iyOW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structOnU7Y1iyOW.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structOruSh6IU68.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structOruSh6IU68.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structP07kLcgWy2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structP07kLcgWy2.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structP0hi03Yr5J.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structP0hi03Yr5J.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structP51IT0iQls.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structP51IT0iQls.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structPC53CFAahl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structPC53CFAahl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structPDETEBub2B.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structPDETEBub2B.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structPIEO17rXv3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structPIEO17rXv3.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structPL1Vy8gAQG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structPL1Vy8gAQG.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structPOAJbOn5yN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structPOAJbOn5yN.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structPWOGZtzGIy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structPWOGZtzGIy.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structPWOtvXxst0.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structPWOtvXxst0.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structPaMBWeOEZb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structPaMBWeOEZb.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structPbViqUkC9s.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structPbViqUkC9s.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structPjXLhVCSo2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structPjXLhVCSo2.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structPmsSWhVFlx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structPmsSWhVFlx.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structPvttwCSove.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structPvttwCSove.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structPy7auxT2wm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structPy7auxT2wm.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structPzKBHCX9aj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structPzKBHCX9aj.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structQ1lt85NZkv.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structQ1lt85NZkv.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structQ9W3v3dQYW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structQ9W3v3dQYW.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structQBpF2mc1un.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structQBpF2mc1un.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structQLoTxIicfl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structQLoTxIicfl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structQNBjmFEISk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structQNBjmFEISk.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structQRNlszU7N1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structQRNlszU7N1.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structQRrZvgSvEl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structQRrZvgSvEl.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structQu8eKSWeIJ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structQu8eKSWeIJ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structQwjx7jDCDX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structQwjx7jDCDX.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structQwri7Ax9TK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structQwri7Ax9TK.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structR4xaEYdpRY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structR4xaEYdpRY.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structR6bsgVIYE6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structR6bsgVIYE6.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structR6j965l6JZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structR6j965l6JZ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structR6yPnOD0oz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structR6yPnOD0oz.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structR8eEQpI0YT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structR8eEQpI0YT.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structRBr9HNIGgm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structRBr9HNIGgm.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structRBwjivoMMP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structRBwjivoMMP.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structRFFK9pIT93.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structRFFK9pIT93.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structRJYj3K0a3c.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structRJYj3K0a3c.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structRLhaWW9haz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structRLhaWW9haz.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structRSckKIVPNO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structRSckKIVPNO.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structRX7hJYzEEc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structRX7hJYzEEc.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structRbEgtyrBAH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structRbEgtyrBAH.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structRbgB04HmL4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structRbgB04HmL4.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structRdgEVFWPU8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structRdgEVFWPU8.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structRjYd0rym9S.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structRjYd0rym9S.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structRpd0ErOBb6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structRpd0ErOBb6.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structRtcf0YV8fO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structRtcf0YV8fO.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structRtjThoUz7H.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structRtjThoUz7H.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structRyTk5RxJJO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structRyTk5RxJJO.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structS1RhuauboU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structS1RhuauboU.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structS6bmXaMMyl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structS6bmXaMMyl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structSDPIMkAwH8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structSDPIMkAwH8.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structSEmAsgVkk9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structSEmAsgVkk9.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structSIfHQocAM7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structSIfHQocAM7.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structSL3XN9PByF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structSL3XN9PByF.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structSOJZorG6h4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structSOJZorG6h4.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structSOQ2b3Trj9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structSOQ2b3Trj9.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structSOcWqfVVcP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structSOcWqfVVcP.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structSUuI5kWBPQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structSUuI5kWBPQ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structSWz0ZdY1fL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structSWz0ZdY1fL.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structSXB5wflpQj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structSXB5wflpQj.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structSaCKmxwW7X.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structSaCKmxwW7X.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structSkgZGVkxzj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structSkgZGVkxzj.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structSuSfIvUv2A.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structSuSfIvUv2A.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structSuaJbDOn73.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structSuaJbDOn73.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structSv55DLNwHy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structSv55DLNwHy.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structSvXjwmwWp8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structSvXjwmwWp8.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structT024qoIGBu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structT024qoIGBu.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structT396ygje53.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structT396ygje53.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structTA8Sp22K2U.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structTA8Sp22K2U.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structTGF07uM1y9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structTGF07uM1y9.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structTKbYYBx9QZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structTKbYYBx9QZ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structTLyC86eODa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structTLyC86eODa.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structTSEu5hclTq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structTSEu5hclTq.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structTX5YCrOcOo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structTX5YCrOcOo.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structTX6rXf2RZh.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structTX6rXf2RZh.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structTaJbzfeDjo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structTaJbzfeDjo.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structTaYGLKdSM8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structTaYGLKdSM8.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structTgcZPmWOx2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structTgcZPmWOx2.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structTh5NbnUqzI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structTh5NbnUqzI.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structTknpxoQFvS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structTknpxoQFvS.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structTqu8KoZQjY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structTqu8KoZQjY.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structTuAcbBNnZm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structTuAcbBNnZm.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structTuWH3zeluv.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structTuWH3zeluv.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structTwjPuMKDiB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structTwjPuMKDiB.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structTxF88EuH4Q.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structTxF88EuH4Q.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structTzQ4rWvlZ3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structTzQ4rWvlZ3.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structU2kogkOlcf.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structU2kogkOlcf.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structU3dy6bkQcN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structU3dy6bkQcN.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structUA5Zgdsa4W.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structUA5Zgdsa4W.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structUC7urls6rG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structUC7urls6rG.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structUJ5RVg0xHN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structUJ5RVg0xHN.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structUL0XgKUiea.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structUL0XgKUiea.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structUYdnQvYvKk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structUYdnQvYvKk.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structUaTPRyIwWQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structUaTPRyIwWQ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structUgp6Bg804O.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structUgp6Bg804O.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structUgsqUT0Fw8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structUgsqUT0Fw8.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structUomjJGDhS3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structUomjJGDhS3.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structUrJ7tMPYdi.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structUrJ7tMPYdi.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structUsGUm5feCJ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structUsGUm5feCJ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structUx6sDnae6o.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structUx6sDnae6o.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structUyBELJkxhd.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structUyBELJkxhd.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structV1mFMqHDyz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structV1mFMqHDyz.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structV3DEOjYkAI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structV3DEOjYkAI.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structV4EcMh64Nu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structV4EcMh64Nu.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structVABFQlbdB8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structVABFQlbdB8.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structVCKWE5qXDQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structVCKWE5qXDQ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structVF3eV6RT5A.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structVF3eV6RT5A.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structVGVFt2H4Jq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structVGVFt2H4Jq.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structVHmibu21U1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structVHmibu21U1.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structVJQMEbTTcW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structVJQMEbTTcW.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structVW9Wugrq8f.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structVW9Wugrq8f.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structVbui9U8nJN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structVbui9U8nJN.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structVqmZxmYjrS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structVqmZxmYjrS.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structVwumd12dMR.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structVwumd12dMR.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structW03TuqLzYH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structW03TuqLzYH.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structW6NGdR4FHA.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structW6NGdR4FHA.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structW8RwEte1K1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structW8RwEte1K1.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structWFr5O7xRwi.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structWFr5O7xRwi.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structWJw9ZLP7fK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structWJw9ZLP7fK.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structWODpD4eAmE.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structWODpD4eAmE.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structWOGNQBbIW7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structWOGNQBbIW7.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structWQN1KyUD5b.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structWQN1KyUD5b.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structWTDgYPieK1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structWTDgYPieK1.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structWVtboPH1aE.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structWVtboPH1aE.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structWiPM4vCvbR.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structWiPM4vCvbR.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structWk1zWo8r9K.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structWk1zWo8r9K.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structWkYOcVuG9r.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structWkYOcVuG9r.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structWqKLr6PuT3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structWqKLr6PuT3.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structWyFaNRxWDU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structWyFaNRxWDU.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structX0tLJiI6QS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structX0tLJiI6QS.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structX74WdLPgP3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structX74WdLPgP3.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structXLePVWtJFS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structXLePVWtJFS.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structXNJAbmwEpz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structXNJAbmwEpz.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structXOlFj8WTWU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structXOlFj8WTWU.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structXQpY9eJk4m.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structXQpY9eJk4m.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structXU2GzBHEnm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structXU2GzBHEnm.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structXWIUjIMjuc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structXWIUjIMjuc.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structXYOl2gpZhZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structXYOl2gpZhZ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structXYrXq7Kz5O.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structXYrXq7Kz5O.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structXab1L6RKkc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structXab1L6RKkc.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structXcQSZS9Pq3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structXcQSZS9Pq3.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structXdOq3rooU7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structXdOq3rooU7.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structXpfvMzo3SU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structXpfvMzo3SU.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structXs0m0HB3Ve.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structXs0m0HB3Ve.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structXsoVym5xGF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structXsoVym5xGF.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structXxbrxyvfJK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structXxbrxyvfJK.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structY0sbuM1lf1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structY0sbuM1lf1.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structY2WI2qZBJc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structY2WI2qZBJc.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structY3MSP8GJLq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structY3MSP8GJLq.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structY7ZzgHzGVw.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structY7ZzgHzGVw.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structY8HkjRfwpg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structY8HkjRfwpg.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structYAzsftuDhx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structYAzsftuDhx.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structYE37gD7DoN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structYE37gD7DoN.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structYNODMJt0nI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structYNODMJt0nI.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structYOoQMQYEZo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structYOoQMQYEZo.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structYPtr2Dr86B.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structYPtr2Dr86B.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structYXRqKm5H9U.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structYXRqKm5H9U.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structYa2X1A0XlS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structYa2X1A0XlS.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structYj7TbLsdP4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structYj7TbLsdP4.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structYlF6RxCqVs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structYlF6RxCqVs.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structYo1jTzfuKl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structYo1jTzfuKl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structYrew2qdBuH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structYrew2qdBuH.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structYwZwDfIvIG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structYwZwDfIvIG.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structZ3DY5gvzFY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structZ3DY5gvzFY.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structZBrvC38b8N.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structZBrvC38b8N.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structZC6ZaapQdD.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structZC6ZaapQdD.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structZGNK9Twr9S.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structZGNK9Twr9S.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structZGqp2bRDtx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structZGqp2bRDtx.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structZJSKolxfqc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structZJSKolxfqc.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structZR3LiJX7PO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structZR3LiJX7PO.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structZW26HGLchP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structZW26HGLchP.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structZi1RqmdSol.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structZi1RqmdSol.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structZoimFj6xEE.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structZoimFj6xEE.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structZpfDnRPksn.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structZpfDnRPksn.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structZr2k5TeLcE.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structZr2k5TeLcE.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structZtqbbnQjzj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structZtqbbnQjzj.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structZupKEHABUk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structZupKEHABUk.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structa0AhWFAoDG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structa0AhWFAoDG.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structa5eW784LQf.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structa5eW784LQf.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structa6BXYQAwEm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structa6BXYQAwEm.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structa6bL6toTDQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structa6bL6toTDQ.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structa85eS8wvGC.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structa85eS8wvGC.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structaBCMiwiL14.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structaBCMiwiL14.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structaCvUpfrOud.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structaCvUpfrOud.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structaMVAJ9INz0.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structaMVAJ9INz0.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structaNX02HPg7T.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structaNX02HPg7T.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structaacjP2BYDY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structaacjP2BYDY.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structafSLEQGtjb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structafSLEQGtjb.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structawZmlvXiXW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structawZmlvXiXW.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structaxV4fiWwZ7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structaxV4fiWwZ7.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structayNEhBBg4t.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structayNEhBBg4t.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structb265yb0csM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structb265yb0csM.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structb63fAzKNR7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structb63fAzKNR7.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structbBsug1Wd34.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structbBsug1Wd34.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structbNMyvNH8WM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structbNMyvNH8WM.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structbX4S27LXkH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structbX4S27LXkH.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structblpexlSs9M.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structblpexlSs9M.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structbmmnw9qu32.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structbmmnw9qu32.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structbsrrxTZOqn.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structbsrrxTZOqn.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structbtgnPXO5Rq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structbtgnPXO5Rq.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structbwtswCbHZn.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structbwtswCbHZn.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structc0ARtdYgED.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structc0ARtdYgED.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structc0K76QtGvt.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structc0K76QtGvt.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structc19BIAaEkY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structc19BIAaEkY.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structcIUFEZhrle.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structcIUFEZhrle.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structcU51DXcyE8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structcU51DXcyE8.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structcbnz0kvIwn.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structcbnz0kvIwn.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structcfbnUeCgbt.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structcfbnUeCgbt.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structcjMmD9Dwfx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structcjMmD9Dwfx.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structclmVkpAhb8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structclmVkpAhb8.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structcoAqE1boX6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structcoAqE1boX6.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structcormXUf4WS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structcormXUf4WS.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structcqdGRq2WNh.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structcqdGRq2WNh.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structczOiELiAB7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structczOiELiAB7.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structd2ojXxCaNW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structd2ojXxCaNW.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structd4OcbMDcGL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structd4OcbMDcGL.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structd9nB4x1U6u.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structd9nB4x1U6u.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structdEhJcrsORt.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structdEhJcrsORt.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structdKBNYvwyxK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structdKBNYvwyxK.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structdNGVHIlzAj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structdNGVHIlzAj.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structdSftno00MK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structdSftno00MK.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structdXZpHpuk3x.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structdXZpHpuk3x.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structdXgIF94ebo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structdXgIF94ebo.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structdhEH1P8yDX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structdhEH1P8yDX.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structdq0ytTGdT7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structdq0ytTGdT7.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structdr28D0z5ZH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structdr28D0z5ZH.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structe4z2kYEwsw.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structe4z2kYEwsw.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structe79Za4b7Ml.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structe79Za4b7Ml.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structeJF56nvsEj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structeJF56nvsEj.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structeW6hiVZjD9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structeW6hiVZjD9.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structegI0J6pwbq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structegI0J6pwbq.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structemjd05RWc3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structemjd05RWc3.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structeqBjnWgb5P.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structeqBjnWgb5P.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structf0akg4gumK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structf0akg4gumK.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structf32Rx1NpEm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structf32Rx1NpEm.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structf3hg4Duqet.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structf3hg4Duqet.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structf74ThK893J.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structf74ThK893J.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structfBkGsQBirP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structfBkGsQBirP.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structfCVtyydYxM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structfCVtyydYxM.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structfCayR9pma6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structfCayR9pma6.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structfG4ASdjUC9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structfG4ASdjUC9.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structfJdkVlyVac.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structfJdkVlyVac.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structfNnOzIDYzL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structfNnOzIDYzL.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structfOOjVzFOC9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structfOOjVzFOC9.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structfTXY9OU4mh.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structfTXY9OU4mh.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structfWEUc1K6FG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structfWEUc1K6FG.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structfYJ2Mkk1al.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structfYJ2Mkk1al.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structfcg2UqwprF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structfcg2UqwprF.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structfd0mCQVHBl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structfd0mCQVHBl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structfwecOIJDmQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structfwecOIJDmQ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structgBuG9DjtOU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structgBuG9DjtOU.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structgIAdPMClq9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structgIAdPMClq9.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structgJaEzQzHlG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structgJaEzQzHlG.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structgTI819u8oK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structgTI819u8oK.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structgaVRwvBYOY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structgaVRwvBYOY.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structgmDuxmO8uQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structgmDuxmO8uQ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structgnTh8YZCI4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structgnTh8YZCI4.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structgnzwfueLCU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structgnzwfueLCU.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structgodJTvsSrL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structgodJTvsSrL.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structgoyNOloADC.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structgoyNOloADC.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structgrMFKxp6Rp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structgrMFKxp6Rp.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structgu5AmoUnKH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structgu5AmoUnKH.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structgw0RpMV2f4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structgw0RpMV2f4.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structgzPFVO95T5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structgzPFVO95T5.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structh0wIvbjPFM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structh0wIvbjPFM.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structh0zYLuKys0.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structh0zYLuKys0.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structh4borQn8tt.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structh4borQn8tt.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structhEYyOpWNQA.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structhEYyOpWNQA.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structhKVOXTzhtj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structhKVOXTzhtj.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structhP7CI8CVIx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structhP7CI8CVIx.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structhRp6BjrXlq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structhRp6BjrXlq.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structhXluAaYGUP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structhXluAaYGUP.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structhc5U7IjcZc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structhc5U7IjcZc.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structhjYDoXKd1y.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structhjYDoXKd1y.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structhk5xXOFY3B.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structhk5xXOFY3B.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structhlXXNdntjL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structhlXXNdntjL.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structhnljKmvH1S.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structhnljKmvH1S.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structhsMP7WDnTb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structhsMP7WDnTb.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structi5tx16f99j.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structi5tx16f99j.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structi60i9flgEl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structi60i9flgEl.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structiGcBGhWkFg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structiGcBGhWkFg.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structiH2t1AudUv.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structiH2t1AudUv.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structiJO3yTUlA6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structiJO3yTUlA6.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structiMxQrDbyMm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structiMxQrDbyMm.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structiRTC8Ri5hh.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structiRTC8Ri5hh.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structiUTYiuw7nL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structiUTYiuw7nL.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structifVuZi4Efe.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structifVuZi4Efe.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structigySx6ywF4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structigySx6ywF4.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structimk6k6ZOQP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structimk6k6ZOQP.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structiyfYt6St4H.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structiyfYt6St4H.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structj0Jp6zlUkb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structj0Jp6zlUkb.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structj2noj6YBli.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structj2noj6YBli.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structj80X6OAWFM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structj80X6OAWFM.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structjATzvt82Yc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structjATzvt82Yc.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structjHYdKd1qGS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structjHYdKd1qGS.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structjIn9JVMI49.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structjIn9JVMI49.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structjKvkQzPnI2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structjKvkQzPnI2.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structjPeWDdzelT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structjPeWDdzelT.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structjVynlgrJOg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structjVynlgrJOg.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structjXzq5dAQfq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structjXzq5dAQfq.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structjlEQy1XgIm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structjlEQy1XgIm.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structjpZYztDGZv.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structjpZYztDGZv.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structjyzBmrWLpD.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structjyzBmrWLpD.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structjzLZ1Fd1su.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structjzLZ1Fd1su.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structk0RWOtD4Cb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structk0RWOtD4Cb.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structk5uhI551Ib.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structk5uhI551Ib.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structkBpo9DUgjg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structkBpo9DUgjg.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structkKCqpBwgSB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structkKCqpBwgSB.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structkMn4TDNnDw.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structkMn4TDNnDw.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structkTDa7zOTTq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structkTDa7zOTTq.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structkcnuBfgvqB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structkcnuBfgvqB.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structke5R4wNmaV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structke5R4wNmaV.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structkgOVznysHS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structkgOVznysHS.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structkjR2PqZPCx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structkjR2PqZPCx.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structkjvkPYElx2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structkjvkPYElx2.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structko3HKcubO4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structko3HKcubO4.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structl1rwee6A0W.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structl1rwee6A0W.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structl9GK15NFfI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structl9GK15NFfI.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structl9dEcAYjZX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structl9dEcAYjZX.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structlCbFTLeEcO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structlCbFTLeEcO.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structlFoUTH7TGY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structlFoUTH7TGY.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structlFuagxP4pj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structlFuagxP4pj.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structlKqlZNIiTG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structlKqlZNIiTG.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structlM9nCK9mVa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structlM9nCK9mVa.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structlNxcettVbW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structlNxcettVbW.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structlOMWejTcie.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structlOMWejTcie.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structlPPzP90v2M.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structlPPzP90v2M.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structlWE7ijbTPg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structlWE7ijbTPg.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structlWZpr8mFUz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structlWZpr8mFUz.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structlfb6Bcmyzv.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structlfb6Bcmyzv.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structliZR39PG4B.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structliZR39PG4B.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structlilo17vqrO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structlilo17vqrO.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structlmBHuI2CdK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structlmBHuI2CdK.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structlsRnaxudRi.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structlsRnaxudRi.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structlwBBVufID9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structlwBBVufID9.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structmE7fFfuHjx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structmE7fFfuHjx.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structmPX6OOh4Nl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structmPX6OOh4Nl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structmR2t9GgAZ5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structmR2t9GgAZ5.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structmU9k8N2S1x.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structmU9k8N2S1x.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structmUQioQKiXp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structmUQioQKiXp.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structmWBF30udKT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structmWBF30udKT.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structmaUySacG7e.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structmaUySacG7e.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structmj4Oyb3GgX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structmj4Oyb3GgX.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structmuAhuD4KVQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structmuAhuD4KVQ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structmwjaO3Uyrs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structmwjaO3Uyrs.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structn5h1DHBxub.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structn5h1DHBxub.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structnAdqmBnbeg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structnAdqmBnbeg.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structnAvYhH07Gs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structnAvYhH07Gs.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structnHnX8P1WDq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structnHnX8P1WDq.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structnNkjJDcz0P.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structnNkjJDcz0P.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structnPwZk9I7YN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structnPwZk9I7YN.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structnUJfW4NMaA.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structnUJfW4NMaA.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structnXMZUp9V4V.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structnXMZUp9V4V.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structnjkuDZnOoQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structnjkuDZnOoQ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structnq8k7vNWX3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structnq8k7vNWX3.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structnrVsGpyHSB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structnrVsGpyHSB.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structnsGvdkMRFZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structnsGvdkMRFZ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structoAhXI74h9j.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structoAhXI74h9j.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structoahbTSUqku.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structoahbTSUqku.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structoiRn4GygF9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structoiRn4GygF9.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structov6aJQLXqu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structov6aJQLXqu.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structovm1h7N1tD.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structovm1h7N1tD.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structoypCXXMXYK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structoypCXXMXYK.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structp39x1W6Nmw.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structp39x1W6Nmw.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structp5F0SqEi1N.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structp5F0SqEi1N.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structpK1zdl2ooH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structpK1zdl2ooH.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structpLXABe2wJc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structpLXABe2wJc.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structpMr2v6juAQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structpMr2v6juAQ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structpXZA41Y8fK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structpXZA41Y8fK.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structpkIouuiKqe.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structpkIouuiKqe.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structpnMhTmK3QH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structpnMhTmK3QH.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structpuA2r64pbW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structpuA2r64pbW.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structpwCAT0hshK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structpwCAT0hshK.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structq1BEWkecYX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structq1BEWkecYX.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structq2gqs38KnH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structq2gqs38KnH.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structq5OjZ10BEs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structq5OjZ10BEs.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structqGa10MSSRs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structqGa10MSSRs.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structqGuE1lEn2E.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structqGuE1lEn2E.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structqK7XKTZI6a.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structqK7XKTZI6a.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structqRtOraogqy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structqRtOraogqy.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structqTdD25cQMq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structqTdD25cQMq.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structqVenFBZMmB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structqVenFBZMmB.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structqVymoyiTzO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structqVymoyiTzO.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structqYoMOdyW5o.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structqYoMOdyW5o.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structqZqGFZMAp0.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structqZqGFZMAp0.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structqceTFkotG1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structqceTFkotG1.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structqklsh0VtCj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structqklsh0VtCj.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structqkwGFodzYo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structqkwGFodzYo.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structqlynSYPIzj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structqlynSYPIzj.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structqmylEQUQxN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structqmylEQUQxN.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structqsdnJQvtod.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structqsdnJQvtod.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structr1IUWdH7kS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structr1IUWdH7kS.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structrDLhl5fFyI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structrDLhl5fFyI.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structrJ6A29EFD3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structrJ6A29EFD3.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structrLI0qkdwNT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structrLI0qkdwNT.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structrNNNMoMUX5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structrNNNMoMUX5.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structrQyjIvxeGC.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structrQyjIvxeGC.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structrUZIsQzLzo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structrUZIsQzLzo.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structrUrNNgGYxl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structrUrNNgGYxl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structrZORE7saci.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structrZORE7saci.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structrnEvXbtOaJ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structrnEvXbtOaJ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structrv6cJ7e4eI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structrv6cJ7e4eI.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structrvnG4DB0O9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structrvnG4DB0O9.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structrxuRIzLrOd.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structrxuRIzLrOd.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structs0wKthNJDH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structs0wKthNJDH.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structs6tlj8Ujb6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structs6tlj8Ujb6.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structs81xiTr3V2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structs81xiTr3V2.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structs9FC686ssT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structs9FC686ssT.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structsU7ru1S3Bn.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structsU7ru1S3Bn.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structsconExg82n.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structsconExg82n.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structsnl6YWFzw6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structsnl6YWFzw6.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structsr11hihvVP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structsr11hihvVP.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structsrFnuySLJZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structsrFnuySLJZ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structsyMjE23XYL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structsyMjE23XYL.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structt1zhtoy3QG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structt1zhtoy3QG.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structt3vc10gLez.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structt3vc10gLez.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structt7Y6XwomUH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structt7Y6XwomUH.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structtFfTsyMFtj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structtFfTsyMFtj.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structtKTQH67TAx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structtKTQH67TAx.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structtRnRKY1Nt9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structtRnRKY1Nt9.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structtVv0gLLUw6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structtVv0gLLUw6.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structtdu9UH9BR6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structtdu9UH9BR6.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structtkLijaINDB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structtkLijaINDB.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structtmi3Y4xjWJ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structtmi3Y4xjWJ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structtoRHBeshpF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structtoRHBeshpF.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structtoojZOxzYL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structtoojZOxzYL.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structuEWock0xfg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structuEWock0xfg.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structuYFS57GpEz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structuYFS57GpEz.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structuZLTFqoTc9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structuZLTFqoTc9.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structuesCCsCmB9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structuesCCsCmB9.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structuk9n40Ba1s.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structuk9n40Ba1s.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structurOByRIJr5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structurOByRIJr5.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structusM7i9eFda.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structusM7i9eFda.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structuzTdZWiu60.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structuzTdZWiu60.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structv4jF52UQ9H.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structv4jF52UQ9H.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structv9bmg59CEV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structv9bmg59CEV.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structvE6YTruKB5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structvE6YTruKB5.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structvGYXxaXkfO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structvGYXxaXkfO.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structvIiPiag0AP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structvIiPiag0AP.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structvJXxV1TNGG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structvJXxV1TNGG.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structvLrhLw24Yo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structvLrhLw24Yo.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structvPLGLtUGvc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structvPLGLtUGvc.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structvQ4tBtsFIQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structvQ4tBtsFIQ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structvetTPo8phL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structvetTPo8phL.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structvh6HUMxCO1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structvh6HUMxCO1.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structvhPOJekCB6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structvhPOJekCB6.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structvqpjGCBNgC.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structvqpjGCBNgC.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structw1Jcuo2qcB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structw1Jcuo2qcB.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structw1LUTeHkEP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structw1LUTeHkEP.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structw704rOrUeD.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structw704rOrUeD.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structwAVE8pzuIw.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structwAVE8pzuIw.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structwE9USHmMoa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structwE9USHmMoa.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structwKyV6c3NXx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structwKyV6c3NXx.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structwNNWk20409.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structwNNWk20409.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structwPjsuxb7PR.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structwPjsuxb7PR.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structwquRams9Fs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structwquRams9Fs.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structwyz9cVcdwh.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structwyz9cVcdwh.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structx29mgYMw04.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structx29mgYMw04.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structx9kDs7ICzW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structx9kDs7ICzW.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structxFTWeVz86X.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structxFTWeVz86X.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structxI8aw5DOBf.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structxI8aw5DOBf.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structxKJxcMqgXp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structxKJxcMqgXp.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structxSyTOLVs2a.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structxSyTOLVs2a.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structxY83QlHYu8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structxY83QlHYu8.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structxatoIPHwut.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structxatoIPHwut.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structxayiSk9poY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structxayiSk9poY.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structxl0tHilNDj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structxl0tHilNDj.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structxpKM8hQmHX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structxpKM8hQmHX.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structxrKKgR1Fe1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structxrKKgR1Fe1.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structxsR9aAsAXm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structxsR9aAsAXm.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structxwNsI8Zdb1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structxwNsI8Zdb1.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structy2eHpFGRr5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structy2eHpFGRr5.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structy5X9cuxDIn.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structy5X9cuxDIn.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structy5wbr5f4bB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structy5wbr5f4bB.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structyAGnaq1EBc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structyAGnaq1EBc.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structyGjRe5am7c.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structyGjRe5am7c.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structyKsJfDGXaz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structyKsJfDGXaz.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structyNBvxKIcti.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structyNBvxKIcti.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structyPEdNMH6Lo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structyPEdNMH6Lo.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structyTmtkFKqd7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structyTmtkFKqd7.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structydbIqe0qPo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structydbIqe0qPo.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structyhDvAbXvCv.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structyhDvAbXvCv.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structynitZhhUeJ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structynitZhhUeJ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structyvVgkdYRXO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structyvVgkdYRXO.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structz1JgTXpAuI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structz1JgTXpAuI.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structz7dfzzL9Yk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structz7dfzzL9Yk.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structzIXefsJFSz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structzIXefsJFSz.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structzPWDt4oN6i.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structzPWDt4oN6i.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structzQUyc7Ws0e.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structzQUyc7Ws0e.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structzTIpN6ALMu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structzTIpN6ALMu.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structzYoD4xKxnZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structzYoD4xKxnZ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structzdXNEcof9V.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structzdXNEcof9V.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structzo3owhla9x.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structzo3owhla9x.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structzyowJj76a6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v5.0/readonly-partial-structzyowJj76a6.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct00oieaoYA5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct00oieaoYA5.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct05nZxSvOQy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct05nZxSvOQy.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct0CW6rWihRa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct0CW6rWihRa.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct0EiiHjJ0Jy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct0EiiHjJ0Jy.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct0HxVdkFuDk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct0HxVdkFuDk.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct0Sp8nFf9po.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct0Sp8nFf9po.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct0YOigHUonk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct0YOigHUonk.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct0mu68DyXFS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct0mu68DyXFS.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct0oZl05ifoL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct0oZl05ifoL.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct101P28DC6b.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct101P28DC6b.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct109xwVU7na.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct109xwVU7na.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct13ZLCuuDdg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct13ZLCuuDdg.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct164v5M7Oiu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct164v5M7Oiu.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct16i8Hnvzik.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct16i8Hnvzik.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct1B64P2KJTT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct1B64P2KJTT.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct1FLNprzFfg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct1FLNprzFfg.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct1Lodf8jQhi.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct1Lodf8jQhi.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct1NM3qeUh2p.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct1NM3qeUh2p.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct1QKloRyprM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct1QKloRyprM.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct1TeundtXb1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct1TeundtXb1.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct1e9vZ2ZVVl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct1e9vZ2ZVVl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct1ibkpE2U9t.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct1ibkpE2U9t.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct1jAvJkz71q.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct1jAvJkz71q.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct1kIcXqyaMm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct1kIcXqyaMm.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct1kIjvNmL26.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct1kIjvNmL26.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct1nopkP9yWt.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct1nopkP9yWt.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct1q3mpvDeuG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct1q3mpvDeuG.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct1rwcZsOxGm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct1rwcZsOxGm.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct1shpv6NmPc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct1shpv6NmPc.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct1tertRu9Xm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct1tertRu9Xm.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct1xSlrFoiE2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct1xSlrFoiE2.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct1xjEjG8zge.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct1xjEjG8zge.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct1zEPcP8TZ0.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct1zEPcP8TZ0.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct22wFvfGOQe.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct22wFvfGOQe.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct23OaGTh97N.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct23OaGTh97N.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct2C0v3cLs4t.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct2C0v3cLs4t.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct2Ii6Pytw94.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct2Ii6Pytw94.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct2KJvO9ifSa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct2KJvO9ifSa.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct2Oea4qEuqL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct2Oea4qEuqL.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct2PRjv73LUz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct2PRjv73LUz.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct2PlWXW13Oo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct2PlWXW13Oo.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct2RjyXdbOmS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct2RjyXdbOmS.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct2WJXBATRow.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct2WJXBATRow.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct2ePshLeWkH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct2ePshLeWkH.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct2iRAZCo7L5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct2iRAZCo7L5.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct2l1qlatawT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct2l1qlatawT.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct2lPhMAoDBl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct2lPhMAoDBl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct2mrBdiaAsD.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct2mrBdiaAsD.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct2yK9S7dzeX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct2yK9S7dzeX.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct2yeMfnvK5l.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct2yeMfnvK5l.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct34i0YswjFg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct34i0YswjFg.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct3AvV0e5RCv.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct3AvV0e5RCv.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct3Fkic0RvsS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct3Fkic0RvsS.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct3Q09CNhFqG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct3Q09CNhFqG.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct3W5X0ROtrE.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct3W5X0ROtrE.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct3YKEcUcTm6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct3YKEcUcTm6.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct3Ysql1aZTo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct3Ysql1aZTo.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct3aLcZ0Gzdp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct3aLcZ0Gzdp.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct3bQ2CbXXiG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct3bQ2CbXXiG.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct3hbQkh2oXr.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct3hbQkh2oXr.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct3o9W3tWIYr.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct3o9W3tWIYr.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct3oRAhgtPFs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct3oRAhgtPFs.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct3rEqyW20Ha.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct3rEqyW20Ha.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct3rh7agTF1u.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct3rh7agTF1u.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct3tAXhVgz0j.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct3tAXhVgz0j.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct3udOlsWezr.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct3udOlsWezr.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct3yavERh0QP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct3yavERh0QP.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct40R1V76roU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct40R1V76roU.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct44PftY660j.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct44PftY660j.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct46ykdVFGwG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct46ykdVFGwG.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct47pp9CzShs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct47pp9CzShs.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct49eWbTEG4e.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct49eWbTEG4e.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct4I0C5KiBcT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct4I0C5KiBcT.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct4NHzRc00m2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct4NHzRc00m2.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct4R1b3Sfk6J.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct4R1b3Sfk6J.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct4VkhuwJa8e.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct4VkhuwJa8e.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct4bA4rV4T7I.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct4bA4rV4T7I.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct4qOfIMBclV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct4qOfIMBclV.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct4tYHXfgnVZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct4tYHXfgnVZ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct4xCfXxpvdy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct4xCfXxpvdy.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct4zYtkggxX9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct4zYtkggxX9.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct566AUa8c9w.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct566AUa8c9w.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct5B3Ki66g8U.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct5B3Ki66g8U.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct5GIHfCnyF0.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct5GIHfCnyF0.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct5GXqW1XpIl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct5GXqW1XpIl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct5R3JtFMKyy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct5R3JtFMKyy.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct5WOnMXao7S.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct5WOnMXao7S.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct5WjoUCBC2W.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct5WjoUCBC2W.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct5YuboIIJis.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct5YuboIIJis.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct5coPgZ627S.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct5coPgZ627S.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct5nsLLrnYzS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct5nsLLrnYzS.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct5p0wzn3Twr.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct5p0wzn3Twr.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct5pUyGEiqRW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct5pUyGEiqRW.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct66VojQk1NI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct66VojQk1NI.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct67D9OX1YBs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct67D9OX1YBs.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct67XWJDtmLp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct67XWJDtmLp.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct6ACGifRdRw.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct6ACGifRdRw.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct6AkdgH06Lh.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct6AkdgH06Lh.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct6BWJO4ygCh.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct6BWJO4ygCh.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct6Eho6XNoOx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct6Eho6XNoOx.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct6Fnny4hIyl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct6Fnny4hIyl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct6GnahT2THT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct6GnahT2THT.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct6Gy1eE7iFg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct6Gy1eE7iFg.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct6InhhK3Bnx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct6InhhK3Bnx.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct6KaWm2V4so.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct6KaWm2V4so.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct6NVZQs4UrE.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct6NVZQs4UrE.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct6PUxZ29VTq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct6PUxZ29VTq.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct6fce05Qu1f.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct6fce05Qu1f.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct6tzbdxQpL4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct6tzbdxQpL4.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct763ixhZiPg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct763ixhZiPg.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct79tZSSX75b.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct79tZSSX75b.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct7E3RzOaVF1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct7E3RzOaVF1.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct7Ev4ba5U4g.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct7Ev4ba5U4g.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct7FkotSk0XD.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct7FkotSk0XD.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct7MpRJpjzYV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct7MpRJpjzYV.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct7UAHrFSXgp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct7UAHrFSXgp.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct7ZDRFK7C6w.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct7ZDRFK7C6w.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct7hWyxK9Im1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct7hWyxK9Im1.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct7vhsXm5Sqy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct7vhsXm5Sqy.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct7vwzjN2hQB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct7vwzjN2hQB.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct7x47kTkDWA.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct7x47kTkDWA.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct814BQq200G.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct814BQq200G.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct84TN7zjoK9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct84TN7zjoK9.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct8CllamWxHF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct8CllamWxHF.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct8KGpb7sMhV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct8KGpb7sMhV.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct8P1XTIrmCU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct8P1XTIrmCU.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct8eGauAG2Iy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct8eGauAG2Iy.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct8hD3MVC60I.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct8hD3MVC60I.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct8q0Jpdjx8u.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct8q0Jpdjx8u.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct8qIwjmR7oN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct8qIwjmR7oN.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct8tbcftbwF8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct8tbcftbwF8.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct8txOZ8smgu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct8txOZ8smgu.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct8yaeAzdZUO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct8yaeAzdZUO.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct98nsmL4Uyu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct98nsmL4Uyu.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct9CTRHeV5gV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct9CTRHeV5gV.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct9E3xYWs4gr.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct9E3xYWs4gr.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct9FbBK7sAEy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct9FbBK7sAEy.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct9HOIXHYhP9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct9HOIXHYhP9.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct9IzMME36Bl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct9IzMME36Bl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct9PLpEx4eEr.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct9PLpEx4eEr.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct9QX6aOMWmP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct9QX6aOMWmP.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct9XFvojKqS7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct9XFvojKqS7.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct9Z0NXJ0nuB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct9Z0NXJ0nuB.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct9cdQxj05PP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct9cdQxj05PP.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct9dJLrfdwrb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct9dJLrfdwrb.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct9fPHF2RcIG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct9fPHF2RcIG.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct9o9IQlJhfF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct9o9IQlJhfF.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct9rTJlJQ4St.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct9rTJlJQ4St.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct9tS75raz9v.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-struct9tS75raz9v.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structA0t67j1fxp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structA0t67j1fxp.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structA2y6S9lFjD.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structA2y6S9lFjD.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structA4N6i5eArl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structA4N6i5eArl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structA6J9ouYjJm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structA6J9ouYjJm.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structAB03r2H43b.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structAB03r2H43b.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structADRxlKyBIl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structADRxlKyBIl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structAE7oPkwYY6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structAE7oPkwYY6.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structAHdMDYZJaK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structAHdMDYZJaK.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structAK2drK1aH7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structAK2drK1aH7.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structAPZGaaiAsI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structAPZGaaiAsI.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structAQE2E9exgF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structAQE2E9exgF.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structAcoWvPhtlp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structAcoWvPhtlp.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structAiFfzJ9xOo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structAiFfzJ9xOo.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structAztsRhE0LF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structAztsRhE0LF.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structB9pN8GfUaU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structB9pN8GfUaU.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structBA8lKBvox6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structBA8lKBvox6.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structBBBafcZBl1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structBBBafcZBl1.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structBF8funmMCW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structBF8funmMCW.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structBNGrkk0Gq9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structBNGrkk0Gq9.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structBW4o7dJUoK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structBW4o7dJUoK.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structBWsRWzQ335.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structBWsRWzQ335.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structBfsVSixXGI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structBfsVSixXGI.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structBjERtQ98tj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structBjERtQ98tj.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structBjy5dZK2rM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structBjy5dZK2rM.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structBm7Ua0ACla.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structBm7Ua0ACla.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structBmz4OJxAlt.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structBmz4OJxAlt.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structBw3OKv2Qms.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structBw3OKv2Qms.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structBzSRBjnY22.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structBzSRBjnY22.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structC0g7V6d3fy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structC0g7V6d3fy.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structCBt0kIYRra.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structCBt0kIYRra.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structCOGSdZd0AL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structCOGSdZd0AL.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structCXeEkfG71q.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structCXeEkfG71q.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structCaHH2Xyhc7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structCaHH2Xyhc7.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structCcLnEruc0v.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structCcLnEruc0v.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structCfD3K5QvsN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structCfD3K5QvsN.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structCqQVJigrtI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structCqQVJigrtI.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structCzvlSZqJoZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structCzvlSZqJoZ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structD2oQVW5tnq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structD2oQVW5tnq.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structD4YplBwWDi.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structD4YplBwWDi.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structD9gno8tRvF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structD9gno8tRvF.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structDACFSZmJCd.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structDACFSZmJCd.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structDVPBdDC863.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structDVPBdDC863.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structDXFa0e4ozX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structDXFa0e4ozX.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structDZZWeqhEZS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structDZZWeqhEZS.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structDhEKpPXtbG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structDhEKpPXtbG.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structDi88qmJim6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structDi88qmJim6.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structDrIOG3dy4E.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structDrIOG3dy4E.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structE1izflhe7m.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structE1izflhe7m.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structE7tbP2KegJ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structE7tbP2KegJ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structECJjSKcI0x.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structECJjSKcI0x.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structECjdzNW2hb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structECjdzNW2hb.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structENNglh8DX6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structENNglh8DX6.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structEVUFJOsbyB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structEVUFJOsbyB.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structEa3Y8fmO5t.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structEa3Y8fmO5t.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structEbe6V1e8rk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structEbe6V1e8rk.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structEilgeng6RU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structEilgeng6RU.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structEjN7KM70nB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structEjN7KM70nB.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structEoc6yu6UZC.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structEoc6yu6UZC.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structEqZWhQIozu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structEqZWhQIozu.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structErRGvv06c5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structErRGvv06c5.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structEvFFf3fZGJ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structEvFFf3fZGJ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structEx5206L0wV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structEx5206L0wV.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structF3dNExh2mR.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structF3dNExh2mR.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structF8DhNrWv7E.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structF8DhNrWv7E.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structF9RjQ90jnp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structF9RjQ90jnp.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structFI3w6VQMfO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structFI3w6VQMfO.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structFJsonz9Nyz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structFJsonz9Nyz.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structFR85FzqbWk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structFR85FzqbWk.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structFXxZeDtCw5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structFXxZeDtCw5.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structFaTXoezJTa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structFaTXoezJTa.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structFhwETmltur.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structFhwETmltur.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structFjGw1Sgvhj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structFjGw1Sgvhj.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structFq1hfAwgHs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structFq1hfAwgHs.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structFvR9kgHTwq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structFvR9kgHTwq.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structFx3ViT9W1l.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structFx3ViT9W1l.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structG23iNFg5pV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structG23iNFg5pV.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structG4WvAWeyY2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structG4WvAWeyY2.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structG5eiJlW14L.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structG5eiJlW14L.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structG7DG28rR3I.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structG7DG28rR3I.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structG8t7pJyR0P.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structG8t7pJyR0P.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structGAhk4JD5f5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structGAhk4JD5f5.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structGElc6so5Vx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structGElc6so5Vx.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structGL3ENulfXA.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structGL3ENulfXA.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structGPgos6Ga6k.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structGPgos6Ga6k.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structGVka0u9TDq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structGVka0u9TDq.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structGXNEUsfHGV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structGXNEUsfHGV.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structGajQGzODLb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structGajQGzODLb.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structGbvlSI6ZFM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structGbvlSI6ZFM.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structGgvsKvoP9v.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structGgvsKvoP9v.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structGiiPLasS8y.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structGiiPLasS8y.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structGlUP6EKlOZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structGlUP6EKlOZ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structGmNuKgusEl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structGmNuKgusEl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structGnndCPLSRE.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structGnndCPLSRE.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structGseI8AQPtb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structGseI8AQPtb.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structGyODqQmfLk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structGyODqQmfLk.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structH5eQeBi4oY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structH5eQeBi4oY.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structH6F7xwrgKM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structH6F7xwrgKM.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structHAW6jHGG5q.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structHAW6jHGG5q.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structHGMhtcP1Gs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structHGMhtcP1Gs.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structHNoL72ys27.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structHNoL72ys27.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structHOwIYbq2Gd.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structHOwIYbq2Gd.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structHQ1FzQOf8n.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structHQ1FzQOf8n.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structHQRXU94JgV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structHQRXU94JgV.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structHSN0q7oMVM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structHSN0q7oMVM.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structHYnhl5ltDv.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structHYnhl5ltDv.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structHcCEQbo9Zf.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structHcCEQbo9Zf.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structHfRiDfgqPK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structHfRiDfgqPK.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structHnGXhmegvA.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structHnGXhmegvA.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structHnNLvYqbMR.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structHnNLvYqbMR.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structHt9F9jtMD0.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structHt9F9jtMD0.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structHusaUbKJVm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structHusaUbKJVm.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structHvGrPaR9Bu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structHvGrPaR9Bu.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structHvI693MHyM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structHvI693MHyM.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structHyrFeqyBCY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structHyrFeqyBCY.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structHzJtxAljeg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structHzJtxAljeg.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structI2aSLtV0nK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structI2aSLtV0nK.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structI5QO2BUMxk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structI5QO2BUMxk.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structI6BZQjT6lx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structI6BZQjT6lx.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structICD2Fjdvwq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structICD2Fjdvwq.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structIHkMJI02Cs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structIHkMJI02Cs.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structIJpxdh5h1j.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structIJpxdh5h1j.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structIKVPnPqtVG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structIKVPnPqtVG.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structIODsh0cyAj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structIODsh0cyAj.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structIWnVfC7bMR.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structIWnVfC7bMR.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structIg48IJ1BGz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structIg48IJ1BGz.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structIjpYds4lWa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structIjpYds4lWa.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structImqfRF5u5d.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structImqfRF5u5d.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structIpNWKHAjIK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structIpNWKHAjIK.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structIq2IxAwTbz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structIq2IxAwTbz.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structIqjoEWN5a6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structIqjoEWN5a6.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structJ1WoVnmoNK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structJ1WoVnmoNK.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structJ4N4ApAuNd.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structJ4N4ApAuNd.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structJ4sxZ95hzs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structJ4sxZ95hzs.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structJ5ThymSmBk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structJ5ThymSmBk.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structJBdaFHCitX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structJBdaFHCitX.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structJBjYKH35Id.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structJBjYKH35Id.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structJEL7o5TRHh.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structJEL7o5TRHh.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structJFU1xlKVwi.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structJFU1xlKVwi.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structJIOp0LkuGx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structJIOp0LkuGx.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structJKSxRHdkgU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structJKSxRHdkgU.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structJLl1JS3EBA.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structJLl1JS3EBA.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structJPod17bl3h.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structJPod17bl3h.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structJSkoDJdEmy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structJSkoDJdEmy.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structJXZ8aT3Z1A.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structJXZ8aT3Z1A.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structJYFDwGezZu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structJYFDwGezZu.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structJZBOzjdChs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structJZBOzjdChs.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structJcJCwPR9O6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structJcJCwPR9O6.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structJdaXHv9XGK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structJdaXHv9XGK.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structJguJlpO2Zx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structJguJlpO2Zx.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structJjOrVxY09U.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structJjOrVxY09U.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structJmS6AEcW3Z.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structJmS6AEcW3Z.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structJmgvdzeb5n.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structJmgvdzeb5n.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structJt6jf8vpBs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structJt6jf8vpBs.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structJyoG3utfUF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structJyoG3utfUF.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structK17aJaWFKp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structK17aJaWFKp.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structK6zBHvtXEz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structK6zBHvtXEz.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structK8yLeG1Rq8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structK8yLeG1Rq8.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structKAGtyEb0Mc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structKAGtyEb0Mc.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structKBZsUWVDxs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structKBZsUWVDxs.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structKD97Jf4W3S.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structKD97Jf4W3S.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structKDBDsZNe9Z.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structKDBDsZNe9Z.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structKDWeAZ2IPn.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structKDWeAZ2IPn.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structKF4sn2PYXa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structKF4sn2PYXa.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structKHnzHYYQv9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structKHnzHYYQv9.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structKJhvJs3EGG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structKJhvJs3EGG.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structKLSPh0PXhl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structKLSPh0PXhl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structKNZX9fxtdl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structKNZX9fxtdl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structKS9Hbi6AwZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structKS9Hbi6AwZ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structKVlfLjDmn1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structKVlfLjDmn1.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structKX2JHsJ0bd.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structKX2JHsJ0bd.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structKkESsYkID7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structKkESsYkID7.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structKkHcnJvU6l.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structKkHcnJvU6l.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structKkvn2ffBgz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structKkvn2ffBgz.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structKxmFSKOkr0.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structKxmFSKOkr0.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structL0iuHiXIxa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structL0iuHiXIxa.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structL28FwCaWlq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structL28FwCaWlq.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structL3YlcXIU3G.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structL3YlcXIU3G.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structL5PAA2Y49o.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structL5PAA2Y49o.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structL8rTw5Q3JI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structL8rTw5Q3JI.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structLJsbrcp1QV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structLJsbrcp1QV.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structLKxIRREq4D.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structLKxIRREq4D.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structLMQlSHV6GT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structLMQlSHV6GT.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structLV2nB9GvAz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structLV2nB9GvAz.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structLa1OJDLBp5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structLa1OJDLBp5.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structLcNNHqG92U.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structLcNNHqG92U.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structLnY2DL1Mbw.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structLnY2DL1Mbw.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structLpxoYUnOy7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structLpxoYUnOy7.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structLs7CLvlkgi.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structLs7CLvlkgi.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structLtMZ0XaStC.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structLtMZ0XaStC.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structLy4yvDjUuQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structLy4yvDjUuQ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structM9DKZGOLDg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structM9DKZGOLDg.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structMBndhRFxei.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structMBndhRFxei.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structMEcvkINwlN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structMEcvkINwlN.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structMFY7puSlGX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structMFY7puSlGX.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structMQnq3Fo18k.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structMQnq3Fo18k.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structMRN9c8EZAu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structMRN9c8EZAu.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structMSaXkM98gx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structMSaXkM98gx.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structMe4GO0lmyL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structMe4GO0lmyL.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structMf7H2FRsCR.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structMf7H2FRsCR.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structMgFMQz9tN4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structMgFMQz9tN4.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structMhWZ76XLqK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structMhWZ76XLqK.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structMiv3889DlT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structMiv3889DlT.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structMkNnqyG9Tl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structMkNnqyG9Tl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structMw7h6zUCoS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structMw7h6zUCoS.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structN5CGh6EWiK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structN5CGh6EWiK.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structN86zzxZWL3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structN86zzxZWL3.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structN9VLieAgkB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structN9VLieAgkB.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structNB005jf6q4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structNB005jf6q4.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structNW2O8zaFJU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structNW2O8zaFJU.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structNXVElSFyJY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structNXVElSFyJY.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structNXkTPXgNCQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structNXkTPXgNCQ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structNYxtIN1k6X.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structNYxtIN1k6X.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structNcunqydrcp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structNcunqydrcp.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structNfG8poVmRX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structNfG8poVmRX.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structNpSaGkUh99.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structNpSaGkUh99.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structNphpYJarez.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structNphpYJarez.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structNq8WSpQa6r.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structNq8WSpQa6r.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structNuHNDIZUYr.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structNuHNDIZUYr.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structO4Kr2Vp6iB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structO4Kr2Vp6iB.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structO5SpO4Lmqy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structO5SpO4Lmqy.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structO6aBEtLHCl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structO6aBEtLHCl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structO8aC92gkJu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structO8aC92gkJu.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structOAXjhVxHVW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structOAXjhVxHVW.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structOBggRrGGeA.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structOBggRrGGeA.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structOCKiZ8XvN4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structOCKiZ8XvN4.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structOTagHf6dta.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structOTagHf6dta.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structOmPR4GDmha.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structOmPR4GDmha.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structOnU7Y1iyOW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structOnU7Y1iyOW.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structOruSh6IU68.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structOruSh6IU68.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structP07kLcgWy2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structP07kLcgWy2.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structP0hi03Yr5J.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structP0hi03Yr5J.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structP51IT0iQls.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structP51IT0iQls.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structPC53CFAahl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structPC53CFAahl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structPDETEBub2B.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structPDETEBub2B.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structPIEO17rXv3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structPIEO17rXv3.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structPL1Vy8gAQG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structPL1Vy8gAQG.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structPOAJbOn5yN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structPOAJbOn5yN.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structPWOGZtzGIy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structPWOGZtzGIy.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structPWOtvXxst0.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structPWOtvXxst0.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structPaMBWeOEZb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structPaMBWeOEZb.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structPbViqUkC9s.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structPbViqUkC9s.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structPjXLhVCSo2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structPjXLhVCSo2.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structPmsSWhVFlx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structPmsSWhVFlx.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structPvttwCSove.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structPvttwCSove.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structPy7auxT2wm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structPy7auxT2wm.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structPzKBHCX9aj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structPzKBHCX9aj.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structQ1lt85NZkv.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structQ1lt85NZkv.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structQ9W3v3dQYW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structQ9W3v3dQYW.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structQBpF2mc1un.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structQBpF2mc1un.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structQLoTxIicfl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structQLoTxIicfl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structQNBjmFEISk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structQNBjmFEISk.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structQRNlszU7N1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structQRNlszU7N1.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structQRrZvgSvEl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structQRrZvgSvEl.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structQu8eKSWeIJ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structQu8eKSWeIJ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structQwjx7jDCDX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structQwjx7jDCDX.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structQwri7Ax9TK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structQwri7Ax9TK.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structR4xaEYdpRY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structR4xaEYdpRY.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structR6bsgVIYE6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structR6bsgVIYE6.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structR6j965l6JZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structR6j965l6JZ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structR6yPnOD0oz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structR6yPnOD0oz.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structR8eEQpI0YT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structR8eEQpI0YT.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structRBr9HNIGgm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structRBr9HNIGgm.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structRBwjivoMMP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structRBwjivoMMP.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structRFFK9pIT93.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structRFFK9pIT93.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structRJYj3K0a3c.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structRJYj3K0a3c.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structRLhaWW9haz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structRLhaWW9haz.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structRSckKIVPNO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structRSckKIVPNO.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structRX7hJYzEEc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structRX7hJYzEEc.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structRbEgtyrBAH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structRbEgtyrBAH.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structRbgB04HmL4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structRbgB04HmL4.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structRdgEVFWPU8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structRdgEVFWPU8.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structRjYd0rym9S.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structRjYd0rym9S.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structRpd0ErOBb6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structRpd0ErOBb6.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structRtcf0YV8fO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structRtcf0YV8fO.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structRtjThoUz7H.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structRtjThoUz7H.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structRyTk5RxJJO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structRyTk5RxJJO.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structS1RhuauboU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structS1RhuauboU.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structS6bmXaMMyl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structS6bmXaMMyl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structSDPIMkAwH8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structSDPIMkAwH8.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structSEmAsgVkk9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structSEmAsgVkk9.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structSIfHQocAM7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structSIfHQocAM7.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structSL3XN9PByF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structSL3XN9PByF.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structSOJZorG6h4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structSOJZorG6h4.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structSOQ2b3Trj9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structSOQ2b3Trj9.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structSOcWqfVVcP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structSOcWqfVVcP.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structSUuI5kWBPQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structSUuI5kWBPQ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structSWz0ZdY1fL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structSWz0ZdY1fL.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structSXB5wflpQj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structSXB5wflpQj.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structSaCKmxwW7X.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structSaCKmxwW7X.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structSkgZGVkxzj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structSkgZGVkxzj.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structSuSfIvUv2A.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structSuSfIvUv2A.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structSuaJbDOn73.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structSuaJbDOn73.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structSv55DLNwHy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structSv55DLNwHy.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structSvXjwmwWp8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structSvXjwmwWp8.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structT024qoIGBu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structT024qoIGBu.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structT396ygje53.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structT396ygje53.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structTA8Sp22K2U.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structTA8Sp22K2U.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structTGF07uM1y9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structTGF07uM1y9.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structTKbYYBx9QZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structTKbYYBx9QZ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structTLyC86eODa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structTLyC86eODa.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structTSEu5hclTq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structTSEu5hclTq.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structTX5YCrOcOo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structTX5YCrOcOo.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structTX6rXf2RZh.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structTX6rXf2RZh.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structTaJbzfeDjo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structTaJbzfeDjo.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structTaYGLKdSM8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structTaYGLKdSM8.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structTgcZPmWOx2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structTgcZPmWOx2.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structTh5NbnUqzI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structTh5NbnUqzI.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structTknpxoQFvS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structTknpxoQFvS.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structTqu8KoZQjY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structTqu8KoZQjY.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structTuAcbBNnZm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structTuAcbBNnZm.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structTuWH3zeluv.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structTuWH3zeluv.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structTwjPuMKDiB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structTwjPuMKDiB.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structTxF88EuH4Q.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structTxF88EuH4Q.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structTzQ4rWvlZ3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structTzQ4rWvlZ3.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structU2kogkOlcf.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structU2kogkOlcf.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structU3dy6bkQcN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structU3dy6bkQcN.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structUA5Zgdsa4W.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structUA5Zgdsa4W.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structUC7urls6rG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structUC7urls6rG.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structUJ5RVg0xHN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structUJ5RVg0xHN.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structUL0XgKUiea.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structUL0XgKUiea.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structUYdnQvYvKk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structUYdnQvYvKk.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structUaTPRyIwWQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structUaTPRyIwWQ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structUgp6Bg804O.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structUgp6Bg804O.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structUgsqUT0Fw8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structUgsqUT0Fw8.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structUomjJGDhS3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structUomjJGDhS3.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structUrJ7tMPYdi.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structUrJ7tMPYdi.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structUsGUm5feCJ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structUsGUm5feCJ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structUx6sDnae6o.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structUx6sDnae6o.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structUyBELJkxhd.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structUyBELJkxhd.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structV1mFMqHDyz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structV1mFMqHDyz.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structV3DEOjYkAI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structV3DEOjYkAI.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structV4EcMh64Nu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structV4EcMh64Nu.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structVABFQlbdB8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structVABFQlbdB8.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structVCKWE5qXDQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structVCKWE5qXDQ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structVF3eV6RT5A.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structVF3eV6RT5A.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structVGVFt2H4Jq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structVGVFt2H4Jq.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structVHmibu21U1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structVHmibu21U1.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structVJQMEbTTcW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structVJQMEbTTcW.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structVW9Wugrq8f.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structVW9Wugrq8f.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structVbui9U8nJN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structVbui9U8nJN.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structVqmZxmYjrS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structVqmZxmYjrS.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structVwumd12dMR.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structVwumd12dMR.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structW03TuqLzYH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structW03TuqLzYH.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structW6NGdR4FHA.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structW6NGdR4FHA.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structW8RwEte1K1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structW8RwEte1K1.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structWFr5O7xRwi.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structWFr5O7xRwi.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structWJw9ZLP7fK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structWJw9ZLP7fK.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structWODpD4eAmE.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structWODpD4eAmE.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structWOGNQBbIW7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structWOGNQBbIW7.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structWQN1KyUD5b.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structWQN1KyUD5b.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structWTDgYPieK1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structWTDgYPieK1.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structWVtboPH1aE.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structWVtboPH1aE.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structWiPM4vCvbR.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structWiPM4vCvbR.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structWk1zWo8r9K.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structWk1zWo8r9K.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structWkYOcVuG9r.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structWkYOcVuG9r.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structWqKLr6PuT3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structWqKLr6PuT3.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structWyFaNRxWDU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structWyFaNRxWDU.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structX0tLJiI6QS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structX0tLJiI6QS.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structX74WdLPgP3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structX74WdLPgP3.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structXLePVWtJFS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structXLePVWtJFS.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structXNJAbmwEpz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structXNJAbmwEpz.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structXOlFj8WTWU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structXOlFj8WTWU.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structXQpY9eJk4m.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structXQpY9eJk4m.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structXU2GzBHEnm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structXU2GzBHEnm.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structXWIUjIMjuc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structXWIUjIMjuc.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structXYOl2gpZhZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structXYOl2gpZhZ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structXYrXq7Kz5O.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structXYrXq7Kz5O.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structXab1L6RKkc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structXab1L6RKkc.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structXcQSZS9Pq3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structXcQSZS9Pq3.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structXdOq3rooU7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structXdOq3rooU7.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structXpfvMzo3SU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structXpfvMzo3SU.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structXs0m0HB3Ve.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structXs0m0HB3Ve.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structXsoVym5xGF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structXsoVym5xGF.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structXxbrxyvfJK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structXxbrxyvfJK.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structY0sbuM1lf1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structY0sbuM1lf1.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structY2WI2qZBJc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structY2WI2qZBJc.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structY3MSP8GJLq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structY3MSP8GJLq.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structY7ZzgHzGVw.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structY7ZzgHzGVw.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structY8HkjRfwpg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structY8HkjRfwpg.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structYAzsftuDhx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structYAzsftuDhx.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structYE37gD7DoN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structYE37gD7DoN.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structYNODMJt0nI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structYNODMJt0nI.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structYOoQMQYEZo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structYOoQMQYEZo.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structYPtr2Dr86B.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structYPtr2Dr86B.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structYXRqKm5H9U.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structYXRqKm5H9U.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structYa2X1A0XlS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structYa2X1A0XlS.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structYj7TbLsdP4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structYj7TbLsdP4.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structYlF6RxCqVs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structYlF6RxCqVs.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structYo1jTzfuKl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structYo1jTzfuKl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structYrew2qdBuH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structYrew2qdBuH.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structYwZwDfIvIG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structYwZwDfIvIG.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structZ3DY5gvzFY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structZ3DY5gvzFY.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structZBrvC38b8N.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structZBrvC38b8N.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structZC6ZaapQdD.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structZC6ZaapQdD.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structZGNK9Twr9S.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structZGNK9Twr9S.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structZGqp2bRDtx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structZGqp2bRDtx.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structZJSKolxfqc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structZJSKolxfqc.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structZR3LiJX7PO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structZR3LiJX7PO.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structZW26HGLchP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structZW26HGLchP.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structZi1RqmdSol.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structZi1RqmdSol.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structZoimFj6xEE.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structZoimFj6xEE.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structZpfDnRPksn.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structZpfDnRPksn.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structZr2k5TeLcE.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structZr2k5TeLcE.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structZtqbbnQjzj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structZtqbbnQjzj.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structZupKEHABUk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structZupKEHABUk.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structa0AhWFAoDG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structa0AhWFAoDG.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structa5eW784LQf.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structa5eW784LQf.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structa6BXYQAwEm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structa6BXYQAwEm.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structa6bL6toTDQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structa6bL6toTDQ.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structa85eS8wvGC.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structa85eS8wvGC.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structaBCMiwiL14.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structaBCMiwiL14.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structaCvUpfrOud.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structaCvUpfrOud.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structaMVAJ9INz0.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structaMVAJ9INz0.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structaNX02HPg7T.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structaNX02HPg7T.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structaacjP2BYDY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structaacjP2BYDY.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structafSLEQGtjb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structafSLEQGtjb.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structawZmlvXiXW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structawZmlvXiXW.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structaxV4fiWwZ7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structaxV4fiWwZ7.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structayNEhBBg4t.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structayNEhBBg4t.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structb265yb0csM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structb265yb0csM.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structb63fAzKNR7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structb63fAzKNR7.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structbBsug1Wd34.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structbBsug1Wd34.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structbNMyvNH8WM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structbNMyvNH8WM.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structbX4S27LXkH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structbX4S27LXkH.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structblpexlSs9M.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structblpexlSs9M.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structbmmnw9qu32.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structbmmnw9qu32.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structbsrrxTZOqn.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structbsrrxTZOqn.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structbtgnPXO5Rq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structbtgnPXO5Rq.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structbwtswCbHZn.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structbwtswCbHZn.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structc0ARtdYgED.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structc0ARtdYgED.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structc0K76QtGvt.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structc0K76QtGvt.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structc19BIAaEkY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structc19BIAaEkY.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structcIUFEZhrle.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structcIUFEZhrle.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structcU51DXcyE8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structcU51DXcyE8.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structcbnz0kvIwn.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structcbnz0kvIwn.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structcfbnUeCgbt.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structcfbnUeCgbt.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structcjMmD9Dwfx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structcjMmD9Dwfx.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structclmVkpAhb8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structclmVkpAhb8.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structcoAqE1boX6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structcoAqE1boX6.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structcormXUf4WS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structcormXUf4WS.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structcqdGRq2WNh.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structcqdGRq2WNh.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structczOiELiAB7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structczOiELiAB7.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structd2ojXxCaNW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structd2ojXxCaNW.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structd4OcbMDcGL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structd4OcbMDcGL.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structd9nB4x1U6u.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structd9nB4x1U6u.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structdEhJcrsORt.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structdEhJcrsORt.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structdKBNYvwyxK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structdKBNYvwyxK.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structdNGVHIlzAj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structdNGVHIlzAj.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structdSftno00MK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structdSftno00MK.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structdXZpHpuk3x.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structdXZpHpuk3x.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structdXgIF94ebo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structdXgIF94ebo.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structdhEH1P8yDX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structdhEH1P8yDX.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structdq0ytTGdT7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structdq0ytTGdT7.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structdr28D0z5ZH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structdr28D0z5ZH.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structe4z2kYEwsw.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structe4z2kYEwsw.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structe79Za4b7Ml.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structe79Za4b7Ml.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structeJF56nvsEj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structeJF56nvsEj.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structeW6hiVZjD9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structeW6hiVZjD9.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structegI0J6pwbq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structegI0J6pwbq.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structemjd05RWc3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structemjd05RWc3.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structeqBjnWgb5P.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structeqBjnWgb5P.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structf0akg4gumK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structf0akg4gumK.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structf32Rx1NpEm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structf32Rx1NpEm.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structf3hg4Duqet.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structf3hg4Duqet.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structf74ThK893J.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structf74ThK893J.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structfBkGsQBirP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structfBkGsQBirP.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structfCVtyydYxM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structfCVtyydYxM.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structfCayR9pma6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structfCayR9pma6.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structfG4ASdjUC9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structfG4ASdjUC9.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structfJdkVlyVac.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structfJdkVlyVac.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structfNnOzIDYzL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structfNnOzIDYzL.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structfOOjVzFOC9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structfOOjVzFOC9.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structfTXY9OU4mh.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structfTXY9OU4mh.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structfWEUc1K6FG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structfWEUc1K6FG.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structfYJ2Mkk1al.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structfYJ2Mkk1al.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structfcg2UqwprF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structfcg2UqwprF.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structfd0mCQVHBl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structfd0mCQVHBl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structfwecOIJDmQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structfwecOIJDmQ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structgBuG9DjtOU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structgBuG9DjtOU.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structgIAdPMClq9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structgIAdPMClq9.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structgJaEzQzHlG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structgJaEzQzHlG.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structgTI819u8oK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structgTI819u8oK.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structgaVRwvBYOY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structgaVRwvBYOY.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structgmDuxmO8uQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structgmDuxmO8uQ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structgnTh8YZCI4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structgnTh8YZCI4.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structgnzwfueLCU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structgnzwfueLCU.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structgodJTvsSrL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structgodJTvsSrL.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structgoyNOloADC.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structgoyNOloADC.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structgrMFKxp6Rp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structgrMFKxp6Rp.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structgu5AmoUnKH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structgu5AmoUnKH.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structgw0RpMV2f4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structgw0RpMV2f4.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structgzPFVO95T5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structgzPFVO95T5.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structh0wIvbjPFM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structh0wIvbjPFM.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structh0zYLuKys0.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structh0zYLuKys0.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structh4borQn8tt.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structh4borQn8tt.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structhEYyOpWNQA.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structhEYyOpWNQA.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structhKVOXTzhtj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structhKVOXTzhtj.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structhP7CI8CVIx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structhP7CI8CVIx.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structhRp6BjrXlq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structhRp6BjrXlq.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structhXluAaYGUP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structhXluAaYGUP.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structhc5U7IjcZc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structhc5U7IjcZc.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structhjYDoXKd1y.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structhjYDoXKd1y.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structhk5xXOFY3B.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structhk5xXOFY3B.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structhlXXNdntjL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structhlXXNdntjL.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structhnljKmvH1S.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structhnljKmvH1S.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structhsMP7WDnTb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structhsMP7WDnTb.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structi5tx16f99j.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structi5tx16f99j.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structi60i9flgEl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structi60i9flgEl.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structiGcBGhWkFg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structiGcBGhWkFg.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structiH2t1AudUv.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structiH2t1AudUv.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structiJO3yTUlA6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structiJO3yTUlA6.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structiMxQrDbyMm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structiMxQrDbyMm.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structiRTC8Ri5hh.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structiRTC8Ri5hh.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structiUTYiuw7nL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structiUTYiuw7nL.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structifVuZi4Efe.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structifVuZi4Efe.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structigySx6ywF4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structigySx6ywF4.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structimk6k6ZOQP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structimk6k6ZOQP.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structiyfYt6St4H.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structiyfYt6St4H.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structj0Jp6zlUkb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structj0Jp6zlUkb.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structj2noj6YBli.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structj2noj6YBli.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structj80X6OAWFM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structj80X6OAWFM.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structjATzvt82Yc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structjATzvt82Yc.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structjHYdKd1qGS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structjHYdKd1qGS.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structjIn9JVMI49.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structjIn9JVMI49.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structjKvkQzPnI2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structjKvkQzPnI2.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structjPeWDdzelT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structjPeWDdzelT.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structjVynlgrJOg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structjVynlgrJOg.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structjXzq5dAQfq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structjXzq5dAQfq.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structjlEQy1XgIm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structjlEQy1XgIm.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structjpZYztDGZv.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structjpZYztDGZv.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structjyzBmrWLpD.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structjyzBmrWLpD.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structjzLZ1Fd1su.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structjzLZ1Fd1su.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structk0RWOtD4Cb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structk0RWOtD4Cb.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structk5uhI551Ib.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structk5uhI551Ib.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structkBpo9DUgjg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structkBpo9DUgjg.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structkKCqpBwgSB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structkKCqpBwgSB.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structkMn4TDNnDw.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structkMn4TDNnDw.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structkTDa7zOTTq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structkTDa7zOTTq.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structkcnuBfgvqB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structkcnuBfgvqB.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structke5R4wNmaV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structke5R4wNmaV.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structkgOVznysHS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structkgOVznysHS.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structkjR2PqZPCx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structkjR2PqZPCx.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structkjvkPYElx2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structkjvkPYElx2.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structko3HKcubO4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structko3HKcubO4.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structl1rwee6A0W.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structl1rwee6A0W.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structl9GK15NFfI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structl9GK15NFfI.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structl9dEcAYjZX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structl9dEcAYjZX.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structlCbFTLeEcO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structlCbFTLeEcO.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structlFoUTH7TGY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structlFoUTH7TGY.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structlFuagxP4pj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structlFuagxP4pj.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structlKqlZNIiTG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structlKqlZNIiTG.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structlM9nCK9mVa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structlM9nCK9mVa.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structlNxcettVbW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structlNxcettVbW.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structlOMWejTcie.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structlOMWejTcie.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structlPPzP90v2M.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structlPPzP90v2M.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structlWE7ijbTPg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structlWE7ijbTPg.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structlWZpr8mFUz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structlWZpr8mFUz.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structlfb6Bcmyzv.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structlfb6Bcmyzv.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structliZR39PG4B.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structliZR39PG4B.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structlilo17vqrO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structlilo17vqrO.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structlmBHuI2CdK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structlmBHuI2CdK.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structlsRnaxudRi.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structlsRnaxudRi.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structlwBBVufID9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structlwBBVufID9.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structmE7fFfuHjx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structmE7fFfuHjx.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structmPX6OOh4Nl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structmPX6OOh4Nl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structmR2t9GgAZ5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structmR2t9GgAZ5.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structmU9k8N2S1x.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structmU9k8N2S1x.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structmUQioQKiXp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structmUQioQKiXp.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structmWBF30udKT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structmWBF30udKT.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structmaUySacG7e.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structmaUySacG7e.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structmj4Oyb3GgX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structmj4Oyb3GgX.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structmuAhuD4KVQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structmuAhuD4KVQ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structmwjaO3Uyrs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structmwjaO3Uyrs.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structn5h1DHBxub.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structn5h1DHBxub.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structnAdqmBnbeg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structnAdqmBnbeg.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structnAvYhH07Gs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structnAvYhH07Gs.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structnHnX8P1WDq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structnHnX8P1WDq.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structnNkjJDcz0P.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structnNkjJDcz0P.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structnPwZk9I7YN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structnPwZk9I7YN.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structnUJfW4NMaA.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structnUJfW4NMaA.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structnXMZUp9V4V.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structnXMZUp9V4V.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structnjkuDZnOoQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structnjkuDZnOoQ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structnq8k7vNWX3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structnq8k7vNWX3.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structnrVsGpyHSB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structnrVsGpyHSB.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structnsGvdkMRFZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structnsGvdkMRFZ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structoAhXI74h9j.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structoAhXI74h9j.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structoahbTSUqku.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structoahbTSUqku.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structoiRn4GygF9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structoiRn4GygF9.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structov6aJQLXqu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structov6aJQLXqu.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structovm1h7N1tD.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structovm1h7N1tD.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structoypCXXMXYK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structoypCXXMXYK.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structp39x1W6Nmw.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structp39x1W6Nmw.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structp5F0SqEi1N.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structp5F0SqEi1N.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structpK1zdl2ooH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structpK1zdl2ooH.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structpLXABe2wJc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structpLXABe2wJc.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structpMr2v6juAQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structpMr2v6juAQ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structpXZA41Y8fK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structpXZA41Y8fK.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structpkIouuiKqe.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structpkIouuiKqe.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structpnMhTmK3QH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structpnMhTmK3QH.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structpuA2r64pbW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structpuA2r64pbW.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structpwCAT0hshK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structpwCAT0hshK.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structq1BEWkecYX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structq1BEWkecYX.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structq2gqs38KnH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structq2gqs38KnH.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structq5OjZ10BEs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structq5OjZ10BEs.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structqGa10MSSRs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structqGa10MSSRs.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structqGuE1lEn2E.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structqGuE1lEn2E.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structqK7XKTZI6a.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structqK7XKTZI6a.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structqRtOraogqy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structqRtOraogqy.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structqTdD25cQMq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structqTdD25cQMq.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structqVenFBZMmB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structqVenFBZMmB.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structqVymoyiTzO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structqVymoyiTzO.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structqYoMOdyW5o.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structqYoMOdyW5o.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structqZqGFZMAp0.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structqZqGFZMAp0.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structqceTFkotG1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structqceTFkotG1.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structqklsh0VtCj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structqklsh0VtCj.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structqkwGFodzYo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structqkwGFodzYo.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structqlynSYPIzj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structqlynSYPIzj.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structqmylEQUQxN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structqmylEQUQxN.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structqsdnJQvtod.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structqsdnJQvtod.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structr1IUWdH7kS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structr1IUWdH7kS.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structrDLhl5fFyI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structrDLhl5fFyI.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structrJ6A29EFD3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structrJ6A29EFD3.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structrLI0qkdwNT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structrLI0qkdwNT.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structrNNNMoMUX5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structrNNNMoMUX5.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structrQyjIvxeGC.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structrQyjIvxeGC.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structrUZIsQzLzo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structrUZIsQzLzo.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structrUrNNgGYxl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structrUrNNgGYxl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structrZORE7saci.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structrZORE7saci.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structrnEvXbtOaJ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structrnEvXbtOaJ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structrv6cJ7e4eI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structrv6cJ7e4eI.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structrvnG4DB0O9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structrvnG4DB0O9.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structrxuRIzLrOd.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structrxuRIzLrOd.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structs0wKthNJDH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structs0wKthNJDH.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structs6tlj8Ujb6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structs6tlj8Ujb6.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structs81xiTr3V2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structs81xiTr3V2.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structs9FC686ssT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structs9FC686ssT.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structsU7ru1S3Bn.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structsU7ru1S3Bn.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structsconExg82n.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structsconExg82n.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structsnl6YWFzw6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structsnl6YWFzw6.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structsr11hihvVP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structsr11hihvVP.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structsrFnuySLJZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structsrFnuySLJZ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structsyMjE23XYL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structsyMjE23XYL.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structt1zhtoy3QG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structt1zhtoy3QG.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structt3vc10gLez.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structt3vc10gLez.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structt7Y6XwomUH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structt7Y6XwomUH.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structtFfTsyMFtj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structtFfTsyMFtj.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structtKTQH67TAx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structtKTQH67TAx.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structtRnRKY1Nt9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structtRnRKY1Nt9.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structtVv0gLLUw6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structtVv0gLLUw6.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structtdu9UH9BR6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structtdu9UH9BR6.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structtkLijaINDB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structtkLijaINDB.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structtmi3Y4xjWJ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structtmi3Y4xjWJ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structtoRHBeshpF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structtoRHBeshpF.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structtoojZOxzYL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structtoojZOxzYL.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structuEWock0xfg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structuEWock0xfg.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structuYFS57GpEz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structuYFS57GpEz.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structuZLTFqoTc9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structuZLTFqoTc9.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structuesCCsCmB9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structuesCCsCmB9.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structuk9n40Ba1s.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structuk9n40Ba1s.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structurOByRIJr5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structurOByRIJr5.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structusM7i9eFda.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structusM7i9eFda.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structuzTdZWiu60.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structuzTdZWiu60.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structv4jF52UQ9H.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structv4jF52UQ9H.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structv9bmg59CEV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structv9bmg59CEV.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structvE6YTruKB5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structvE6YTruKB5.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structvGYXxaXkfO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structvGYXxaXkfO.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structvIiPiag0AP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structvIiPiag0AP.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structvJXxV1TNGG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structvJXxV1TNGG.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structvLrhLw24Yo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structvLrhLw24Yo.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structvPLGLtUGvc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structvPLGLtUGvc.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structvQ4tBtsFIQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structvQ4tBtsFIQ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structvetTPo8phL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structvetTPo8phL.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structvh6HUMxCO1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structvh6HUMxCO1.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structvhPOJekCB6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structvhPOJekCB6.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structvqpjGCBNgC.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structvqpjGCBNgC.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structw1Jcuo2qcB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structw1Jcuo2qcB.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structw1LUTeHkEP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structw1LUTeHkEP.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structw704rOrUeD.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structw704rOrUeD.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structwAVE8pzuIw.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structwAVE8pzuIw.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structwE9USHmMoa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structwE9USHmMoa.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structwKyV6c3NXx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structwKyV6c3NXx.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structwNNWk20409.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structwNNWk20409.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structwPjsuxb7PR.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structwPjsuxb7PR.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structwquRams9Fs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structwquRams9Fs.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structwyz9cVcdwh.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structwyz9cVcdwh.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structx29mgYMw04.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structx29mgYMw04.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structx9kDs7ICzW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structx9kDs7ICzW.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structxFTWeVz86X.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structxFTWeVz86X.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structxI8aw5DOBf.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structxI8aw5DOBf.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structxKJxcMqgXp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structxKJxcMqgXp.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structxSyTOLVs2a.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structxSyTOLVs2a.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structxY83QlHYu8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structxY83QlHYu8.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structxatoIPHwut.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structxatoIPHwut.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structxayiSk9poY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structxayiSk9poY.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structxl0tHilNDj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structxl0tHilNDj.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structxpKM8hQmHX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structxpKM8hQmHX.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structxrKKgR1Fe1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structxrKKgR1Fe1.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structxsR9aAsAXm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structxsR9aAsAXm.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structxwNsI8Zdb1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structxwNsI8Zdb1.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structy2eHpFGRr5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structy2eHpFGRr5.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structy5X9cuxDIn.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structy5X9cuxDIn.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structy5wbr5f4bB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structy5wbr5f4bB.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structyAGnaq1EBc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structyAGnaq1EBc.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structyGjRe5am7c.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structyGjRe5am7c.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structyKsJfDGXaz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structyKsJfDGXaz.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structyNBvxKIcti.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structyNBvxKIcti.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structyPEdNMH6Lo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structyPEdNMH6Lo.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structyTmtkFKqd7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structyTmtkFKqd7.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structydbIqe0qPo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structydbIqe0qPo.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structyhDvAbXvCv.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structyhDvAbXvCv.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structynitZhhUeJ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structynitZhhUeJ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structyvVgkdYRXO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structyvVgkdYRXO.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structz1JgTXpAuI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structz1JgTXpAuI.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structz7dfzzL9Yk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structz7dfzzL9Yk.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structzIXefsJFSz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structzIXefsJFSz.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structzPWDt4oN6i.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structzPWDt4oN6i.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structzQUyc7Ws0e.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structzQUyc7Ws0e.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structzTIpN6ALMu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structzTIpN6ALMu.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structzYoD4xKxnZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structzYoD4xKxnZ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structzdXNEcof9V.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structzdXNEcof9V.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structzo3owhla9x.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structzo3owhla9x.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structzyowJj76a6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/partial-structzyowJj76a6.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct00oieaoYA5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct00oieaoYA5.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct05nZxSvOQy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct05nZxSvOQy.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct0CW6rWihRa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct0CW6rWihRa.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct0EiiHjJ0Jy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct0EiiHjJ0Jy.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct0HxVdkFuDk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct0HxVdkFuDk.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct0Sp8nFf9po.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct0Sp8nFf9po.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct0YOigHUonk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct0YOigHUonk.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct0mu68DyXFS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct0mu68DyXFS.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct0oZl05ifoL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct0oZl05ifoL.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct101P28DC6b.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct101P28DC6b.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct109xwVU7na.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct109xwVU7na.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct13ZLCuuDdg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct13ZLCuuDdg.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct164v5M7Oiu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct164v5M7Oiu.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct16i8Hnvzik.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct16i8Hnvzik.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct1B64P2KJTT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct1B64P2KJTT.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct1FLNprzFfg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct1FLNprzFfg.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct1Lodf8jQhi.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct1Lodf8jQhi.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct1NM3qeUh2p.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct1NM3qeUh2p.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct1QKloRyprM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct1QKloRyprM.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct1TeundtXb1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct1TeundtXb1.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct1e9vZ2ZVVl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct1e9vZ2ZVVl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct1ibkpE2U9t.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct1ibkpE2U9t.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct1jAvJkz71q.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct1jAvJkz71q.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct1kIcXqyaMm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct1kIcXqyaMm.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct1kIjvNmL26.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct1kIjvNmL26.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct1nopkP9yWt.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct1nopkP9yWt.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct1q3mpvDeuG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct1q3mpvDeuG.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct1rwcZsOxGm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct1rwcZsOxGm.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct1shpv6NmPc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct1shpv6NmPc.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct1tertRu9Xm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct1tertRu9Xm.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct1xSlrFoiE2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct1xSlrFoiE2.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct1xjEjG8zge.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct1xjEjG8zge.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct1zEPcP8TZ0.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct1zEPcP8TZ0.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct22wFvfGOQe.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct22wFvfGOQe.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct23OaGTh97N.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct23OaGTh97N.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct2C0v3cLs4t.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct2C0v3cLs4t.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct2Ii6Pytw94.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct2Ii6Pytw94.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct2KJvO9ifSa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct2KJvO9ifSa.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct2Oea4qEuqL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct2Oea4qEuqL.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct2PRjv73LUz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct2PRjv73LUz.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct2PlWXW13Oo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct2PlWXW13Oo.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct2RjyXdbOmS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct2RjyXdbOmS.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct2WJXBATRow.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct2WJXBATRow.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct2ePshLeWkH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct2ePshLeWkH.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct2iRAZCo7L5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct2iRAZCo7L5.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct2l1qlatawT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct2l1qlatawT.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct2lPhMAoDBl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct2lPhMAoDBl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct2mrBdiaAsD.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct2mrBdiaAsD.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct2yK9S7dzeX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct2yK9S7dzeX.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct2yeMfnvK5l.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct2yeMfnvK5l.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct34i0YswjFg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct34i0YswjFg.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct3AvV0e5RCv.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct3AvV0e5RCv.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct3Fkic0RvsS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct3Fkic0RvsS.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct3Q09CNhFqG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct3Q09CNhFqG.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct3W5X0ROtrE.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct3W5X0ROtrE.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct3YKEcUcTm6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct3YKEcUcTm6.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct3Ysql1aZTo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct3Ysql1aZTo.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct3aLcZ0Gzdp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct3aLcZ0Gzdp.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct3bQ2CbXXiG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct3bQ2CbXXiG.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct3hbQkh2oXr.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct3hbQkh2oXr.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct3o9W3tWIYr.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct3o9W3tWIYr.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct3oRAhgtPFs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct3oRAhgtPFs.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct3rEqyW20Ha.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct3rEqyW20Ha.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct3rh7agTF1u.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct3rh7agTF1u.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct3tAXhVgz0j.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct3tAXhVgz0j.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct3udOlsWezr.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct3udOlsWezr.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct3yavERh0QP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct3yavERh0QP.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct40R1V76roU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct40R1V76roU.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct44PftY660j.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct44PftY660j.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct46ykdVFGwG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct46ykdVFGwG.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct47pp9CzShs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct47pp9CzShs.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct49eWbTEG4e.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct49eWbTEG4e.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct4I0C5KiBcT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct4I0C5KiBcT.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct4NHzRc00m2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct4NHzRc00m2.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct4R1b3Sfk6J.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct4R1b3Sfk6J.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct4VkhuwJa8e.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct4VkhuwJa8e.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct4bA4rV4T7I.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct4bA4rV4T7I.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct4qOfIMBclV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct4qOfIMBclV.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct4tYHXfgnVZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct4tYHXfgnVZ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct4xCfXxpvdy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct4xCfXxpvdy.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct4zYtkggxX9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct4zYtkggxX9.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct566AUa8c9w.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct566AUa8c9w.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct5B3Ki66g8U.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct5B3Ki66g8U.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct5GIHfCnyF0.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct5GIHfCnyF0.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct5GXqW1XpIl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct5GXqW1XpIl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct5R3JtFMKyy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct5R3JtFMKyy.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct5WOnMXao7S.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct5WOnMXao7S.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct5WjoUCBC2W.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct5WjoUCBC2W.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct5YuboIIJis.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct5YuboIIJis.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct5coPgZ627S.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct5coPgZ627S.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct5nsLLrnYzS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct5nsLLrnYzS.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct5p0wzn3Twr.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct5p0wzn3Twr.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct5pUyGEiqRW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct5pUyGEiqRW.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct66VojQk1NI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct66VojQk1NI.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct67D9OX1YBs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct67D9OX1YBs.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct67XWJDtmLp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct67XWJDtmLp.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct6ACGifRdRw.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct6ACGifRdRw.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct6AkdgH06Lh.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct6AkdgH06Lh.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct6BWJO4ygCh.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct6BWJO4ygCh.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct6Eho6XNoOx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct6Eho6XNoOx.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct6Fnny4hIyl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct6Fnny4hIyl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct6GnahT2THT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct6GnahT2THT.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct6Gy1eE7iFg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct6Gy1eE7iFg.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct6InhhK3Bnx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct6InhhK3Bnx.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct6KaWm2V4so.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct6KaWm2V4so.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct6NVZQs4UrE.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct6NVZQs4UrE.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct6PUxZ29VTq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct6PUxZ29VTq.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct6fce05Qu1f.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct6fce05Qu1f.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct6tzbdxQpL4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct6tzbdxQpL4.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct763ixhZiPg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct763ixhZiPg.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct79tZSSX75b.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct79tZSSX75b.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct7E3RzOaVF1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct7E3RzOaVF1.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct7Ev4ba5U4g.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct7Ev4ba5U4g.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct7FkotSk0XD.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct7FkotSk0XD.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct7MpRJpjzYV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct7MpRJpjzYV.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct7UAHrFSXgp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct7UAHrFSXgp.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct7ZDRFK7C6w.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct7ZDRFK7C6w.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct7hWyxK9Im1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct7hWyxK9Im1.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct7vhsXm5Sqy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct7vhsXm5Sqy.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct7vwzjN2hQB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct7vwzjN2hQB.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct7x47kTkDWA.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct7x47kTkDWA.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct814BQq200G.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct814BQq200G.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct84TN7zjoK9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct84TN7zjoK9.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct8CllamWxHF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct8CllamWxHF.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct8KGpb7sMhV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct8KGpb7sMhV.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct8P1XTIrmCU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct8P1XTIrmCU.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct8eGauAG2Iy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct8eGauAG2Iy.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct8hD3MVC60I.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct8hD3MVC60I.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct8q0Jpdjx8u.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct8q0Jpdjx8u.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct8qIwjmR7oN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct8qIwjmR7oN.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct8tbcftbwF8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct8tbcftbwF8.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct8txOZ8smgu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct8txOZ8smgu.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct8yaeAzdZUO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct8yaeAzdZUO.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct98nsmL4Uyu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct98nsmL4Uyu.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct9CTRHeV5gV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct9CTRHeV5gV.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct9E3xYWs4gr.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct9E3xYWs4gr.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct9FbBK7sAEy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct9FbBK7sAEy.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct9HOIXHYhP9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct9HOIXHYhP9.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct9IzMME36Bl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct9IzMME36Bl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct9PLpEx4eEr.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct9PLpEx4eEr.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct9QX6aOMWmP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct9QX6aOMWmP.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct9XFvojKqS7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct9XFvojKqS7.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct9Z0NXJ0nuB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct9Z0NXJ0nuB.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct9cdQxj05PP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct9cdQxj05PP.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct9dJLrfdwrb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct9dJLrfdwrb.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct9fPHF2RcIG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct9fPHF2RcIG.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct9o9IQlJhfF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct9o9IQlJhfF.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct9rTJlJQ4St.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct9rTJlJQ4St.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct9tS75raz9v.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-struct9tS75raz9v.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structA0t67j1fxp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structA0t67j1fxp.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structA2y6S9lFjD.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structA2y6S9lFjD.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structA4N6i5eArl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structA4N6i5eArl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structA6J9ouYjJm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structA6J9ouYjJm.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structAB03r2H43b.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structAB03r2H43b.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structADRxlKyBIl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structADRxlKyBIl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structAE7oPkwYY6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structAE7oPkwYY6.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structAHdMDYZJaK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structAHdMDYZJaK.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structAK2drK1aH7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structAK2drK1aH7.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structAPZGaaiAsI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structAPZGaaiAsI.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structAQE2E9exgF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structAQE2E9exgF.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structAcoWvPhtlp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structAcoWvPhtlp.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structAiFfzJ9xOo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structAiFfzJ9xOo.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structAztsRhE0LF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structAztsRhE0LF.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structB9pN8GfUaU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structB9pN8GfUaU.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structBA8lKBvox6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structBA8lKBvox6.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structBBBafcZBl1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structBBBafcZBl1.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structBF8funmMCW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structBF8funmMCW.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structBNGrkk0Gq9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structBNGrkk0Gq9.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structBW4o7dJUoK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structBW4o7dJUoK.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structBWsRWzQ335.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structBWsRWzQ335.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structBfsVSixXGI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structBfsVSixXGI.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structBjERtQ98tj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structBjERtQ98tj.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structBjy5dZK2rM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structBjy5dZK2rM.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structBm7Ua0ACla.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structBm7Ua0ACla.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structBmz4OJxAlt.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structBmz4OJxAlt.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structBw3OKv2Qms.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structBw3OKv2Qms.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structBzSRBjnY22.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structBzSRBjnY22.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structC0g7V6d3fy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structC0g7V6d3fy.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structCBt0kIYRra.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structCBt0kIYRra.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structCOGSdZd0AL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structCOGSdZd0AL.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structCXeEkfG71q.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structCXeEkfG71q.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structCaHH2Xyhc7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structCaHH2Xyhc7.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structCcLnEruc0v.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structCcLnEruc0v.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structCfD3K5QvsN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structCfD3K5QvsN.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structCqQVJigrtI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structCqQVJigrtI.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structCzvlSZqJoZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structCzvlSZqJoZ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structD2oQVW5tnq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structD2oQVW5tnq.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structD4YplBwWDi.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structD4YplBwWDi.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structD9gno8tRvF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structD9gno8tRvF.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structDACFSZmJCd.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structDACFSZmJCd.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structDVPBdDC863.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structDVPBdDC863.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structDXFa0e4ozX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structDXFa0e4ozX.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structDZZWeqhEZS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structDZZWeqhEZS.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structDhEKpPXtbG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structDhEKpPXtbG.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structDi88qmJim6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structDi88qmJim6.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structDrIOG3dy4E.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structDrIOG3dy4E.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structE1izflhe7m.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structE1izflhe7m.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structE7tbP2KegJ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structE7tbP2KegJ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structECJjSKcI0x.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structECJjSKcI0x.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structECjdzNW2hb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structECjdzNW2hb.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structENNglh8DX6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structENNglh8DX6.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structEVUFJOsbyB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structEVUFJOsbyB.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structEa3Y8fmO5t.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structEa3Y8fmO5t.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structEbe6V1e8rk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structEbe6V1e8rk.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structEilgeng6RU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structEilgeng6RU.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structEjN7KM70nB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structEjN7KM70nB.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structEoc6yu6UZC.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structEoc6yu6UZC.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structEqZWhQIozu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structEqZWhQIozu.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structErRGvv06c5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structErRGvv06c5.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structEvFFf3fZGJ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structEvFFf3fZGJ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structEx5206L0wV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structEx5206L0wV.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structF3dNExh2mR.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structF3dNExh2mR.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structF8DhNrWv7E.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structF8DhNrWv7E.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structF9RjQ90jnp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structF9RjQ90jnp.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structFI3w6VQMfO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structFI3w6VQMfO.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structFJsonz9Nyz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structFJsonz9Nyz.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structFR85FzqbWk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structFR85FzqbWk.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structFXxZeDtCw5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structFXxZeDtCw5.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structFaTXoezJTa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structFaTXoezJTa.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structFhwETmltur.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structFhwETmltur.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structFjGw1Sgvhj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structFjGw1Sgvhj.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structFq1hfAwgHs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structFq1hfAwgHs.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structFvR9kgHTwq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structFvR9kgHTwq.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structFx3ViT9W1l.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structFx3ViT9W1l.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structG23iNFg5pV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structG23iNFg5pV.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structG4WvAWeyY2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structG4WvAWeyY2.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structG5eiJlW14L.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structG5eiJlW14L.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structG7DG28rR3I.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structG7DG28rR3I.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structG8t7pJyR0P.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structG8t7pJyR0P.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structGAhk4JD5f5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structGAhk4JD5f5.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structGElc6so5Vx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structGElc6so5Vx.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structGL3ENulfXA.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structGL3ENulfXA.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structGPgos6Ga6k.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structGPgos6Ga6k.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structGVka0u9TDq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structGVka0u9TDq.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structGXNEUsfHGV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structGXNEUsfHGV.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structGajQGzODLb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structGajQGzODLb.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structGbvlSI6ZFM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structGbvlSI6ZFM.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structGgvsKvoP9v.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structGgvsKvoP9v.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structGiiPLasS8y.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structGiiPLasS8y.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structGlUP6EKlOZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structGlUP6EKlOZ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structGmNuKgusEl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structGmNuKgusEl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structGnndCPLSRE.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structGnndCPLSRE.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structGseI8AQPtb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structGseI8AQPtb.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structGyODqQmfLk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structGyODqQmfLk.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structH5eQeBi4oY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structH5eQeBi4oY.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structH6F7xwrgKM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structH6F7xwrgKM.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structHAW6jHGG5q.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structHAW6jHGG5q.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structHGMhtcP1Gs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structHGMhtcP1Gs.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structHNoL72ys27.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structHNoL72ys27.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structHOwIYbq2Gd.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structHOwIYbq2Gd.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structHQ1FzQOf8n.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structHQ1FzQOf8n.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structHQRXU94JgV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structHQRXU94JgV.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structHSN0q7oMVM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structHSN0q7oMVM.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structHYnhl5ltDv.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structHYnhl5ltDv.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structHcCEQbo9Zf.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structHcCEQbo9Zf.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structHfRiDfgqPK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structHfRiDfgqPK.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structHnGXhmegvA.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structHnGXhmegvA.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structHnNLvYqbMR.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structHnNLvYqbMR.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structHt9F9jtMD0.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structHt9F9jtMD0.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structHusaUbKJVm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structHusaUbKJVm.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structHvGrPaR9Bu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structHvGrPaR9Bu.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structHvI693MHyM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structHvI693MHyM.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structHyrFeqyBCY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structHyrFeqyBCY.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structHzJtxAljeg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structHzJtxAljeg.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structI2aSLtV0nK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structI2aSLtV0nK.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structI5QO2BUMxk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structI5QO2BUMxk.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structI6BZQjT6lx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structI6BZQjT6lx.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structICD2Fjdvwq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structICD2Fjdvwq.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structIHkMJI02Cs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structIHkMJI02Cs.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structIJpxdh5h1j.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structIJpxdh5h1j.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structIKVPnPqtVG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structIKVPnPqtVG.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structIODsh0cyAj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structIODsh0cyAj.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structIWnVfC7bMR.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structIWnVfC7bMR.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structIg48IJ1BGz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structIg48IJ1BGz.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structIjpYds4lWa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structIjpYds4lWa.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structImqfRF5u5d.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structImqfRF5u5d.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structIpNWKHAjIK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structIpNWKHAjIK.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structIq2IxAwTbz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structIq2IxAwTbz.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structIqjoEWN5a6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structIqjoEWN5a6.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structJ1WoVnmoNK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structJ1WoVnmoNK.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structJ4N4ApAuNd.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structJ4N4ApAuNd.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structJ4sxZ95hzs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structJ4sxZ95hzs.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structJ5ThymSmBk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structJ5ThymSmBk.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structJBdaFHCitX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structJBdaFHCitX.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structJBjYKH35Id.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structJBjYKH35Id.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structJEL7o5TRHh.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structJEL7o5TRHh.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structJFU1xlKVwi.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structJFU1xlKVwi.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structJIOp0LkuGx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structJIOp0LkuGx.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structJKSxRHdkgU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structJKSxRHdkgU.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structJLl1JS3EBA.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structJLl1JS3EBA.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structJPod17bl3h.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structJPod17bl3h.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structJSkoDJdEmy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structJSkoDJdEmy.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structJXZ8aT3Z1A.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structJXZ8aT3Z1A.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structJYFDwGezZu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structJYFDwGezZu.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structJZBOzjdChs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structJZBOzjdChs.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structJcJCwPR9O6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structJcJCwPR9O6.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structJdaXHv9XGK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structJdaXHv9XGK.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structJguJlpO2Zx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structJguJlpO2Zx.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structJjOrVxY09U.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structJjOrVxY09U.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structJmS6AEcW3Z.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structJmS6AEcW3Z.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structJmgvdzeb5n.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structJmgvdzeb5n.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structJt6jf8vpBs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structJt6jf8vpBs.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structJyoG3utfUF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structJyoG3utfUF.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structK17aJaWFKp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structK17aJaWFKp.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structK6zBHvtXEz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structK6zBHvtXEz.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structK8yLeG1Rq8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structK8yLeG1Rq8.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structKAGtyEb0Mc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structKAGtyEb0Mc.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structKBZsUWVDxs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structKBZsUWVDxs.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structKD97Jf4W3S.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structKD97Jf4W3S.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structKDBDsZNe9Z.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structKDBDsZNe9Z.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structKDWeAZ2IPn.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structKDWeAZ2IPn.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structKF4sn2PYXa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structKF4sn2PYXa.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structKHnzHYYQv9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structKHnzHYYQv9.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structKJhvJs3EGG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structKJhvJs3EGG.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structKLSPh0PXhl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structKLSPh0PXhl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structKNZX9fxtdl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structKNZX9fxtdl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structKS9Hbi6AwZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structKS9Hbi6AwZ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structKVlfLjDmn1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structKVlfLjDmn1.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structKX2JHsJ0bd.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structKX2JHsJ0bd.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structKkESsYkID7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structKkESsYkID7.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structKkHcnJvU6l.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structKkHcnJvU6l.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structKkvn2ffBgz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structKkvn2ffBgz.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structKxmFSKOkr0.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structKxmFSKOkr0.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structL0iuHiXIxa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structL0iuHiXIxa.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structL28FwCaWlq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structL28FwCaWlq.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structL3YlcXIU3G.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structL3YlcXIU3G.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structL5PAA2Y49o.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structL5PAA2Y49o.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structL8rTw5Q3JI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structL8rTw5Q3JI.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structLJsbrcp1QV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structLJsbrcp1QV.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structLKxIRREq4D.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structLKxIRREq4D.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structLMQlSHV6GT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structLMQlSHV6GT.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structLV2nB9GvAz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structLV2nB9GvAz.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structLa1OJDLBp5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structLa1OJDLBp5.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structLcNNHqG92U.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structLcNNHqG92U.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structLnY2DL1Mbw.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structLnY2DL1Mbw.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structLpxoYUnOy7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structLpxoYUnOy7.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structLs7CLvlkgi.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structLs7CLvlkgi.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structLtMZ0XaStC.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structLtMZ0XaStC.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structLy4yvDjUuQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structLy4yvDjUuQ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structM9DKZGOLDg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structM9DKZGOLDg.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structMBndhRFxei.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structMBndhRFxei.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structMEcvkINwlN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structMEcvkINwlN.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structMFY7puSlGX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structMFY7puSlGX.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structMQnq3Fo18k.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structMQnq3Fo18k.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structMRN9c8EZAu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structMRN9c8EZAu.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structMSaXkM98gx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structMSaXkM98gx.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structMe4GO0lmyL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structMe4GO0lmyL.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structMf7H2FRsCR.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structMf7H2FRsCR.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structMgFMQz9tN4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structMgFMQz9tN4.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structMhWZ76XLqK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structMhWZ76XLqK.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structMiv3889DlT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structMiv3889DlT.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structMkNnqyG9Tl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structMkNnqyG9Tl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structMw7h6zUCoS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structMw7h6zUCoS.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structN5CGh6EWiK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structN5CGh6EWiK.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structN86zzxZWL3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structN86zzxZWL3.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structN9VLieAgkB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structN9VLieAgkB.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structNB005jf6q4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structNB005jf6q4.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structNW2O8zaFJU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structNW2O8zaFJU.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structNXVElSFyJY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structNXVElSFyJY.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structNXkTPXgNCQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structNXkTPXgNCQ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structNYxtIN1k6X.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structNYxtIN1k6X.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structNcunqydrcp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structNcunqydrcp.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structNfG8poVmRX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structNfG8poVmRX.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structNpSaGkUh99.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structNpSaGkUh99.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structNphpYJarez.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structNphpYJarez.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structNq8WSpQa6r.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structNq8WSpQa6r.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structNuHNDIZUYr.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structNuHNDIZUYr.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structO4Kr2Vp6iB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structO4Kr2Vp6iB.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structO5SpO4Lmqy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structO5SpO4Lmqy.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structO6aBEtLHCl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structO6aBEtLHCl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structO8aC92gkJu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structO8aC92gkJu.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structOAXjhVxHVW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structOAXjhVxHVW.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structOBggRrGGeA.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structOBggRrGGeA.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structOCKiZ8XvN4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structOCKiZ8XvN4.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structOTagHf6dta.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structOTagHf6dta.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structOmPR4GDmha.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structOmPR4GDmha.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structOnU7Y1iyOW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structOnU7Y1iyOW.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structOruSh6IU68.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structOruSh6IU68.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structP07kLcgWy2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structP07kLcgWy2.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structP0hi03Yr5J.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structP0hi03Yr5J.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structP51IT0iQls.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structP51IT0iQls.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structPC53CFAahl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structPC53CFAahl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structPDETEBub2B.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structPDETEBub2B.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structPIEO17rXv3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structPIEO17rXv3.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structPL1Vy8gAQG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structPL1Vy8gAQG.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structPOAJbOn5yN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structPOAJbOn5yN.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structPWOGZtzGIy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structPWOGZtzGIy.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structPWOtvXxst0.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structPWOtvXxst0.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structPaMBWeOEZb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structPaMBWeOEZb.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structPbViqUkC9s.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structPbViqUkC9s.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structPjXLhVCSo2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structPjXLhVCSo2.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structPmsSWhVFlx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structPmsSWhVFlx.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structPvttwCSove.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structPvttwCSove.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structPy7auxT2wm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structPy7auxT2wm.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structPzKBHCX9aj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structPzKBHCX9aj.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structQ1lt85NZkv.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structQ1lt85NZkv.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structQ9W3v3dQYW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structQ9W3v3dQYW.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structQBpF2mc1un.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structQBpF2mc1un.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structQLoTxIicfl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structQLoTxIicfl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structQNBjmFEISk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structQNBjmFEISk.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structQRNlszU7N1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structQRNlszU7N1.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structQRrZvgSvEl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structQRrZvgSvEl.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structQu8eKSWeIJ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structQu8eKSWeIJ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structQwjx7jDCDX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structQwjx7jDCDX.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structQwri7Ax9TK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structQwri7Ax9TK.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structR4xaEYdpRY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structR4xaEYdpRY.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structR6bsgVIYE6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structR6bsgVIYE6.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structR6j965l6JZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structR6j965l6JZ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structR6yPnOD0oz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structR6yPnOD0oz.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structR8eEQpI0YT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structR8eEQpI0YT.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structRBr9HNIGgm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structRBr9HNIGgm.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structRBwjivoMMP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structRBwjivoMMP.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structRFFK9pIT93.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structRFFK9pIT93.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structRJYj3K0a3c.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structRJYj3K0a3c.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structRLhaWW9haz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structRLhaWW9haz.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structRSckKIVPNO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structRSckKIVPNO.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structRX7hJYzEEc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structRX7hJYzEEc.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structRbEgtyrBAH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structRbEgtyrBAH.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structRbgB04HmL4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structRbgB04HmL4.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structRdgEVFWPU8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structRdgEVFWPU8.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structRjYd0rym9S.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structRjYd0rym9S.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structRpd0ErOBb6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structRpd0ErOBb6.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structRtcf0YV8fO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structRtcf0YV8fO.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structRtjThoUz7H.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structRtjThoUz7H.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structRyTk5RxJJO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structRyTk5RxJJO.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structS1RhuauboU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structS1RhuauboU.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structS6bmXaMMyl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structS6bmXaMMyl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structSDPIMkAwH8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structSDPIMkAwH8.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structSEmAsgVkk9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structSEmAsgVkk9.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structSIfHQocAM7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structSIfHQocAM7.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structSL3XN9PByF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structSL3XN9PByF.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structSOJZorG6h4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structSOJZorG6h4.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structSOQ2b3Trj9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structSOQ2b3Trj9.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structSOcWqfVVcP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structSOcWqfVVcP.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structSUuI5kWBPQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structSUuI5kWBPQ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structSWz0ZdY1fL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structSWz0ZdY1fL.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structSXB5wflpQj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structSXB5wflpQj.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structSaCKmxwW7X.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structSaCKmxwW7X.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structSkgZGVkxzj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structSkgZGVkxzj.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structSuSfIvUv2A.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structSuSfIvUv2A.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structSuaJbDOn73.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structSuaJbDOn73.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structSv55DLNwHy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structSv55DLNwHy.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structSvXjwmwWp8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structSvXjwmwWp8.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structT024qoIGBu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structT024qoIGBu.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structT396ygje53.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structT396ygje53.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structTA8Sp22K2U.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structTA8Sp22K2U.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structTGF07uM1y9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structTGF07uM1y9.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structTKbYYBx9QZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structTKbYYBx9QZ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structTLyC86eODa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structTLyC86eODa.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structTSEu5hclTq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structTSEu5hclTq.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structTX5YCrOcOo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structTX5YCrOcOo.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structTX6rXf2RZh.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structTX6rXf2RZh.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structTaJbzfeDjo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structTaJbzfeDjo.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structTaYGLKdSM8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structTaYGLKdSM8.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structTgcZPmWOx2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structTgcZPmWOx2.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structTh5NbnUqzI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structTh5NbnUqzI.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structTknpxoQFvS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structTknpxoQFvS.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structTqu8KoZQjY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structTqu8KoZQjY.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structTuAcbBNnZm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structTuAcbBNnZm.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structTuWH3zeluv.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structTuWH3zeluv.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structTwjPuMKDiB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structTwjPuMKDiB.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structTxF88EuH4Q.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structTxF88EuH4Q.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structTzQ4rWvlZ3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structTzQ4rWvlZ3.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structU2kogkOlcf.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structU2kogkOlcf.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structU3dy6bkQcN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structU3dy6bkQcN.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structUA5Zgdsa4W.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structUA5Zgdsa4W.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structUC7urls6rG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structUC7urls6rG.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structUJ5RVg0xHN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structUJ5RVg0xHN.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structUL0XgKUiea.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structUL0XgKUiea.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structUYdnQvYvKk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structUYdnQvYvKk.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structUaTPRyIwWQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structUaTPRyIwWQ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structUgp6Bg804O.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structUgp6Bg804O.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structUgsqUT0Fw8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structUgsqUT0Fw8.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structUomjJGDhS3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structUomjJGDhS3.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structUrJ7tMPYdi.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structUrJ7tMPYdi.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structUsGUm5feCJ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structUsGUm5feCJ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structUx6sDnae6o.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structUx6sDnae6o.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structUyBELJkxhd.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structUyBELJkxhd.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structV1mFMqHDyz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structV1mFMqHDyz.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structV3DEOjYkAI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structV3DEOjYkAI.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structV4EcMh64Nu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structV4EcMh64Nu.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structVABFQlbdB8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structVABFQlbdB8.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structVCKWE5qXDQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structVCKWE5qXDQ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structVF3eV6RT5A.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structVF3eV6RT5A.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structVGVFt2H4Jq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structVGVFt2H4Jq.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structVHmibu21U1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structVHmibu21U1.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structVJQMEbTTcW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structVJQMEbTTcW.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structVW9Wugrq8f.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structVW9Wugrq8f.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structVbui9U8nJN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structVbui9U8nJN.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structVqmZxmYjrS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structVqmZxmYjrS.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structVwumd12dMR.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structVwumd12dMR.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structW03TuqLzYH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structW03TuqLzYH.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structW6NGdR4FHA.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structW6NGdR4FHA.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structW8RwEte1K1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structW8RwEte1K1.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structWFr5O7xRwi.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structWFr5O7xRwi.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structWJw9ZLP7fK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structWJw9ZLP7fK.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structWODpD4eAmE.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structWODpD4eAmE.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structWOGNQBbIW7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structWOGNQBbIW7.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structWQN1KyUD5b.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structWQN1KyUD5b.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structWTDgYPieK1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structWTDgYPieK1.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structWVtboPH1aE.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structWVtboPH1aE.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structWiPM4vCvbR.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structWiPM4vCvbR.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structWk1zWo8r9K.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structWk1zWo8r9K.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structWkYOcVuG9r.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structWkYOcVuG9r.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structWqKLr6PuT3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structWqKLr6PuT3.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structWyFaNRxWDU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structWyFaNRxWDU.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structX0tLJiI6QS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structX0tLJiI6QS.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structX74WdLPgP3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structX74WdLPgP3.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structXLePVWtJFS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structXLePVWtJFS.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structXNJAbmwEpz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structXNJAbmwEpz.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structXOlFj8WTWU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structXOlFj8WTWU.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structXQpY9eJk4m.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structXQpY9eJk4m.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structXU2GzBHEnm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structXU2GzBHEnm.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structXWIUjIMjuc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structXWIUjIMjuc.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structXYOl2gpZhZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structXYOl2gpZhZ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structXYrXq7Kz5O.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structXYrXq7Kz5O.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structXab1L6RKkc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structXab1L6RKkc.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structXcQSZS9Pq3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structXcQSZS9Pq3.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structXdOq3rooU7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structXdOq3rooU7.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structXpfvMzo3SU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structXpfvMzo3SU.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structXs0m0HB3Ve.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structXs0m0HB3Ve.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structXsoVym5xGF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structXsoVym5xGF.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structXxbrxyvfJK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structXxbrxyvfJK.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structY0sbuM1lf1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structY0sbuM1lf1.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structY2WI2qZBJc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structY2WI2qZBJc.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structY3MSP8GJLq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structY3MSP8GJLq.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structY7ZzgHzGVw.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structY7ZzgHzGVw.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structY8HkjRfwpg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structY8HkjRfwpg.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structYAzsftuDhx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structYAzsftuDhx.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structYE37gD7DoN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structYE37gD7DoN.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structYNODMJt0nI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structYNODMJt0nI.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structYOoQMQYEZo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structYOoQMQYEZo.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structYPtr2Dr86B.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structYPtr2Dr86B.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structYXRqKm5H9U.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structYXRqKm5H9U.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structYa2X1A0XlS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structYa2X1A0XlS.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structYj7TbLsdP4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structYj7TbLsdP4.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structYlF6RxCqVs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structYlF6RxCqVs.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structYo1jTzfuKl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structYo1jTzfuKl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structYrew2qdBuH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structYrew2qdBuH.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structYwZwDfIvIG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structYwZwDfIvIG.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structZ3DY5gvzFY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structZ3DY5gvzFY.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structZBrvC38b8N.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structZBrvC38b8N.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structZC6ZaapQdD.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structZC6ZaapQdD.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structZGNK9Twr9S.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structZGNK9Twr9S.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structZGqp2bRDtx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structZGqp2bRDtx.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structZJSKolxfqc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structZJSKolxfqc.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structZR3LiJX7PO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structZR3LiJX7PO.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structZW26HGLchP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structZW26HGLchP.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structZi1RqmdSol.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structZi1RqmdSol.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structZoimFj6xEE.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structZoimFj6xEE.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structZpfDnRPksn.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structZpfDnRPksn.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structZr2k5TeLcE.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structZr2k5TeLcE.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structZtqbbnQjzj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structZtqbbnQjzj.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structZupKEHABUk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structZupKEHABUk.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structa0AhWFAoDG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structa0AhWFAoDG.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structa5eW784LQf.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structa5eW784LQf.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structa6BXYQAwEm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structa6BXYQAwEm.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structa6bL6toTDQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structa6bL6toTDQ.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structa85eS8wvGC.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structa85eS8wvGC.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structaBCMiwiL14.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structaBCMiwiL14.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structaCvUpfrOud.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structaCvUpfrOud.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structaMVAJ9INz0.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structaMVAJ9INz0.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structaNX02HPg7T.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structaNX02HPg7T.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structaacjP2BYDY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structaacjP2BYDY.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structafSLEQGtjb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structafSLEQGtjb.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structawZmlvXiXW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structawZmlvXiXW.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structaxV4fiWwZ7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structaxV4fiWwZ7.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structayNEhBBg4t.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structayNEhBBg4t.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structb265yb0csM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structb265yb0csM.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structb63fAzKNR7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structb63fAzKNR7.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structbBsug1Wd34.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structbBsug1Wd34.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structbNMyvNH8WM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structbNMyvNH8WM.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structbX4S27LXkH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structbX4S27LXkH.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structblpexlSs9M.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structblpexlSs9M.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structbmmnw9qu32.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structbmmnw9qu32.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structbsrrxTZOqn.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structbsrrxTZOqn.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structbtgnPXO5Rq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structbtgnPXO5Rq.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structbwtswCbHZn.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structbwtswCbHZn.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structc0ARtdYgED.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structc0ARtdYgED.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structc0K76QtGvt.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structc0K76QtGvt.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structc19BIAaEkY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structc19BIAaEkY.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structcIUFEZhrle.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structcIUFEZhrle.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structcU51DXcyE8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structcU51DXcyE8.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structcbnz0kvIwn.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structcbnz0kvIwn.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structcfbnUeCgbt.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structcfbnUeCgbt.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structcjMmD9Dwfx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structcjMmD9Dwfx.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structclmVkpAhb8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structclmVkpAhb8.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structcoAqE1boX6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structcoAqE1boX6.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structcormXUf4WS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structcormXUf4WS.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structcqdGRq2WNh.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structcqdGRq2WNh.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structczOiELiAB7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structczOiELiAB7.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structd2ojXxCaNW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structd2ojXxCaNW.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structd4OcbMDcGL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structd4OcbMDcGL.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structd9nB4x1U6u.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structd9nB4x1U6u.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structdEhJcrsORt.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structdEhJcrsORt.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structdKBNYvwyxK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structdKBNYvwyxK.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structdNGVHIlzAj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structdNGVHIlzAj.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structdSftno00MK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structdSftno00MK.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structdXZpHpuk3x.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structdXZpHpuk3x.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structdXgIF94ebo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structdXgIF94ebo.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structdhEH1P8yDX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structdhEH1P8yDX.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structdq0ytTGdT7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structdq0ytTGdT7.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structdr28D0z5ZH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structdr28D0z5ZH.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structe4z2kYEwsw.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structe4z2kYEwsw.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structe79Za4b7Ml.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structe79Za4b7Ml.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structeJF56nvsEj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structeJF56nvsEj.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structeW6hiVZjD9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structeW6hiVZjD9.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structegI0J6pwbq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structegI0J6pwbq.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structemjd05RWc3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structemjd05RWc3.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structeqBjnWgb5P.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structeqBjnWgb5P.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structf0akg4gumK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structf0akg4gumK.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structf32Rx1NpEm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structf32Rx1NpEm.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structf3hg4Duqet.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structf3hg4Duqet.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structf74ThK893J.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structf74ThK893J.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structfBkGsQBirP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structfBkGsQBirP.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structfCVtyydYxM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structfCVtyydYxM.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structfCayR9pma6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structfCayR9pma6.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structfG4ASdjUC9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structfG4ASdjUC9.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structfJdkVlyVac.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structfJdkVlyVac.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structfNnOzIDYzL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structfNnOzIDYzL.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structfOOjVzFOC9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structfOOjVzFOC9.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structfTXY9OU4mh.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structfTXY9OU4mh.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structfWEUc1K6FG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structfWEUc1K6FG.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structfYJ2Mkk1al.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structfYJ2Mkk1al.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structfcg2UqwprF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structfcg2UqwprF.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structfd0mCQVHBl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structfd0mCQVHBl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structfwecOIJDmQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structfwecOIJDmQ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structgBuG9DjtOU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structgBuG9DjtOU.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structgIAdPMClq9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structgIAdPMClq9.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structgJaEzQzHlG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structgJaEzQzHlG.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structgTI819u8oK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structgTI819u8oK.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structgaVRwvBYOY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structgaVRwvBYOY.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structgmDuxmO8uQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structgmDuxmO8uQ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structgnTh8YZCI4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structgnTh8YZCI4.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structgnzwfueLCU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structgnzwfueLCU.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structgodJTvsSrL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structgodJTvsSrL.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structgoyNOloADC.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structgoyNOloADC.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structgrMFKxp6Rp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structgrMFKxp6Rp.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structgu5AmoUnKH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structgu5AmoUnKH.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structgw0RpMV2f4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structgw0RpMV2f4.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structgzPFVO95T5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structgzPFVO95T5.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structh0wIvbjPFM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structh0wIvbjPFM.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structh0zYLuKys0.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structh0zYLuKys0.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structh4borQn8tt.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structh4borQn8tt.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structhEYyOpWNQA.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structhEYyOpWNQA.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structhKVOXTzhtj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structhKVOXTzhtj.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structhP7CI8CVIx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structhP7CI8CVIx.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structhRp6BjrXlq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structhRp6BjrXlq.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structhXluAaYGUP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structhXluAaYGUP.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structhc5U7IjcZc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structhc5U7IjcZc.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structhjYDoXKd1y.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structhjYDoXKd1y.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structhk5xXOFY3B.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structhk5xXOFY3B.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structhlXXNdntjL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structhlXXNdntjL.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structhnljKmvH1S.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structhnljKmvH1S.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structhsMP7WDnTb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structhsMP7WDnTb.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structi5tx16f99j.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structi5tx16f99j.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structi60i9flgEl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structi60i9flgEl.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structiGcBGhWkFg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structiGcBGhWkFg.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structiH2t1AudUv.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structiH2t1AudUv.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structiJO3yTUlA6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structiJO3yTUlA6.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structiMxQrDbyMm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structiMxQrDbyMm.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structiRTC8Ri5hh.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structiRTC8Ri5hh.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structiUTYiuw7nL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structiUTYiuw7nL.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structifVuZi4Efe.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structifVuZi4Efe.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structigySx6ywF4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structigySx6ywF4.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structimk6k6ZOQP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structimk6k6ZOQP.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structiyfYt6St4H.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structiyfYt6St4H.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structj0Jp6zlUkb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structj0Jp6zlUkb.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structj2noj6YBli.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structj2noj6YBli.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structj80X6OAWFM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structj80X6OAWFM.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structjATzvt82Yc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structjATzvt82Yc.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structjHYdKd1qGS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structjHYdKd1qGS.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structjIn9JVMI49.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structjIn9JVMI49.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structjKvkQzPnI2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structjKvkQzPnI2.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structjPeWDdzelT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structjPeWDdzelT.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structjVynlgrJOg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structjVynlgrJOg.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structjXzq5dAQfq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structjXzq5dAQfq.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structjlEQy1XgIm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structjlEQy1XgIm.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structjpZYztDGZv.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structjpZYztDGZv.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structjyzBmrWLpD.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structjyzBmrWLpD.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structjzLZ1Fd1su.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structjzLZ1Fd1su.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structk0RWOtD4Cb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structk0RWOtD4Cb.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structk5uhI551Ib.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structk5uhI551Ib.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structkBpo9DUgjg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structkBpo9DUgjg.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structkKCqpBwgSB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structkKCqpBwgSB.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structkMn4TDNnDw.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structkMn4TDNnDw.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structkTDa7zOTTq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structkTDa7zOTTq.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structkcnuBfgvqB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structkcnuBfgvqB.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structke5R4wNmaV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structke5R4wNmaV.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structkgOVznysHS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structkgOVznysHS.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structkjR2PqZPCx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structkjR2PqZPCx.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structkjvkPYElx2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structkjvkPYElx2.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structko3HKcubO4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structko3HKcubO4.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structl1rwee6A0W.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structl1rwee6A0W.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structl9GK15NFfI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structl9GK15NFfI.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structl9dEcAYjZX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structl9dEcAYjZX.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structlCbFTLeEcO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structlCbFTLeEcO.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structlFoUTH7TGY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structlFoUTH7TGY.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structlFuagxP4pj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structlFuagxP4pj.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structlKqlZNIiTG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structlKqlZNIiTG.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structlM9nCK9mVa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structlM9nCK9mVa.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structlNxcettVbW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structlNxcettVbW.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structlOMWejTcie.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structlOMWejTcie.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structlPPzP90v2M.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structlPPzP90v2M.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structlWE7ijbTPg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structlWE7ijbTPg.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structlWZpr8mFUz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structlWZpr8mFUz.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structlfb6Bcmyzv.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structlfb6Bcmyzv.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structliZR39PG4B.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structliZR39PG4B.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structlilo17vqrO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structlilo17vqrO.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structlmBHuI2CdK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structlmBHuI2CdK.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structlsRnaxudRi.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structlsRnaxudRi.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structlwBBVufID9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structlwBBVufID9.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structmE7fFfuHjx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structmE7fFfuHjx.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structmPX6OOh4Nl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structmPX6OOh4Nl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structmR2t9GgAZ5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structmR2t9GgAZ5.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structmU9k8N2S1x.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structmU9k8N2S1x.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structmUQioQKiXp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structmUQioQKiXp.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structmWBF30udKT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structmWBF30udKT.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structmaUySacG7e.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structmaUySacG7e.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structmj4Oyb3GgX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structmj4Oyb3GgX.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structmuAhuD4KVQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structmuAhuD4KVQ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structmwjaO3Uyrs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structmwjaO3Uyrs.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structn5h1DHBxub.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structn5h1DHBxub.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structnAdqmBnbeg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structnAdqmBnbeg.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structnAvYhH07Gs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structnAvYhH07Gs.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structnHnX8P1WDq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structnHnX8P1WDq.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structnNkjJDcz0P.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structnNkjJDcz0P.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structnPwZk9I7YN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structnPwZk9I7YN.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structnUJfW4NMaA.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structnUJfW4NMaA.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structnXMZUp9V4V.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structnXMZUp9V4V.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structnjkuDZnOoQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structnjkuDZnOoQ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structnq8k7vNWX3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structnq8k7vNWX3.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structnrVsGpyHSB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structnrVsGpyHSB.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structnsGvdkMRFZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structnsGvdkMRFZ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structoAhXI74h9j.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structoAhXI74h9j.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structoahbTSUqku.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structoahbTSUqku.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structoiRn4GygF9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structoiRn4GygF9.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structov6aJQLXqu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structov6aJQLXqu.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structovm1h7N1tD.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structovm1h7N1tD.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structoypCXXMXYK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structoypCXXMXYK.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structp39x1W6Nmw.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structp39x1W6Nmw.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structp5F0SqEi1N.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structp5F0SqEi1N.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structpK1zdl2ooH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structpK1zdl2ooH.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structpLXABe2wJc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structpLXABe2wJc.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structpMr2v6juAQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structpMr2v6juAQ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structpXZA41Y8fK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structpXZA41Y8fK.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structpkIouuiKqe.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structpkIouuiKqe.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structpnMhTmK3QH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structpnMhTmK3QH.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structpuA2r64pbW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structpuA2r64pbW.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structpwCAT0hshK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structpwCAT0hshK.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structq1BEWkecYX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structq1BEWkecYX.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structq2gqs38KnH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structq2gqs38KnH.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structq5OjZ10BEs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structq5OjZ10BEs.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structqGa10MSSRs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structqGa10MSSRs.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structqGuE1lEn2E.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structqGuE1lEn2E.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structqK7XKTZI6a.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structqK7XKTZI6a.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structqRtOraogqy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structqRtOraogqy.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structqTdD25cQMq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structqTdD25cQMq.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structqVenFBZMmB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structqVenFBZMmB.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structqVymoyiTzO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structqVymoyiTzO.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structqYoMOdyW5o.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structqYoMOdyW5o.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structqZqGFZMAp0.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structqZqGFZMAp0.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structqceTFkotG1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structqceTFkotG1.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structqklsh0VtCj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structqklsh0VtCj.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structqkwGFodzYo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structqkwGFodzYo.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structqlynSYPIzj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structqlynSYPIzj.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structqmylEQUQxN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structqmylEQUQxN.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structqsdnJQvtod.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structqsdnJQvtod.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structr1IUWdH7kS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structr1IUWdH7kS.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structrDLhl5fFyI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structrDLhl5fFyI.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structrJ6A29EFD3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structrJ6A29EFD3.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structrLI0qkdwNT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structrLI0qkdwNT.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structrNNNMoMUX5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structrNNNMoMUX5.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structrQyjIvxeGC.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structrQyjIvxeGC.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structrUZIsQzLzo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structrUZIsQzLzo.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structrUrNNgGYxl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structrUrNNgGYxl.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structrZORE7saci.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structrZORE7saci.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structrnEvXbtOaJ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structrnEvXbtOaJ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structrv6cJ7e4eI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structrv6cJ7e4eI.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structrvnG4DB0O9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structrvnG4DB0O9.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structrxuRIzLrOd.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structrxuRIzLrOd.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structs0wKthNJDH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structs0wKthNJDH.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structs6tlj8Ujb6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structs6tlj8Ujb6.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structs81xiTr3V2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structs81xiTr3V2.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structs9FC686ssT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structs9FC686ssT.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structsU7ru1S3Bn.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structsU7ru1S3Bn.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structsconExg82n.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structsconExg82n.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structsnl6YWFzw6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structsnl6YWFzw6.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structsr11hihvVP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structsr11hihvVP.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structsrFnuySLJZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structsrFnuySLJZ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structsyMjE23XYL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structsyMjE23XYL.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structt1zhtoy3QG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structt1zhtoy3QG.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structt3vc10gLez.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structt3vc10gLez.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structt7Y6XwomUH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structt7Y6XwomUH.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structtFfTsyMFtj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structtFfTsyMFtj.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structtKTQH67TAx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structtKTQH67TAx.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structtRnRKY1Nt9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structtRnRKY1Nt9.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structtVv0gLLUw6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structtVv0gLLUw6.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structtdu9UH9BR6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structtdu9UH9BR6.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structtkLijaINDB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structtkLijaINDB.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structtmi3Y4xjWJ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structtmi3Y4xjWJ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structtoRHBeshpF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structtoRHBeshpF.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structtoojZOxzYL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structtoojZOxzYL.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structuEWock0xfg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structuEWock0xfg.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structuYFS57GpEz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structuYFS57GpEz.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structuZLTFqoTc9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structuZLTFqoTc9.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structuesCCsCmB9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structuesCCsCmB9.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structuk9n40Ba1s.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structuk9n40Ba1s.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structurOByRIJr5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structurOByRIJr5.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structusM7i9eFda.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structusM7i9eFda.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structuzTdZWiu60.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structuzTdZWiu60.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structv4jF52UQ9H.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structv4jF52UQ9H.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structv9bmg59CEV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structv9bmg59CEV.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structvE6YTruKB5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structvE6YTruKB5.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structvGYXxaXkfO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structvGYXxaXkfO.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structvIiPiag0AP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structvIiPiag0AP.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structvJXxV1TNGG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structvJXxV1TNGG.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structvLrhLw24Yo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structvLrhLw24Yo.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structvPLGLtUGvc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structvPLGLtUGvc.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structvQ4tBtsFIQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structvQ4tBtsFIQ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structvetTPo8phL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structvetTPo8phL.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structvh6HUMxCO1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structvh6HUMxCO1.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structvhPOJekCB6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structvhPOJekCB6.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structvqpjGCBNgC.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structvqpjGCBNgC.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structw1Jcuo2qcB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structw1Jcuo2qcB.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structw1LUTeHkEP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structw1LUTeHkEP.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structw704rOrUeD.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structw704rOrUeD.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structwAVE8pzuIw.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structwAVE8pzuIw.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structwE9USHmMoa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structwE9USHmMoa.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structwKyV6c3NXx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structwKyV6c3NXx.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structwNNWk20409.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structwNNWk20409.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structwPjsuxb7PR.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structwPjsuxb7PR.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structwquRams9Fs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structwquRams9Fs.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structwyz9cVcdwh.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structwyz9cVcdwh.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structx29mgYMw04.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structx29mgYMw04.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structx9kDs7ICzW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structx9kDs7ICzW.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structxFTWeVz86X.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structxFTWeVz86X.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structxI8aw5DOBf.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structxI8aw5DOBf.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structxKJxcMqgXp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structxKJxcMqgXp.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structxSyTOLVs2a.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structxSyTOLVs2a.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structxY83QlHYu8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structxY83QlHYu8.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structxatoIPHwut.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structxatoIPHwut.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structxayiSk9poY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structxayiSk9poY.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structxl0tHilNDj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structxl0tHilNDj.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structxpKM8hQmHX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structxpKM8hQmHX.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structxrKKgR1Fe1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structxrKKgR1Fe1.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structxsR9aAsAXm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structxsR9aAsAXm.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structxwNsI8Zdb1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structxwNsI8Zdb1.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structy2eHpFGRr5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structy2eHpFGRr5.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structy5X9cuxDIn.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structy5X9cuxDIn.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structy5wbr5f4bB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structy5wbr5f4bB.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structyAGnaq1EBc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structyAGnaq1EBc.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structyGjRe5am7c.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structyGjRe5am7c.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structyKsJfDGXaz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structyKsJfDGXaz.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structyNBvxKIcti.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structyNBvxKIcti.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structyPEdNMH6Lo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structyPEdNMH6Lo.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structyTmtkFKqd7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structyTmtkFKqd7.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structydbIqe0qPo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structydbIqe0qPo.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structyhDvAbXvCv.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structyhDvAbXvCv.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structynitZhhUeJ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structynitZhhUeJ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structyvVgkdYRXO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structyvVgkdYRXO.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structz1JgTXpAuI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structz1JgTXpAuI.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structz7dfzzL9Yk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structz7dfzzL9Yk.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structzIXefsJFSz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structzIXefsJFSz.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structzPWDt4oN6i.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structzPWDt4oN6i.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structzQUyc7Ws0e.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structzQUyc7Ws0e.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structzTIpN6ALMu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structzTIpN6ALMu.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structzYoD4xKxnZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structzYoD4xKxnZ.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structzdXNEcof9V.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structzdXNEcof9V.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structzo3owhla9x.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structzo3owhla9x.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structzyowJj76a6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v6.0/readonly-partial-structzyowJj76a6.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct00oieaoYA5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct00oieaoYA5.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct05nZxSvOQy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct05nZxSvOQy.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct0CW6rWihRa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct0CW6rWihRa.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct0EiiHjJ0Jy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct0EiiHjJ0Jy.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct0HxVdkFuDk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct0HxVdkFuDk.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct0Sp8nFf9po.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct0Sp8nFf9po.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct0YOigHUonk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct0YOigHUonk.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct0mu68DyXFS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct0mu68DyXFS.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct0oZl05ifoL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct0oZl05ifoL.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct101P28DC6b.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct101P28DC6b.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct109xwVU7na.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct109xwVU7na.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct13ZLCuuDdg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct13ZLCuuDdg.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct164v5M7Oiu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct164v5M7Oiu.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct16i8Hnvzik.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct16i8Hnvzik.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct1B64P2KJTT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct1B64P2KJTT.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct1FLNprzFfg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct1FLNprzFfg.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct1Lodf8jQhi.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct1Lodf8jQhi.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct1NM3qeUh2p.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct1NM3qeUh2p.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct1QKloRyprM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct1QKloRyprM.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct1TeundtXb1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct1TeundtXb1.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct1e9vZ2ZVVl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct1e9vZ2ZVVl.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct1ibkpE2U9t.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct1ibkpE2U9t.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct1jAvJkz71q.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct1jAvJkz71q.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct1kIcXqyaMm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct1kIcXqyaMm.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct1kIjvNmL26.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct1kIjvNmL26.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct1nopkP9yWt.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct1nopkP9yWt.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct1q3mpvDeuG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct1q3mpvDeuG.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct1rwcZsOxGm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct1rwcZsOxGm.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct1shpv6NmPc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct1shpv6NmPc.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct1tertRu9Xm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct1tertRu9Xm.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct1xSlrFoiE2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct1xSlrFoiE2.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct1xjEjG8zge.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct1xjEjG8zge.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct1zEPcP8TZ0.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct1zEPcP8TZ0.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct22wFvfGOQe.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct22wFvfGOQe.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct23OaGTh97N.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct23OaGTh97N.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct2C0v3cLs4t.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct2C0v3cLs4t.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct2Ii6Pytw94.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct2Ii6Pytw94.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct2KJvO9ifSa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct2KJvO9ifSa.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct2Oea4qEuqL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct2Oea4qEuqL.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct2PRjv73LUz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct2PRjv73LUz.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct2PlWXW13Oo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct2PlWXW13Oo.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct2RjyXdbOmS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct2RjyXdbOmS.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct2WJXBATRow.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct2WJXBATRow.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct2ePshLeWkH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct2ePshLeWkH.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct2iRAZCo7L5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct2iRAZCo7L5.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct2l1qlatawT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct2l1qlatawT.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct2lPhMAoDBl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct2lPhMAoDBl.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct2mrBdiaAsD.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct2mrBdiaAsD.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct2yK9S7dzeX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct2yK9S7dzeX.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct2yeMfnvK5l.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct2yeMfnvK5l.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct34i0YswjFg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct34i0YswjFg.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct3AvV0e5RCv.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct3AvV0e5RCv.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct3Fkic0RvsS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct3Fkic0RvsS.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct3Q09CNhFqG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct3Q09CNhFqG.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct3W5X0ROtrE.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct3W5X0ROtrE.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct3YKEcUcTm6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct3YKEcUcTm6.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct3Ysql1aZTo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct3Ysql1aZTo.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct3aLcZ0Gzdp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct3aLcZ0Gzdp.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct3bQ2CbXXiG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct3bQ2CbXXiG.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct3hbQkh2oXr.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct3hbQkh2oXr.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct3o9W3tWIYr.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct3o9W3tWIYr.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct3oRAhgtPFs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct3oRAhgtPFs.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct3rEqyW20Ha.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct3rEqyW20Ha.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct3rh7agTF1u.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct3rh7agTF1u.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct3tAXhVgz0j.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct3tAXhVgz0j.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct3udOlsWezr.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct3udOlsWezr.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct3yavERh0QP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct3yavERh0QP.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct40R1V76roU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct40R1V76roU.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct44PftY660j.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct44PftY660j.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct46ykdVFGwG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct46ykdVFGwG.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct47pp9CzShs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct47pp9CzShs.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct49eWbTEG4e.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct49eWbTEG4e.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct4I0C5KiBcT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct4I0C5KiBcT.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct4NHzRc00m2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct4NHzRc00m2.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct4R1b3Sfk6J.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct4R1b3Sfk6J.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct4VkhuwJa8e.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct4VkhuwJa8e.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct4bA4rV4T7I.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct4bA4rV4T7I.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct4qOfIMBclV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct4qOfIMBclV.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct4tYHXfgnVZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct4tYHXfgnVZ.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct4xCfXxpvdy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct4xCfXxpvdy.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct4zYtkggxX9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct4zYtkggxX9.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct566AUa8c9w.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct566AUa8c9w.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct5B3Ki66g8U.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct5B3Ki66g8U.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct5GIHfCnyF0.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct5GIHfCnyF0.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct5GXqW1XpIl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct5GXqW1XpIl.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct5R3JtFMKyy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct5R3JtFMKyy.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct5WOnMXao7S.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct5WOnMXao7S.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct5WjoUCBC2W.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct5WjoUCBC2W.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct5YuboIIJis.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct5YuboIIJis.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct5coPgZ627S.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct5coPgZ627S.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct5nsLLrnYzS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct5nsLLrnYzS.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct5p0wzn3Twr.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct5p0wzn3Twr.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct5pUyGEiqRW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct5pUyGEiqRW.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct66VojQk1NI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct66VojQk1NI.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct67D9OX1YBs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct67D9OX1YBs.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct67XWJDtmLp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct67XWJDtmLp.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct6ACGifRdRw.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct6ACGifRdRw.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct6AkdgH06Lh.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct6AkdgH06Lh.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct6BWJO4ygCh.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct6BWJO4ygCh.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct6Eho6XNoOx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct6Eho6XNoOx.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct6Fnny4hIyl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct6Fnny4hIyl.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct6GnahT2THT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct6GnahT2THT.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct6Gy1eE7iFg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct6Gy1eE7iFg.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct6InhhK3Bnx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct6InhhK3Bnx.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct6KaWm2V4so.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct6KaWm2V4so.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct6NVZQs4UrE.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct6NVZQs4UrE.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct6PUxZ29VTq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct6PUxZ29VTq.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct6fce05Qu1f.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct6fce05Qu1f.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct6tzbdxQpL4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct6tzbdxQpL4.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct763ixhZiPg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct763ixhZiPg.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct79tZSSX75b.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct79tZSSX75b.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct7E3RzOaVF1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct7E3RzOaVF1.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct7Ev4ba5U4g.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct7Ev4ba5U4g.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct7FkotSk0XD.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct7FkotSk0XD.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct7MpRJpjzYV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct7MpRJpjzYV.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct7UAHrFSXgp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct7UAHrFSXgp.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct7ZDRFK7C6w.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct7ZDRFK7C6w.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct7hWyxK9Im1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct7hWyxK9Im1.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct7vhsXm5Sqy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct7vhsXm5Sqy.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct7vwzjN2hQB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct7vwzjN2hQB.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct7x47kTkDWA.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct7x47kTkDWA.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct814BQq200G.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct814BQq200G.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct84TN7zjoK9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct84TN7zjoK9.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct8CllamWxHF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct8CllamWxHF.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct8KGpb7sMhV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct8KGpb7sMhV.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct8P1XTIrmCU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct8P1XTIrmCU.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct8eGauAG2Iy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct8eGauAG2Iy.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct8hD3MVC60I.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct8hD3MVC60I.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct8q0Jpdjx8u.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct8q0Jpdjx8u.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct8qIwjmR7oN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct8qIwjmR7oN.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct8tbcftbwF8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct8tbcftbwF8.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct8txOZ8smgu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct8txOZ8smgu.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct8yaeAzdZUO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct8yaeAzdZUO.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct98nsmL4Uyu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct98nsmL4Uyu.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct9CTRHeV5gV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct9CTRHeV5gV.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct9E3xYWs4gr.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct9E3xYWs4gr.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct9FbBK7sAEy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct9FbBK7sAEy.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct9HOIXHYhP9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct9HOIXHYhP9.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct9IzMME36Bl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct9IzMME36Bl.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct9PLpEx4eEr.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct9PLpEx4eEr.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct9QX6aOMWmP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct9QX6aOMWmP.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct9XFvojKqS7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct9XFvojKqS7.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct9Z0NXJ0nuB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct9Z0NXJ0nuB.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct9cdQxj05PP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct9cdQxj05PP.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct9dJLrfdwrb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct9dJLrfdwrb.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct9fPHF2RcIG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct9fPHF2RcIG.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct9o9IQlJhfF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct9o9IQlJhfF.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct9rTJlJQ4St.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct9rTJlJQ4St.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct9tS75raz9v.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-struct9tS75raz9v.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structA0t67j1fxp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structA0t67j1fxp.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structA2y6S9lFjD.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structA2y6S9lFjD.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structA4N6i5eArl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structA4N6i5eArl.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structA6J9ouYjJm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structA6J9ouYjJm.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structAB03r2H43b.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structAB03r2H43b.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structADRxlKyBIl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structADRxlKyBIl.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structAE7oPkwYY6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structAE7oPkwYY6.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structAHdMDYZJaK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structAHdMDYZJaK.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structAK2drK1aH7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structAK2drK1aH7.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structAPZGaaiAsI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structAPZGaaiAsI.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structAQE2E9exgF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structAQE2E9exgF.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structAcoWvPhtlp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structAcoWvPhtlp.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structAiFfzJ9xOo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structAiFfzJ9xOo.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structAztsRhE0LF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structAztsRhE0LF.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structB9pN8GfUaU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structB9pN8GfUaU.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structBA8lKBvox6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structBA8lKBvox6.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structBBBafcZBl1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structBBBafcZBl1.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structBF8funmMCW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structBF8funmMCW.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structBNGrkk0Gq9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structBNGrkk0Gq9.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structBW4o7dJUoK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structBW4o7dJUoK.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structBWsRWzQ335.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structBWsRWzQ335.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structBfsVSixXGI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structBfsVSixXGI.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structBjERtQ98tj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structBjERtQ98tj.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structBjy5dZK2rM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structBjy5dZK2rM.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structBm7Ua0ACla.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structBm7Ua0ACla.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structBmz4OJxAlt.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structBmz4OJxAlt.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structBw3OKv2Qms.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structBw3OKv2Qms.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structBzSRBjnY22.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structBzSRBjnY22.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structC0g7V6d3fy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structC0g7V6d3fy.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structCBt0kIYRra.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structCBt0kIYRra.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structCOGSdZd0AL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structCOGSdZd0AL.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structCXeEkfG71q.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structCXeEkfG71q.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structCaHH2Xyhc7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structCaHH2Xyhc7.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structCcLnEruc0v.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structCcLnEruc0v.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structCfD3K5QvsN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structCfD3K5QvsN.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structCqQVJigrtI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structCqQVJigrtI.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structCzvlSZqJoZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structCzvlSZqJoZ.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structD2oQVW5tnq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structD2oQVW5tnq.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structD4YplBwWDi.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structD4YplBwWDi.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structD9gno8tRvF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structD9gno8tRvF.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structDACFSZmJCd.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structDACFSZmJCd.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structDVPBdDC863.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structDVPBdDC863.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structDXFa0e4ozX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structDXFa0e4ozX.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structDZZWeqhEZS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structDZZWeqhEZS.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structDhEKpPXtbG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structDhEKpPXtbG.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structDi88qmJim6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structDi88qmJim6.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structDrIOG3dy4E.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structDrIOG3dy4E.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structE1izflhe7m.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structE1izflhe7m.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structE7tbP2KegJ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structE7tbP2KegJ.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structECJjSKcI0x.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structECJjSKcI0x.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structECjdzNW2hb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structECjdzNW2hb.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structENNglh8DX6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structENNglh8DX6.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structEVUFJOsbyB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structEVUFJOsbyB.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structEa3Y8fmO5t.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structEa3Y8fmO5t.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structEbe6V1e8rk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structEbe6V1e8rk.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structEilgeng6RU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structEilgeng6RU.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structEjN7KM70nB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structEjN7KM70nB.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structEoc6yu6UZC.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structEoc6yu6UZC.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structEqZWhQIozu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structEqZWhQIozu.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structErRGvv06c5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structErRGvv06c5.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structEvFFf3fZGJ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structEvFFf3fZGJ.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structEx5206L0wV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structEx5206L0wV.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structF3dNExh2mR.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structF3dNExh2mR.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structF8DhNrWv7E.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structF8DhNrWv7E.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structF9RjQ90jnp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structF9RjQ90jnp.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structFI3w6VQMfO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structFI3w6VQMfO.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structFJsonz9Nyz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structFJsonz9Nyz.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structFR85FzqbWk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structFR85FzqbWk.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structFXxZeDtCw5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structFXxZeDtCw5.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structFaTXoezJTa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structFaTXoezJTa.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structFhwETmltur.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structFhwETmltur.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structFjGw1Sgvhj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structFjGw1Sgvhj.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structFq1hfAwgHs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structFq1hfAwgHs.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structFvR9kgHTwq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structFvR9kgHTwq.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structFx3ViT9W1l.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structFx3ViT9W1l.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structG23iNFg5pV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structG23iNFg5pV.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structG4WvAWeyY2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structG4WvAWeyY2.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structG5eiJlW14L.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structG5eiJlW14L.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structG7DG28rR3I.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structG7DG28rR3I.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structG8t7pJyR0P.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structG8t7pJyR0P.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structGAhk4JD5f5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structGAhk4JD5f5.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structGElc6so5Vx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structGElc6so5Vx.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structGL3ENulfXA.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structGL3ENulfXA.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structGPgos6Ga6k.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structGPgos6Ga6k.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structGVka0u9TDq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structGVka0u9TDq.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structGXNEUsfHGV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structGXNEUsfHGV.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structGajQGzODLb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structGajQGzODLb.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structGbvlSI6ZFM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structGbvlSI6ZFM.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structGgvsKvoP9v.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structGgvsKvoP9v.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structGiiPLasS8y.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structGiiPLasS8y.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structGlUP6EKlOZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structGlUP6EKlOZ.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structGmNuKgusEl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structGmNuKgusEl.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structGnndCPLSRE.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structGnndCPLSRE.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structGseI8AQPtb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structGseI8AQPtb.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structGyODqQmfLk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structGyODqQmfLk.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structH5eQeBi4oY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structH5eQeBi4oY.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structH6F7xwrgKM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structH6F7xwrgKM.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structHAW6jHGG5q.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structHAW6jHGG5q.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structHGMhtcP1Gs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structHGMhtcP1Gs.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structHNoL72ys27.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structHNoL72ys27.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structHOwIYbq2Gd.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structHOwIYbq2Gd.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structHQ1FzQOf8n.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structHQ1FzQOf8n.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structHQRXU94JgV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structHQRXU94JgV.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structHSN0q7oMVM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structHSN0q7oMVM.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structHYnhl5ltDv.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structHYnhl5ltDv.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structHcCEQbo9Zf.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structHcCEQbo9Zf.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structHfRiDfgqPK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structHfRiDfgqPK.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structHnGXhmegvA.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structHnGXhmegvA.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structHnNLvYqbMR.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structHnNLvYqbMR.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structHt9F9jtMD0.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structHt9F9jtMD0.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structHusaUbKJVm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structHusaUbKJVm.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structHvGrPaR9Bu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structHvGrPaR9Bu.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structHvI693MHyM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structHvI693MHyM.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structHyrFeqyBCY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structHyrFeqyBCY.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structHzJtxAljeg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structHzJtxAljeg.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structI2aSLtV0nK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structI2aSLtV0nK.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structI5QO2BUMxk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structI5QO2BUMxk.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structI6BZQjT6lx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structI6BZQjT6lx.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structICD2Fjdvwq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structICD2Fjdvwq.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structIHkMJI02Cs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structIHkMJI02Cs.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structIJpxdh5h1j.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structIJpxdh5h1j.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structIKVPnPqtVG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structIKVPnPqtVG.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structIODsh0cyAj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structIODsh0cyAj.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structIWnVfC7bMR.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structIWnVfC7bMR.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structIg48IJ1BGz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structIg48IJ1BGz.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structIjpYds4lWa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structIjpYds4lWa.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structImqfRF5u5d.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structImqfRF5u5d.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structIpNWKHAjIK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structIpNWKHAjIK.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structIq2IxAwTbz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structIq2IxAwTbz.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structIqjoEWN5a6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structIqjoEWN5a6.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structJ1WoVnmoNK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structJ1WoVnmoNK.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structJ4N4ApAuNd.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structJ4N4ApAuNd.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structJ4sxZ95hzs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structJ4sxZ95hzs.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structJ5ThymSmBk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structJ5ThymSmBk.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structJBdaFHCitX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structJBdaFHCitX.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structJBjYKH35Id.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structJBjYKH35Id.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structJEL7o5TRHh.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structJEL7o5TRHh.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structJFU1xlKVwi.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structJFU1xlKVwi.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structJIOp0LkuGx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structJIOp0LkuGx.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structJKSxRHdkgU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structJKSxRHdkgU.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structJLl1JS3EBA.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structJLl1JS3EBA.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structJPod17bl3h.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structJPod17bl3h.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structJSkoDJdEmy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structJSkoDJdEmy.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structJXZ8aT3Z1A.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structJXZ8aT3Z1A.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structJYFDwGezZu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structJYFDwGezZu.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structJZBOzjdChs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structJZBOzjdChs.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structJcJCwPR9O6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structJcJCwPR9O6.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structJdaXHv9XGK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structJdaXHv9XGK.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structJguJlpO2Zx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structJguJlpO2Zx.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structJjOrVxY09U.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structJjOrVxY09U.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structJmS6AEcW3Z.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structJmS6AEcW3Z.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structJmgvdzeb5n.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structJmgvdzeb5n.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structJt6jf8vpBs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structJt6jf8vpBs.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structJyoG3utfUF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structJyoG3utfUF.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structK17aJaWFKp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structK17aJaWFKp.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structK6zBHvtXEz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structK6zBHvtXEz.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structK8yLeG1Rq8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structK8yLeG1Rq8.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structKAGtyEb0Mc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structKAGtyEb0Mc.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structKBZsUWVDxs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structKBZsUWVDxs.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structKD97Jf4W3S.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structKD97Jf4W3S.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structKDBDsZNe9Z.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structKDBDsZNe9Z.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structKDWeAZ2IPn.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structKDWeAZ2IPn.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structKF4sn2PYXa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structKF4sn2PYXa.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structKHnzHYYQv9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structKHnzHYYQv9.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structKJhvJs3EGG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structKJhvJs3EGG.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structKLSPh0PXhl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structKLSPh0PXhl.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structKNZX9fxtdl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structKNZX9fxtdl.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structKS9Hbi6AwZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structKS9Hbi6AwZ.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structKVlfLjDmn1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structKVlfLjDmn1.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structKX2JHsJ0bd.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structKX2JHsJ0bd.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structKkESsYkID7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structKkESsYkID7.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structKkHcnJvU6l.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structKkHcnJvU6l.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structKkvn2ffBgz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structKkvn2ffBgz.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structKxmFSKOkr0.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structKxmFSKOkr0.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structL0iuHiXIxa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structL0iuHiXIxa.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structL28FwCaWlq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structL28FwCaWlq.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structL3YlcXIU3G.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structL3YlcXIU3G.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structL5PAA2Y49o.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structL5PAA2Y49o.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structL8rTw5Q3JI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structL8rTw5Q3JI.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structLJsbrcp1QV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structLJsbrcp1QV.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structLKxIRREq4D.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structLKxIRREq4D.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structLMQlSHV6GT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structLMQlSHV6GT.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structLV2nB9GvAz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structLV2nB9GvAz.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structLa1OJDLBp5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structLa1OJDLBp5.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structLcNNHqG92U.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structLcNNHqG92U.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structLnY2DL1Mbw.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structLnY2DL1Mbw.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structLpxoYUnOy7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structLpxoYUnOy7.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structLs7CLvlkgi.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structLs7CLvlkgi.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structLtMZ0XaStC.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structLtMZ0XaStC.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structLy4yvDjUuQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structLy4yvDjUuQ.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structM9DKZGOLDg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structM9DKZGOLDg.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structMBndhRFxei.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structMBndhRFxei.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structMEcvkINwlN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structMEcvkINwlN.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structMFY7puSlGX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structMFY7puSlGX.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structMQnq3Fo18k.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structMQnq3Fo18k.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structMRN9c8EZAu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structMRN9c8EZAu.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structMSaXkM98gx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structMSaXkM98gx.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structMe4GO0lmyL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structMe4GO0lmyL.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structMf7H2FRsCR.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structMf7H2FRsCR.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structMgFMQz9tN4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structMgFMQz9tN4.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structMhWZ76XLqK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structMhWZ76XLqK.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structMiv3889DlT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structMiv3889DlT.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structMkNnqyG9Tl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structMkNnqyG9Tl.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structMw7h6zUCoS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structMw7h6zUCoS.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structN5CGh6EWiK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structN5CGh6EWiK.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structN86zzxZWL3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structN86zzxZWL3.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structN9VLieAgkB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structN9VLieAgkB.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structNB005jf6q4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structNB005jf6q4.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structNW2O8zaFJU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structNW2O8zaFJU.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structNXVElSFyJY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structNXVElSFyJY.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structNXkTPXgNCQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structNXkTPXgNCQ.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structNYxtIN1k6X.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structNYxtIN1k6X.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structNcunqydrcp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structNcunqydrcp.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structNfG8poVmRX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structNfG8poVmRX.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structNpSaGkUh99.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structNpSaGkUh99.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structNphpYJarez.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structNphpYJarez.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structNq8WSpQa6r.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structNq8WSpQa6r.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structNuHNDIZUYr.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structNuHNDIZUYr.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structO4Kr2Vp6iB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structO4Kr2Vp6iB.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structO5SpO4Lmqy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structO5SpO4Lmqy.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structO6aBEtLHCl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structO6aBEtLHCl.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structO8aC92gkJu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structO8aC92gkJu.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structOAXjhVxHVW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structOAXjhVxHVW.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structOBggRrGGeA.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structOBggRrGGeA.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structOCKiZ8XvN4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structOCKiZ8XvN4.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structOTagHf6dta.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structOTagHf6dta.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structOmPR4GDmha.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structOmPR4GDmha.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structOnU7Y1iyOW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structOnU7Y1iyOW.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structOruSh6IU68.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structOruSh6IU68.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structP07kLcgWy2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structP07kLcgWy2.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structP0hi03Yr5J.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structP0hi03Yr5J.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structP51IT0iQls.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structP51IT0iQls.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structPC53CFAahl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structPC53CFAahl.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structPDETEBub2B.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structPDETEBub2B.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structPIEO17rXv3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structPIEO17rXv3.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structPL1Vy8gAQG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structPL1Vy8gAQG.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structPOAJbOn5yN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structPOAJbOn5yN.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structPWOGZtzGIy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structPWOGZtzGIy.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structPWOtvXxst0.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structPWOtvXxst0.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structPaMBWeOEZb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structPaMBWeOEZb.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structPbViqUkC9s.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structPbViqUkC9s.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structPjXLhVCSo2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structPjXLhVCSo2.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structPmsSWhVFlx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structPmsSWhVFlx.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structPvttwCSove.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structPvttwCSove.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structPy7auxT2wm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structPy7auxT2wm.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structPzKBHCX9aj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structPzKBHCX9aj.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structQ1lt85NZkv.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structQ1lt85NZkv.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structQ9W3v3dQYW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structQ9W3v3dQYW.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structQBpF2mc1un.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structQBpF2mc1un.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structQLoTxIicfl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structQLoTxIicfl.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structQNBjmFEISk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structQNBjmFEISk.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structQRNlszU7N1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structQRNlszU7N1.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structQRrZvgSvEl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structQRrZvgSvEl.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structQu8eKSWeIJ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structQu8eKSWeIJ.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structQwjx7jDCDX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structQwjx7jDCDX.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structQwri7Ax9TK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structQwri7Ax9TK.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structR4xaEYdpRY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structR4xaEYdpRY.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structR6bsgVIYE6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structR6bsgVIYE6.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structR6j965l6JZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structR6j965l6JZ.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structR6yPnOD0oz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structR6yPnOD0oz.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structR8eEQpI0YT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structR8eEQpI0YT.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structRBr9HNIGgm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structRBr9HNIGgm.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structRBwjivoMMP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structRBwjivoMMP.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structRFFK9pIT93.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structRFFK9pIT93.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structRJYj3K0a3c.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structRJYj3K0a3c.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structRLhaWW9haz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structRLhaWW9haz.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structRSckKIVPNO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structRSckKIVPNO.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structRX7hJYzEEc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structRX7hJYzEEc.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structRbEgtyrBAH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structRbEgtyrBAH.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structRbgB04HmL4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structRbgB04HmL4.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structRdgEVFWPU8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structRdgEVFWPU8.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structRjYd0rym9S.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structRjYd0rym9S.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structRpd0ErOBb6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structRpd0ErOBb6.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structRtcf0YV8fO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structRtcf0YV8fO.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structRtjThoUz7H.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structRtjThoUz7H.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structRyTk5RxJJO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structRyTk5RxJJO.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structS1RhuauboU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structS1RhuauboU.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structS6bmXaMMyl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structS6bmXaMMyl.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structSDPIMkAwH8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structSDPIMkAwH8.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structSEmAsgVkk9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structSEmAsgVkk9.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structSIfHQocAM7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structSIfHQocAM7.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structSL3XN9PByF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structSL3XN9PByF.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structSOJZorG6h4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structSOJZorG6h4.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structSOQ2b3Trj9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structSOQ2b3Trj9.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structSOcWqfVVcP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structSOcWqfVVcP.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structSUuI5kWBPQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structSUuI5kWBPQ.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structSWz0ZdY1fL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structSWz0ZdY1fL.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structSXB5wflpQj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structSXB5wflpQj.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structSaCKmxwW7X.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structSaCKmxwW7X.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structSkgZGVkxzj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structSkgZGVkxzj.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structSuSfIvUv2A.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structSuSfIvUv2A.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structSuaJbDOn73.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structSuaJbDOn73.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structSv55DLNwHy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structSv55DLNwHy.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structSvXjwmwWp8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structSvXjwmwWp8.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structT024qoIGBu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structT024qoIGBu.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structT396ygje53.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structT396ygje53.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structTA8Sp22K2U.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structTA8Sp22K2U.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structTGF07uM1y9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structTGF07uM1y9.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structTKbYYBx9QZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structTKbYYBx9QZ.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structTLyC86eODa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structTLyC86eODa.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structTSEu5hclTq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structTSEu5hclTq.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structTX5YCrOcOo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structTX5YCrOcOo.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structTX6rXf2RZh.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structTX6rXf2RZh.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structTaJbzfeDjo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structTaJbzfeDjo.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structTaYGLKdSM8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structTaYGLKdSM8.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structTgcZPmWOx2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structTgcZPmWOx2.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structTh5NbnUqzI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structTh5NbnUqzI.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structTknpxoQFvS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structTknpxoQFvS.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structTqu8KoZQjY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structTqu8KoZQjY.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structTuAcbBNnZm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structTuAcbBNnZm.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structTuWH3zeluv.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structTuWH3zeluv.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structTwjPuMKDiB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structTwjPuMKDiB.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structTxF88EuH4Q.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structTxF88EuH4Q.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structTzQ4rWvlZ3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structTzQ4rWvlZ3.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structU2kogkOlcf.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structU2kogkOlcf.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structU3dy6bkQcN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structU3dy6bkQcN.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structUA5Zgdsa4W.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structUA5Zgdsa4W.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structUC7urls6rG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structUC7urls6rG.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structUJ5RVg0xHN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structUJ5RVg0xHN.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structUL0XgKUiea.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structUL0XgKUiea.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structUYdnQvYvKk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structUYdnQvYvKk.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structUaTPRyIwWQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structUaTPRyIwWQ.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structUgp6Bg804O.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structUgp6Bg804O.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structUgsqUT0Fw8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structUgsqUT0Fw8.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structUomjJGDhS3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structUomjJGDhS3.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structUrJ7tMPYdi.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structUrJ7tMPYdi.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structUsGUm5feCJ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structUsGUm5feCJ.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structUx6sDnae6o.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structUx6sDnae6o.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structUyBELJkxhd.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structUyBELJkxhd.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structV1mFMqHDyz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structV1mFMqHDyz.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structV3DEOjYkAI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structV3DEOjYkAI.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structV4EcMh64Nu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structV4EcMh64Nu.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structVABFQlbdB8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structVABFQlbdB8.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structVCKWE5qXDQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structVCKWE5qXDQ.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structVF3eV6RT5A.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structVF3eV6RT5A.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structVGVFt2H4Jq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structVGVFt2H4Jq.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structVHmibu21U1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structVHmibu21U1.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structVJQMEbTTcW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structVJQMEbTTcW.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structVW9Wugrq8f.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structVW9Wugrq8f.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structVbui9U8nJN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structVbui9U8nJN.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structVqmZxmYjrS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structVqmZxmYjrS.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structVwumd12dMR.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structVwumd12dMR.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structW03TuqLzYH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structW03TuqLzYH.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structW6NGdR4FHA.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structW6NGdR4FHA.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structW8RwEte1K1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structW8RwEte1K1.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structWFr5O7xRwi.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structWFr5O7xRwi.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structWJw9ZLP7fK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structWJw9ZLP7fK.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structWODpD4eAmE.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structWODpD4eAmE.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structWOGNQBbIW7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structWOGNQBbIW7.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structWQN1KyUD5b.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structWQN1KyUD5b.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structWTDgYPieK1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structWTDgYPieK1.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structWVtboPH1aE.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structWVtboPH1aE.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structWiPM4vCvbR.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structWiPM4vCvbR.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structWk1zWo8r9K.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structWk1zWo8r9K.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structWkYOcVuG9r.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structWkYOcVuG9r.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structWqKLr6PuT3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structWqKLr6PuT3.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structWyFaNRxWDU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structWyFaNRxWDU.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structX0tLJiI6QS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structX0tLJiI6QS.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structX74WdLPgP3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structX74WdLPgP3.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structXLePVWtJFS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structXLePVWtJFS.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structXNJAbmwEpz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structXNJAbmwEpz.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structXOlFj8WTWU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structXOlFj8WTWU.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structXQpY9eJk4m.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structXQpY9eJk4m.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structXU2GzBHEnm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structXU2GzBHEnm.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structXWIUjIMjuc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structXWIUjIMjuc.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structXYOl2gpZhZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structXYOl2gpZhZ.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structXYrXq7Kz5O.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structXYrXq7Kz5O.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structXab1L6RKkc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structXab1L6RKkc.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structXcQSZS9Pq3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structXcQSZS9Pq3.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structXdOq3rooU7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structXdOq3rooU7.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structXpfvMzo3SU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structXpfvMzo3SU.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structXs0m0HB3Ve.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structXs0m0HB3Ve.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structXsoVym5xGF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structXsoVym5xGF.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structXxbrxyvfJK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structXxbrxyvfJK.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structY0sbuM1lf1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structY0sbuM1lf1.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structY2WI2qZBJc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structY2WI2qZBJc.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structY3MSP8GJLq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structY3MSP8GJLq.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structY7ZzgHzGVw.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structY7ZzgHzGVw.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structY8HkjRfwpg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structY8HkjRfwpg.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structYAzsftuDhx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structYAzsftuDhx.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structYE37gD7DoN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structYE37gD7DoN.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structYNODMJt0nI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structYNODMJt0nI.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structYOoQMQYEZo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structYOoQMQYEZo.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structYPtr2Dr86B.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structYPtr2Dr86B.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structYXRqKm5H9U.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structYXRqKm5H9U.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structYa2X1A0XlS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structYa2X1A0XlS.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structYj7TbLsdP4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structYj7TbLsdP4.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structYlF6RxCqVs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structYlF6RxCqVs.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structYo1jTzfuKl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structYo1jTzfuKl.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structYrew2qdBuH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structYrew2qdBuH.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structYwZwDfIvIG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structYwZwDfIvIG.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structZ3DY5gvzFY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structZ3DY5gvzFY.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structZBrvC38b8N.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structZBrvC38b8N.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structZC6ZaapQdD.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structZC6ZaapQdD.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structZGNK9Twr9S.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structZGNK9Twr9S.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structZGqp2bRDtx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structZGqp2bRDtx.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structZJSKolxfqc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structZJSKolxfqc.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structZR3LiJX7PO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structZR3LiJX7PO.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structZW26HGLchP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structZW26HGLchP.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structZi1RqmdSol.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structZi1RqmdSol.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structZoimFj6xEE.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structZoimFj6xEE.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structZpfDnRPksn.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structZpfDnRPksn.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structZr2k5TeLcE.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structZr2k5TeLcE.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structZtqbbnQjzj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structZtqbbnQjzj.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structZupKEHABUk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structZupKEHABUk.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structa0AhWFAoDG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structa0AhWFAoDG.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structa5eW784LQf.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structa5eW784LQf.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structa6BXYQAwEm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structa6BXYQAwEm.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structa6bL6toTDQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structa6bL6toTDQ.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structa85eS8wvGC.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structa85eS8wvGC.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structaBCMiwiL14.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structaBCMiwiL14.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structaCvUpfrOud.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structaCvUpfrOud.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structaMVAJ9INz0.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structaMVAJ9INz0.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structaNX02HPg7T.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structaNX02HPg7T.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structaacjP2BYDY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structaacjP2BYDY.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structafSLEQGtjb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structafSLEQGtjb.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structawZmlvXiXW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structawZmlvXiXW.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structaxV4fiWwZ7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structaxV4fiWwZ7.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structayNEhBBg4t.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structayNEhBBg4t.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structb265yb0csM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structb265yb0csM.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structb63fAzKNR7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structb63fAzKNR7.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structbBsug1Wd34.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structbBsug1Wd34.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structbNMyvNH8WM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structbNMyvNH8WM.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structbX4S27LXkH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structbX4S27LXkH.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structblpexlSs9M.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structblpexlSs9M.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structbmmnw9qu32.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structbmmnw9qu32.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structbsrrxTZOqn.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structbsrrxTZOqn.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structbtgnPXO5Rq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structbtgnPXO5Rq.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structbwtswCbHZn.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structbwtswCbHZn.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structc0ARtdYgED.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structc0ARtdYgED.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structc0K76QtGvt.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structc0K76QtGvt.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structc19BIAaEkY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structc19BIAaEkY.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structcIUFEZhrle.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structcIUFEZhrle.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structcU51DXcyE8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structcU51DXcyE8.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structcbnz0kvIwn.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structcbnz0kvIwn.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structcfbnUeCgbt.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structcfbnUeCgbt.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structcjMmD9Dwfx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structcjMmD9Dwfx.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structclmVkpAhb8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structclmVkpAhb8.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structcoAqE1boX6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structcoAqE1boX6.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structcormXUf4WS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structcormXUf4WS.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structcqdGRq2WNh.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structcqdGRq2WNh.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structczOiELiAB7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structczOiELiAB7.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structd2ojXxCaNW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structd2ojXxCaNW.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structd4OcbMDcGL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structd4OcbMDcGL.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structd9nB4x1U6u.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structd9nB4x1U6u.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structdEhJcrsORt.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structdEhJcrsORt.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structdKBNYvwyxK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structdKBNYvwyxK.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structdNGVHIlzAj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structdNGVHIlzAj.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structdSftno00MK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structdSftno00MK.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structdXZpHpuk3x.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structdXZpHpuk3x.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structdXgIF94ebo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structdXgIF94ebo.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structdhEH1P8yDX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structdhEH1P8yDX.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structdq0ytTGdT7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structdq0ytTGdT7.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structdr28D0z5ZH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structdr28D0z5ZH.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structe4z2kYEwsw.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structe4z2kYEwsw.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structe79Za4b7Ml.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structe79Za4b7Ml.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structeJF56nvsEj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structeJF56nvsEj.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structeW6hiVZjD9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structeW6hiVZjD9.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structegI0J6pwbq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structegI0J6pwbq.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structemjd05RWc3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structemjd05RWc3.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structeqBjnWgb5P.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structeqBjnWgb5P.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structf0akg4gumK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structf0akg4gumK.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structf32Rx1NpEm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structf32Rx1NpEm.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structf3hg4Duqet.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structf3hg4Duqet.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structf74ThK893J.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structf74ThK893J.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structfBkGsQBirP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structfBkGsQBirP.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structfCVtyydYxM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structfCVtyydYxM.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structfCayR9pma6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structfCayR9pma6.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structfG4ASdjUC9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structfG4ASdjUC9.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structfJdkVlyVac.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structfJdkVlyVac.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structfNnOzIDYzL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structfNnOzIDYzL.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structfOOjVzFOC9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structfOOjVzFOC9.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structfTXY9OU4mh.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structfTXY9OU4mh.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structfWEUc1K6FG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structfWEUc1K6FG.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structfYJ2Mkk1al.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structfYJ2Mkk1al.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structfcg2UqwprF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structfcg2UqwprF.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structfd0mCQVHBl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structfd0mCQVHBl.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structfwecOIJDmQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structfwecOIJDmQ.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structgBuG9DjtOU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structgBuG9DjtOU.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structgIAdPMClq9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structgIAdPMClq9.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structgJaEzQzHlG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structgJaEzQzHlG.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structgTI819u8oK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structgTI819u8oK.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structgaVRwvBYOY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structgaVRwvBYOY.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structgmDuxmO8uQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structgmDuxmO8uQ.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structgnTh8YZCI4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structgnTh8YZCI4.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structgnzwfueLCU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structgnzwfueLCU.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structgodJTvsSrL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structgodJTvsSrL.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structgoyNOloADC.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structgoyNOloADC.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structgrMFKxp6Rp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structgrMFKxp6Rp.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structgu5AmoUnKH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structgu5AmoUnKH.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structgw0RpMV2f4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structgw0RpMV2f4.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structgzPFVO95T5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structgzPFVO95T5.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structh0wIvbjPFM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structh0wIvbjPFM.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structh0zYLuKys0.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structh0zYLuKys0.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structh4borQn8tt.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structh4borQn8tt.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structhEYyOpWNQA.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structhEYyOpWNQA.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structhKVOXTzhtj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structhKVOXTzhtj.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structhP7CI8CVIx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structhP7CI8CVIx.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structhRp6BjrXlq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structhRp6BjrXlq.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structhXluAaYGUP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structhXluAaYGUP.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structhc5U7IjcZc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structhc5U7IjcZc.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structhjYDoXKd1y.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structhjYDoXKd1y.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structhk5xXOFY3B.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structhk5xXOFY3B.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structhlXXNdntjL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structhlXXNdntjL.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structhnljKmvH1S.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structhnljKmvH1S.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structhsMP7WDnTb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structhsMP7WDnTb.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structi5tx16f99j.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structi5tx16f99j.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structi60i9flgEl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structi60i9flgEl.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structiGcBGhWkFg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structiGcBGhWkFg.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structiH2t1AudUv.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structiH2t1AudUv.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structiJO3yTUlA6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structiJO3yTUlA6.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structiMxQrDbyMm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structiMxQrDbyMm.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structiRTC8Ri5hh.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structiRTC8Ri5hh.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structiUTYiuw7nL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structiUTYiuw7nL.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structifVuZi4Efe.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structifVuZi4Efe.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structigySx6ywF4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structigySx6ywF4.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structimk6k6ZOQP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structimk6k6ZOQP.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structiyfYt6St4H.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structiyfYt6St4H.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structj0Jp6zlUkb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structj0Jp6zlUkb.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structj2noj6YBli.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structj2noj6YBli.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structj80X6OAWFM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structj80X6OAWFM.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structjATzvt82Yc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structjATzvt82Yc.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structjHYdKd1qGS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structjHYdKd1qGS.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structjIn9JVMI49.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structjIn9JVMI49.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structjKvkQzPnI2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structjKvkQzPnI2.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structjPeWDdzelT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structjPeWDdzelT.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structjVynlgrJOg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structjVynlgrJOg.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structjXzq5dAQfq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structjXzq5dAQfq.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structjlEQy1XgIm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structjlEQy1XgIm.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structjpZYztDGZv.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structjpZYztDGZv.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structjyzBmrWLpD.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structjyzBmrWLpD.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structjzLZ1Fd1su.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structjzLZ1Fd1su.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structk0RWOtD4Cb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structk0RWOtD4Cb.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structk5uhI551Ib.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structk5uhI551Ib.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structkBpo9DUgjg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structkBpo9DUgjg.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structkKCqpBwgSB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structkKCqpBwgSB.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structkMn4TDNnDw.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structkMn4TDNnDw.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structkTDa7zOTTq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structkTDa7zOTTq.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structkcnuBfgvqB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structkcnuBfgvqB.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structke5R4wNmaV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structke5R4wNmaV.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structkgOVznysHS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structkgOVznysHS.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structkjR2PqZPCx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structkjR2PqZPCx.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structkjvkPYElx2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structkjvkPYElx2.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structko3HKcubO4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structko3HKcubO4.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structl1rwee6A0W.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structl1rwee6A0W.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structl9GK15NFfI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structl9GK15NFfI.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structl9dEcAYjZX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structl9dEcAYjZX.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structlCbFTLeEcO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structlCbFTLeEcO.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structlFoUTH7TGY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structlFoUTH7TGY.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structlFuagxP4pj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structlFuagxP4pj.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structlKqlZNIiTG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structlKqlZNIiTG.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structlM9nCK9mVa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structlM9nCK9mVa.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structlNxcettVbW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structlNxcettVbW.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structlOMWejTcie.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structlOMWejTcie.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structlPPzP90v2M.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structlPPzP90v2M.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structlWE7ijbTPg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structlWE7ijbTPg.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structlWZpr8mFUz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structlWZpr8mFUz.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structlfb6Bcmyzv.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structlfb6Bcmyzv.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structliZR39PG4B.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structliZR39PG4B.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structlilo17vqrO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structlilo17vqrO.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structlmBHuI2CdK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structlmBHuI2CdK.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structlsRnaxudRi.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structlsRnaxudRi.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structlwBBVufID9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structlwBBVufID9.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structmE7fFfuHjx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structmE7fFfuHjx.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structmPX6OOh4Nl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structmPX6OOh4Nl.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structmR2t9GgAZ5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structmR2t9GgAZ5.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structmU9k8N2S1x.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structmU9k8N2S1x.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structmUQioQKiXp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structmUQioQKiXp.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structmWBF30udKT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structmWBF30udKT.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structmaUySacG7e.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structmaUySacG7e.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structmj4Oyb3GgX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structmj4Oyb3GgX.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structmuAhuD4KVQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structmuAhuD4KVQ.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structmwjaO3Uyrs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structmwjaO3Uyrs.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structn5h1DHBxub.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structn5h1DHBxub.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structnAdqmBnbeg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structnAdqmBnbeg.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structnAvYhH07Gs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structnAvYhH07Gs.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structnHnX8P1WDq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structnHnX8P1WDq.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structnNkjJDcz0P.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structnNkjJDcz0P.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structnPwZk9I7YN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structnPwZk9I7YN.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structnUJfW4NMaA.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structnUJfW4NMaA.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structnXMZUp9V4V.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structnXMZUp9V4V.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structnjkuDZnOoQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structnjkuDZnOoQ.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structnq8k7vNWX3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structnq8k7vNWX3.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structnrVsGpyHSB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structnrVsGpyHSB.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structnsGvdkMRFZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structnsGvdkMRFZ.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structoAhXI74h9j.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structoAhXI74h9j.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structoahbTSUqku.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structoahbTSUqku.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structoiRn4GygF9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structoiRn4GygF9.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structov6aJQLXqu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structov6aJQLXqu.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structovm1h7N1tD.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structovm1h7N1tD.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structoypCXXMXYK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structoypCXXMXYK.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structp39x1W6Nmw.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structp39x1W6Nmw.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structp5F0SqEi1N.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structp5F0SqEi1N.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structpK1zdl2ooH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structpK1zdl2ooH.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structpLXABe2wJc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structpLXABe2wJc.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structpMr2v6juAQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structpMr2v6juAQ.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structpXZA41Y8fK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structpXZA41Y8fK.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structpkIouuiKqe.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structpkIouuiKqe.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structpnMhTmK3QH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structpnMhTmK3QH.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structpuA2r64pbW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structpuA2r64pbW.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structpwCAT0hshK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structpwCAT0hshK.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structq1BEWkecYX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structq1BEWkecYX.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structq2gqs38KnH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structq2gqs38KnH.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structq5OjZ10BEs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structq5OjZ10BEs.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structqGa10MSSRs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structqGa10MSSRs.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structqGuE1lEn2E.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structqGuE1lEn2E.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structqK7XKTZI6a.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structqK7XKTZI6a.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structqRtOraogqy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structqRtOraogqy.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structqTdD25cQMq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structqTdD25cQMq.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structqVenFBZMmB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structqVenFBZMmB.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structqVymoyiTzO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structqVymoyiTzO.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structqYoMOdyW5o.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structqYoMOdyW5o.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structqZqGFZMAp0.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structqZqGFZMAp0.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structqceTFkotG1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structqceTFkotG1.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structqklsh0VtCj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structqklsh0VtCj.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structqkwGFodzYo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structqkwGFodzYo.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structqlynSYPIzj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structqlynSYPIzj.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structqmylEQUQxN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structqmylEQUQxN.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structqsdnJQvtod.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structqsdnJQvtod.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structr1IUWdH7kS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structr1IUWdH7kS.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structrDLhl5fFyI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structrDLhl5fFyI.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structrJ6A29EFD3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structrJ6A29EFD3.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structrLI0qkdwNT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structrLI0qkdwNT.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structrNNNMoMUX5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structrNNNMoMUX5.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structrQyjIvxeGC.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structrQyjIvxeGC.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structrUZIsQzLzo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structrUZIsQzLzo.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structrUrNNgGYxl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structrUrNNgGYxl.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structrZORE7saci.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structrZORE7saci.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structrnEvXbtOaJ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structrnEvXbtOaJ.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structrv6cJ7e4eI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structrv6cJ7e4eI.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structrvnG4DB0O9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structrvnG4DB0O9.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structrxuRIzLrOd.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structrxuRIzLrOd.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structs0wKthNJDH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structs0wKthNJDH.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structs6tlj8Ujb6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structs6tlj8Ujb6.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structs81xiTr3V2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structs81xiTr3V2.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structs9FC686ssT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structs9FC686ssT.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structsU7ru1S3Bn.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structsU7ru1S3Bn.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structsconExg82n.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structsconExg82n.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structsnl6YWFzw6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structsnl6YWFzw6.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structsr11hihvVP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structsr11hihvVP.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structsrFnuySLJZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structsrFnuySLJZ.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structsyMjE23XYL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structsyMjE23XYL.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structt1zhtoy3QG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structt1zhtoy3QG.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structt3vc10gLez.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structt3vc10gLez.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structt7Y6XwomUH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structt7Y6XwomUH.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structtFfTsyMFtj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structtFfTsyMFtj.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structtKTQH67TAx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structtKTQH67TAx.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structtRnRKY1Nt9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structtRnRKY1Nt9.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structtVv0gLLUw6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structtVv0gLLUw6.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structtdu9UH9BR6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structtdu9UH9BR6.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structtkLijaINDB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structtkLijaINDB.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structtmi3Y4xjWJ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structtmi3Y4xjWJ.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structtoRHBeshpF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structtoRHBeshpF.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structtoojZOxzYL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structtoojZOxzYL.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structuEWock0xfg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structuEWock0xfg.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structuYFS57GpEz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structuYFS57GpEz.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structuZLTFqoTc9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structuZLTFqoTc9.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structuesCCsCmB9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structuesCCsCmB9.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structuk9n40Ba1s.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structuk9n40Ba1s.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structurOByRIJr5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structurOByRIJr5.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structusM7i9eFda.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structusM7i9eFda.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structuzTdZWiu60.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structuzTdZWiu60.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structv4jF52UQ9H.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structv4jF52UQ9H.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structv9bmg59CEV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structv9bmg59CEV.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structvE6YTruKB5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structvE6YTruKB5.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structvGYXxaXkfO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structvGYXxaXkfO.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structvIiPiag0AP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structvIiPiag0AP.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structvJXxV1TNGG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structvJXxV1TNGG.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structvLrhLw24Yo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structvLrhLw24Yo.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structvPLGLtUGvc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structvPLGLtUGvc.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structvQ4tBtsFIQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structvQ4tBtsFIQ.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structvetTPo8phL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structvetTPo8phL.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structvh6HUMxCO1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structvh6HUMxCO1.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structvhPOJekCB6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structvhPOJekCB6.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structvqpjGCBNgC.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structvqpjGCBNgC.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structw1Jcuo2qcB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structw1Jcuo2qcB.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structw1LUTeHkEP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structw1LUTeHkEP.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structw704rOrUeD.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structw704rOrUeD.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structwAVE8pzuIw.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structwAVE8pzuIw.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structwE9USHmMoa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structwE9USHmMoa.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structwKyV6c3NXx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structwKyV6c3NXx.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structwNNWk20409.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structwNNWk20409.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structwPjsuxb7PR.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structwPjsuxb7PR.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structwquRams9Fs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structwquRams9Fs.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structwyz9cVcdwh.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structwyz9cVcdwh.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structx29mgYMw04.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structx29mgYMw04.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structx9kDs7ICzW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structx9kDs7ICzW.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structxFTWeVz86X.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structxFTWeVz86X.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structxI8aw5DOBf.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structxI8aw5DOBf.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structxKJxcMqgXp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structxKJxcMqgXp.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structxSyTOLVs2a.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structxSyTOLVs2a.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structxY83QlHYu8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structxY83QlHYu8.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structxatoIPHwut.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structxatoIPHwut.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structxayiSk9poY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structxayiSk9poY.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structxl0tHilNDj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structxl0tHilNDj.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structxpKM8hQmHX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structxpKM8hQmHX.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structxrKKgR1Fe1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structxrKKgR1Fe1.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structxsR9aAsAXm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structxsR9aAsAXm.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structxwNsI8Zdb1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structxwNsI8Zdb1.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structy2eHpFGRr5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structy2eHpFGRr5.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structy5X9cuxDIn.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structy5X9cuxDIn.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structy5wbr5f4bB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structy5wbr5f4bB.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structyAGnaq1EBc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structyAGnaq1EBc.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structyGjRe5am7c.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structyGjRe5am7c.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structyKsJfDGXaz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structyKsJfDGXaz.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structyNBvxKIcti.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structyNBvxKIcti.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structyPEdNMH6Lo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structyPEdNMH6Lo.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structyTmtkFKqd7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structyTmtkFKqd7.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structydbIqe0qPo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structydbIqe0qPo.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structyhDvAbXvCv.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structyhDvAbXvCv.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structynitZhhUeJ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structynitZhhUeJ.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structyvVgkdYRXO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structyvVgkdYRXO.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structz1JgTXpAuI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structz1JgTXpAuI.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structz7dfzzL9Yk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structz7dfzzL9Yk.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structzIXefsJFSz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structzIXefsJFSz.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structzPWDt4oN6i.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structzPWDt4oN6i.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structzQUyc7Ws0e.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structzQUyc7Ws0e.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structzTIpN6ALMu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structzTIpN6ALMu.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structzYoD4xKxnZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structzYoD4xKxnZ.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structzdXNEcof9V.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structzdXNEcof9V.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structzo3owhla9x.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structzo3owhla9x.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structzyowJj76a6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/partial-structzyowJj76a6.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct00oieaoYA5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct00oieaoYA5.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct05nZxSvOQy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct05nZxSvOQy.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct0CW6rWihRa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct0CW6rWihRa.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct0EiiHjJ0Jy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct0EiiHjJ0Jy.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct0HxVdkFuDk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct0HxVdkFuDk.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct0Sp8nFf9po.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct0Sp8nFf9po.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct0YOigHUonk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct0YOigHUonk.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct0mu68DyXFS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct0mu68DyXFS.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct0oZl05ifoL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct0oZl05ifoL.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct101P28DC6b.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct101P28DC6b.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct109xwVU7na.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct109xwVU7na.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct13ZLCuuDdg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct13ZLCuuDdg.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct164v5M7Oiu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct164v5M7Oiu.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct16i8Hnvzik.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct16i8Hnvzik.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct1B64P2KJTT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct1B64P2KJTT.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct1FLNprzFfg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct1FLNprzFfg.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct1Lodf8jQhi.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct1Lodf8jQhi.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct1NM3qeUh2p.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct1NM3qeUh2p.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct1QKloRyprM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct1QKloRyprM.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct1TeundtXb1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct1TeundtXb1.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct1e9vZ2ZVVl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct1e9vZ2ZVVl.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct1ibkpE2U9t.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct1ibkpE2U9t.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct1jAvJkz71q.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct1jAvJkz71q.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct1kIcXqyaMm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct1kIcXqyaMm.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct1kIjvNmL26.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct1kIjvNmL26.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct1nopkP9yWt.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct1nopkP9yWt.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct1q3mpvDeuG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct1q3mpvDeuG.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct1rwcZsOxGm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct1rwcZsOxGm.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct1shpv6NmPc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct1shpv6NmPc.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct1tertRu9Xm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct1tertRu9Xm.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct1xSlrFoiE2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct1xSlrFoiE2.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct1xjEjG8zge.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct1xjEjG8zge.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct1zEPcP8TZ0.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct1zEPcP8TZ0.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct22wFvfGOQe.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct22wFvfGOQe.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct23OaGTh97N.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct23OaGTh97N.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct2C0v3cLs4t.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct2C0v3cLs4t.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct2Ii6Pytw94.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct2Ii6Pytw94.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct2KJvO9ifSa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct2KJvO9ifSa.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct2Oea4qEuqL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct2Oea4qEuqL.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct2PRjv73LUz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct2PRjv73LUz.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct2PlWXW13Oo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct2PlWXW13Oo.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct2RjyXdbOmS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct2RjyXdbOmS.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct2WJXBATRow.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct2WJXBATRow.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct2ePshLeWkH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct2ePshLeWkH.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct2iRAZCo7L5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct2iRAZCo7L5.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct2l1qlatawT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct2l1qlatawT.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct2lPhMAoDBl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct2lPhMAoDBl.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct2mrBdiaAsD.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct2mrBdiaAsD.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct2yK9S7dzeX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct2yK9S7dzeX.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct2yeMfnvK5l.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct2yeMfnvK5l.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct34i0YswjFg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct34i0YswjFg.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct3AvV0e5RCv.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct3AvV0e5RCv.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct3Fkic0RvsS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct3Fkic0RvsS.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct3Q09CNhFqG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct3Q09CNhFqG.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct3W5X0ROtrE.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct3W5X0ROtrE.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct3YKEcUcTm6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct3YKEcUcTm6.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct3Ysql1aZTo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct3Ysql1aZTo.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct3aLcZ0Gzdp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct3aLcZ0Gzdp.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct3bQ2CbXXiG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct3bQ2CbXXiG.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct3hbQkh2oXr.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct3hbQkh2oXr.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct3o9W3tWIYr.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct3o9W3tWIYr.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct3oRAhgtPFs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct3oRAhgtPFs.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct3rEqyW20Ha.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct3rEqyW20Ha.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct3rh7agTF1u.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct3rh7agTF1u.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct3tAXhVgz0j.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct3tAXhVgz0j.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct3udOlsWezr.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct3udOlsWezr.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct3yavERh0QP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct3yavERh0QP.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct40R1V76roU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct40R1V76roU.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct44PftY660j.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct44PftY660j.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct46ykdVFGwG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct46ykdVFGwG.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct47pp9CzShs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct47pp9CzShs.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct49eWbTEG4e.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct49eWbTEG4e.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct4I0C5KiBcT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct4I0C5KiBcT.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct4NHzRc00m2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct4NHzRc00m2.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct4R1b3Sfk6J.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct4R1b3Sfk6J.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct4VkhuwJa8e.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct4VkhuwJa8e.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct4bA4rV4T7I.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct4bA4rV4T7I.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct4qOfIMBclV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct4qOfIMBclV.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct4tYHXfgnVZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct4tYHXfgnVZ.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct4xCfXxpvdy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct4xCfXxpvdy.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct4zYtkggxX9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct4zYtkggxX9.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct566AUa8c9w.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct566AUa8c9w.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct5B3Ki66g8U.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct5B3Ki66g8U.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct5GIHfCnyF0.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct5GIHfCnyF0.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct5GXqW1XpIl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct5GXqW1XpIl.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct5R3JtFMKyy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct5R3JtFMKyy.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct5WOnMXao7S.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct5WOnMXao7S.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct5WjoUCBC2W.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct5WjoUCBC2W.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct5YuboIIJis.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct5YuboIIJis.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct5coPgZ627S.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct5coPgZ627S.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct5nsLLrnYzS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct5nsLLrnYzS.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct5p0wzn3Twr.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct5p0wzn3Twr.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct5pUyGEiqRW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct5pUyGEiqRW.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct66VojQk1NI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct66VojQk1NI.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct67D9OX1YBs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct67D9OX1YBs.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct67XWJDtmLp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct67XWJDtmLp.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct6ACGifRdRw.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct6ACGifRdRw.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct6AkdgH06Lh.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct6AkdgH06Lh.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct6BWJO4ygCh.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct6BWJO4ygCh.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct6Eho6XNoOx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct6Eho6XNoOx.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct6Fnny4hIyl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct6Fnny4hIyl.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct6GnahT2THT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct6GnahT2THT.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct6Gy1eE7iFg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct6Gy1eE7iFg.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct6InhhK3Bnx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct6InhhK3Bnx.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct6KaWm2V4so.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct6KaWm2V4so.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct6NVZQs4UrE.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct6NVZQs4UrE.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct6PUxZ29VTq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct6PUxZ29VTq.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct6fce05Qu1f.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct6fce05Qu1f.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct6tzbdxQpL4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct6tzbdxQpL4.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct763ixhZiPg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct763ixhZiPg.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct79tZSSX75b.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct79tZSSX75b.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct7E3RzOaVF1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct7E3RzOaVF1.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct7Ev4ba5U4g.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct7Ev4ba5U4g.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct7FkotSk0XD.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct7FkotSk0XD.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct7MpRJpjzYV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct7MpRJpjzYV.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct7UAHrFSXgp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct7UAHrFSXgp.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct7ZDRFK7C6w.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct7ZDRFK7C6w.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct7hWyxK9Im1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct7hWyxK9Im1.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct7vhsXm5Sqy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct7vhsXm5Sqy.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct7vwzjN2hQB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct7vwzjN2hQB.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct7x47kTkDWA.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct7x47kTkDWA.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct814BQq200G.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct814BQq200G.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct84TN7zjoK9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct84TN7zjoK9.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct8CllamWxHF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct8CllamWxHF.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct8KGpb7sMhV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct8KGpb7sMhV.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct8P1XTIrmCU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct8P1XTIrmCU.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct8eGauAG2Iy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct8eGauAG2Iy.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct8hD3MVC60I.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct8hD3MVC60I.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct8q0Jpdjx8u.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct8q0Jpdjx8u.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct8qIwjmR7oN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct8qIwjmR7oN.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct8tbcftbwF8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct8tbcftbwF8.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct8txOZ8smgu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct8txOZ8smgu.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct8yaeAzdZUO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct8yaeAzdZUO.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct98nsmL4Uyu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct98nsmL4Uyu.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct9CTRHeV5gV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct9CTRHeV5gV.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct9E3xYWs4gr.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct9E3xYWs4gr.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct9FbBK7sAEy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct9FbBK7sAEy.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct9HOIXHYhP9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct9HOIXHYhP9.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct9IzMME36Bl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct9IzMME36Bl.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct9PLpEx4eEr.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct9PLpEx4eEr.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct9QX6aOMWmP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct9QX6aOMWmP.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct9XFvojKqS7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct9XFvojKqS7.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct9Z0NXJ0nuB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct9Z0NXJ0nuB.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct9cdQxj05PP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct9cdQxj05PP.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct9dJLrfdwrb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct9dJLrfdwrb.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct9fPHF2RcIG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct9fPHF2RcIG.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct9o9IQlJhfF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct9o9IQlJhfF.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct9rTJlJQ4St.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct9rTJlJQ4St.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct9tS75raz9v.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-struct9tS75raz9v.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structA0t67j1fxp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structA0t67j1fxp.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structA2y6S9lFjD.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structA2y6S9lFjD.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structA4N6i5eArl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structA4N6i5eArl.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structA6J9ouYjJm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structA6J9ouYjJm.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structAB03r2H43b.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structAB03r2H43b.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structADRxlKyBIl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structADRxlKyBIl.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structAE7oPkwYY6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structAE7oPkwYY6.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structAHdMDYZJaK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structAHdMDYZJaK.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structAK2drK1aH7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structAK2drK1aH7.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structAPZGaaiAsI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structAPZGaaiAsI.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structAQE2E9exgF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structAQE2E9exgF.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structAcoWvPhtlp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structAcoWvPhtlp.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structAiFfzJ9xOo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structAiFfzJ9xOo.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structAztsRhE0LF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structAztsRhE0LF.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structB9pN8GfUaU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structB9pN8GfUaU.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structBA8lKBvox6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structBA8lKBvox6.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structBBBafcZBl1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structBBBafcZBl1.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structBF8funmMCW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structBF8funmMCW.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structBNGrkk0Gq9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structBNGrkk0Gq9.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structBW4o7dJUoK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structBW4o7dJUoK.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structBWsRWzQ335.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structBWsRWzQ335.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structBfsVSixXGI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structBfsVSixXGI.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structBjERtQ98tj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structBjERtQ98tj.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structBjy5dZK2rM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structBjy5dZK2rM.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structBm7Ua0ACla.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structBm7Ua0ACla.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structBmz4OJxAlt.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structBmz4OJxAlt.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structBw3OKv2Qms.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structBw3OKv2Qms.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structBzSRBjnY22.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structBzSRBjnY22.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structC0g7V6d3fy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structC0g7V6d3fy.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structCBt0kIYRra.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structCBt0kIYRra.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structCOGSdZd0AL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structCOGSdZd0AL.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structCXeEkfG71q.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structCXeEkfG71q.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structCaHH2Xyhc7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structCaHH2Xyhc7.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structCcLnEruc0v.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structCcLnEruc0v.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structCfD3K5QvsN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structCfD3K5QvsN.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structCqQVJigrtI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structCqQVJigrtI.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structCzvlSZqJoZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structCzvlSZqJoZ.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structD2oQVW5tnq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structD2oQVW5tnq.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structD4YplBwWDi.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structD4YplBwWDi.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structD9gno8tRvF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structD9gno8tRvF.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structDACFSZmJCd.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structDACFSZmJCd.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structDVPBdDC863.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structDVPBdDC863.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structDXFa0e4ozX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structDXFa0e4ozX.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structDZZWeqhEZS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structDZZWeqhEZS.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structDhEKpPXtbG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structDhEKpPXtbG.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structDi88qmJim6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structDi88qmJim6.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structDrIOG3dy4E.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structDrIOG3dy4E.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structE1izflhe7m.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structE1izflhe7m.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structE7tbP2KegJ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structE7tbP2KegJ.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structECJjSKcI0x.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structECJjSKcI0x.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structECjdzNW2hb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structECjdzNW2hb.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structENNglh8DX6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structENNglh8DX6.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structEVUFJOsbyB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structEVUFJOsbyB.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structEa3Y8fmO5t.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structEa3Y8fmO5t.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structEbe6V1e8rk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structEbe6V1e8rk.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structEilgeng6RU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structEilgeng6RU.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structEjN7KM70nB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structEjN7KM70nB.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structEoc6yu6UZC.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structEoc6yu6UZC.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structEqZWhQIozu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structEqZWhQIozu.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structErRGvv06c5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structErRGvv06c5.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structEvFFf3fZGJ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structEvFFf3fZGJ.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structEx5206L0wV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structEx5206L0wV.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structF3dNExh2mR.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structF3dNExh2mR.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structF8DhNrWv7E.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structF8DhNrWv7E.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structF9RjQ90jnp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structF9RjQ90jnp.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structFI3w6VQMfO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structFI3w6VQMfO.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structFJsonz9Nyz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structFJsonz9Nyz.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structFR85FzqbWk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structFR85FzqbWk.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structFXxZeDtCw5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structFXxZeDtCw5.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structFaTXoezJTa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structFaTXoezJTa.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structFhwETmltur.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structFhwETmltur.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structFjGw1Sgvhj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structFjGw1Sgvhj.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structFq1hfAwgHs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structFq1hfAwgHs.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structFvR9kgHTwq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structFvR9kgHTwq.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structFx3ViT9W1l.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structFx3ViT9W1l.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structG23iNFg5pV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structG23iNFg5pV.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structG4WvAWeyY2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structG4WvAWeyY2.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structG5eiJlW14L.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structG5eiJlW14L.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structG7DG28rR3I.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structG7DG28rR3I.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structG8t7pJyR0P.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structG8t7pJyR0P.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structGAhk4JD5f5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structGAhk4JD5f5.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structGElc6so5Vx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structGElc6so5Vx.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structGL3ENulfXA.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structGL3ENulfXA.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structGPgos6Ga6k.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structGPgos6Ga6k.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structGVka0u9TDq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structGVka0u9TDq.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structGXNEUsfHGV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structGXNEUsfHGV.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structGajQGzODLb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structGajQGzODLb.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structGbvlSI6ZFM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structGbvlSI6ZFM.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structGgvsKvoP9v.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structGgvsKvoP9v.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structGiiPLasS8y.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structGiiPLasS8y.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structGlUP6EKlOZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structGlUP6EKlOZ.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structGmNuKgusEl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structGmNuKgusEl.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structGnndCPLSRE.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structGnndCPLSRE.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structGseI8AQPtb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structGseI8AQPtb.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structGyODqQmfLk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structGyODqQmfLk.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structH5eQeBi4oY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structH5eQeBi4oY.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structH6F7xwrgKM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structH6F7xwrgKM.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structHAW6jHGG5q.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structHAW6jHGG5q.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structHGMhtcP1Gs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structHGMhtcP1Gs.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structHNoL72ys27.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structHNoL72ys27.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structHOwIYbq2Gd.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structHOwIYbq2Gd.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structHQ1FzQOf8n.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structHQ1FzQOf8n.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structHQRXU94JgV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structHQRXU94JgV.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structHSN0q7oMVM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structHSN0q7oMVM.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structHYnhl5ltDv.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structHYnhl5ltDv.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structHcCEQbo9Zf.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structHcCEQbo9Zf.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structHfRiDfgqPK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structHfRiDfgqPK.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structHnGXhmegvA.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structHnGXhmegvA.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structHnNLvYqbMR.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structHnNLvYqbMR.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structHt9F9jtMD0.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structHt9F9jtMD0.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structHusaUbKJVm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structHusaUbKJVm.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structHvGrPaR9Bu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structHvGrPaR9Bu.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structHvI693MHyM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structHvI693MHyM.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structHyrFeqyBCY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structHyrFeqyBCY.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structHzJtxAljeg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structHzJtxAljeg.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structI2aSLtV0nK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structI2aSLtV0nK.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structI5QO2BUMxk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structI5QO2BUMxk.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structI6BZQjT6lx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structI6BZQjT6lx.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structICD2Fjdvwq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structICD2Fjdvwq.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structIHkMJI02Cs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structIHkMJI02Cs.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structIJpxdh5h1j.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structIJpxdh5h1j.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structIKVPnPqtVG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structIKVPnPqtVG.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structIODsh0cyAj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structIODsh0cyAj.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structIWnVfC7bMR.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structIWnVfC7bMR.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structIg48IJ1BGz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structIg48IJ1BGz.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structIjpYds4lWa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structIjpYds4lWa.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structImqfRF5u5d.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structImqfRF5u5d.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structIpNWKHAjIK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structIpNWKHAjIK.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structIq2IxAwTbz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structIq2IxAwTbz.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structIqjoEWN5a6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structIqjoEWN5a6.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structJ1WoVnmoNK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structJ1WoVnmoNK.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structJ4N4ApAuNd.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structJ4N4ApAuNd.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structJ4sxZ95hzs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structJ4sxZ95hzs.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structJ5ThymSmBk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structJ5ThymSmBk.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structJBdaFHCitX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structJBdaFHCitX.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structJBjYKH35Id.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structJBjYKH35Id.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structJEL7o5TRHh.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structJEL7o5TRHh.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structJFU1xlKVwi.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structJFU1xlKVwi.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structJIOp0LkuGx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structJIOp0LkuGx.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structJKSxRHdkgU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structJKSxRHdkgU.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structJLl1JS3EBA.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structJLl1JS3EBA.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structJPod17bl3h.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structJPod17bl3h.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structJSkoDJdEmy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structJSkoDJdEmy.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structJXZ8aT3Z1A.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structJXZ8aT3Z1A.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structJYFDwGezZu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structJYFDwGezZu.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structJZBOzjdChs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structJZBOzjdChs.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structJcJCwPR9O6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structJcJCwPR9O6.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structJdaXHv9XGK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structJdaXHv9XGK.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structJguJlpO2Zx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structJguJlpO2Zx.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structJjOrVxY09U.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structJjOrVxY09U.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structJmS6AEcW3Z.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structJmS6AEcW3Z.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structJmgvdzeb5n.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structJmgvdzeb5n.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structJt6jf8vpBs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structJt6jf8vpBs.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structJyoG3utfUF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structJyoG3utfUF.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structK17aJaWFKp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structK17aJaWFKp.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structK6zBHvtXEz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structK6zBHvtXEz.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structK8yLeG1Rq8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structK8yLeG1Rq8.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structKAGtyEb0Mc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structKAGtyEb0Mc.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structKBZsUWVDxs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structKBZsUWVDxs.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structKD97Jf4W3S.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structKD97Jf4W3S.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structKDBDsZNe9Z.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structKDBDsZNe9Z.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structKDWeAZ2IPn.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structKDWeAZ2IPn.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structKF4sn2PYXa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structKF4sn2PYXa.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structKHnzHYYQv9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structKHnzHYYQv9.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structKJhvJs3EGG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structKJhvJs3EGG.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structKLSPh0PXhl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structKLSPh0PXhl.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structKNZX9fxtdl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structKNZX9fxtdl.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structKS9Hbi6AwZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structKS9Hbi6AwZ.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structKVlfLjDmn1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structKVlfLjDmn1.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structKX2JHsJ0bd.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structKX2JHsJ0bd.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structKkESsYkID7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structKkESsYkID7.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structKkHcnJvU6l.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structKkHcnJvU6l.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structKkvn2ffBgz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structKkvn2ffBgz.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structKxmFSKOkr0.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structKxmFSKOkr0.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structL0iuHiXIxa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structL0iuHiXIxa.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structL28FwCaWlq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structL28FwCaWlq.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structL3YlcXIU3G.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structL3YlcXIU3G.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structL5PAA2Y49o.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structL5PAA2Y49o.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structL8rTw5Q3JI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structL8rTw5Q3JI.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structLJsbrcp1QV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structLJsbrcp1QV.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structLKxIRREq4D.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structLKxIRREq4D.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structLMQlSHV6GT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structLMQlSHV6GT.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structLV2nB9GvAz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structLV2nB9GvAz.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structLa1OJDLBp5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structLa1OJDLBp5.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structLcNNHqG92U.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structLcNNHqG92U.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structLnY2DL1Mbw.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structLnY2DL1Mbw.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structLpxoYUnOy7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structLpxoYUnOy7.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structLs7CLvlkgi.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structLs7CLvlkgi.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structLtMZ0XaStC.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structLtMZ0XaStC.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structLy4yvDjUuQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structLy4yvDjUuQ.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structM9DKZGOLDg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structM9DKZGOLDg.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structMBndhRFxei.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structMBndhRFxei.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structMEcvkINwlN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structMEcvkINwlN.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structMFY7puSlGX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structMFY7puSlGX.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structMQnq3Fo18k.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structMQnq3Fo18k.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structMRN9c8EZAu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structMRN9c8EZAu.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structMSaXkM98gx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structMSaXkM98gx.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structMe4GO0lmyL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structMe4GO0lmyL.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structMf7H2FRsCR.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structMf7H2FRsCR.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structMgFMQz9tN4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structMgFMQz9tN4.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structMhWZ76XLqK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structMhWZ76XLqK.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structMiv3889DlT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structMiv3889DlT.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structMkNnqyG9Tl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structMkNnqyG9Tl.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structMw7h6zUCoS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structMw7h6zUCoS.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structN5CGh6EWiK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structN5CGh6EWiK.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structN86zzxZWL3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structN86zzxZWL3.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structN9VLieAgkB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structN9VLieAgkB.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structNB005jf6q4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structNB005jf6q4.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structNW2O8zaFJU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structNW2O8zaFJU.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structNXVElSFyJY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structNXVElSFyJY.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structNXkTPXgNCQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structNXkTPXgNCQ.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structNYxtIN1k6X.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structNYxtIN1k6X.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structNcunqydrcp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structNcunqydrcp.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structNfG8poVmRX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structNfG8poVmRX.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structNpSaGkUh99.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structNpSaGkUh99.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structNphpYJarez.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structNphpYJarez.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structNq8WSpQa6r.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structNq8WSpQa6r.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structNuHNDIZUYr.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structNuHNDIZUYr.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structO4Kr2Vp6iB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structO4Kr2Vp6iB.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structO5SpO4Lmqy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structO5SpO4Lmqy.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structO6aBEtLHCl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structO6aBEtLHCl.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structO8aC92gkJu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structO8aC92gkJu.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structOAXjhVxHVW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structOAXjhVxHVW.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structOBggRrGGeA.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structOBggRrGGeA.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structOCKiZ8XvN4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structOCKiZ8XvN4.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structOTagHf6dta.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structOTagHf6dta.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structOmPR4GDmha.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structOmPR4GDmha.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structOnU7Y1iyOW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structOnU7Y1iyOW.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structOruSh6IU68.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structOruSh6IU68.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structP07kLcgWy2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structP07kLcgWy2.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structP0hi03Yr5J.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structP0hi03Yr5J.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structP51IT0iQls.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structP51IT0iQls.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structPC53CFAahl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structPC53CFAahl.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structPDETEBub2B.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structPDETEBub2B.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structPIEO17rXv3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structPIEO17rXv3.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structPL1Vy8gAQG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structPL1Vy8gAQG.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structPOAJbOn5yN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structPOAJbOn5yN.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structPWOGZtzGIy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structPWOGZtzGIy.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structPWOtvXxst0.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structPWOtvXxst0.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structPaMBWeOEZb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structPaMBWeOEZb.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structPbViqUkC9s.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structPbViqUkC9s.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structPjXLhVCSo2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structPjXLhVCSo2.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structPmsSWhVFlx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structPmsSWhVFlx.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structPvttwCSove.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structPvttwCSove.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structPy7auxT2wm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structPy7auxT2wm.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structPzKBHCX9aj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structPzKBHCX9aj.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structQ1lt85NZkv.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structQ1lt85NZkv.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structQ9W3v3dQYW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structQ9W3v3dQYW.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structQBpF2mc1un.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structQBpF2mc1un.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structQLoTxIicfl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structQLoTxIicfl.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structQNBjmFEISk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structQNBjmFEISk.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structQRNlszU7N1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structQRNlszU7N1.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structQRrZvgSvEl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structQRrZvgSvEl.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structQu8eKSWeIJ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structQu8eKSWeIJ.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structQwjx7jDCDX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structQwjx7jDCDX.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structQwri7Ax9TK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structQwri7Ax9TK.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structR4xaEYdpRY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structR4xaEYdpRY.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structR6bsgVIYE6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structR6bsgVIYE6.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structR6j965l6JZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structR6j965l6JZ.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structR6yPnOD0oz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structR6yPnOD0oz.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structR8eEQpI0YT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structR8eEQpI0YT.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structRBr9HNIGgm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structRBr9HNIGgm.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structRBwjivoMMP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structRBwjivoMMP.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structRFFK9pIT93.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structRFFK9pIT93.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structRJYj3K0a3c.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structRJYj3K0a3c.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structRLhaWW9haz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structRLhaWW9haz.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structRSckKIVPNO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structRSckKIVPNO.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structRX7hJYzEEc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structRX7hJYzEEc.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structRbEgtyrBAH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structRbEgtyrBAH.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structRbgB04HmL4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structRbgB04HmL4.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structRdgEVFWPU8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structRdgEVFWPU8.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structRjYd0rym9S.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structRjYd0rym9S.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structRpd0ErOBb6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structRpd0ErOBb6.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structRtcf0YV8fO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structRtcf0YV8fO.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structRtjThoUz7H.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structRtjThoUz7H.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structRyTk5RxJJO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structRyTk5RxJJO.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structS1RhuauboU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structS1RhuauboU.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structS6bmXaMMyl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structS6bmXaMMyl.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structSDPIMkAwH8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structSDPIMkAwH8.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structSEmAsgVkk9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structSEmAsgVkk9.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structSIfHQocAM7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structSIfHQocAM7.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structSL3XN9PByF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structSL3XN9PByF.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structSOJZorG6h4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structSOJZorG6h4.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structSOQ2b3Trj9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structSOQ2b3Trj9.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structSOcWqfVVcP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structSOcWqfVVcP.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structSUuI5kWBPQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structSUuI5kWBPQ.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structSWz0ZdY1fL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structSWz0ZdY1fL.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structSXB5wflpQj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structSXB5wflpQj.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structSaCKmxwW7X.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structSaCKmxwW7X.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structSkgZGVkxzj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structSkgZGVkxzj.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structSuSfIvUv2A.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structSuSfIvUv2A.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structSuaJbDOn73.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structSuaJbDOn73.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structSv55DLNwHy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structSv55DLNwHy.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structSvXjwmwWp8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structSvXjwmwWp8.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structT024qoIGBu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structT024qoIGBu.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structT396ygje53.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structT396ygje53.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structTA8Sp22K2U.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structTA8Sp22K2U.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structTGF07uM1y9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structTGF07uM1y9.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structTKbYYBx9QZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structTKbYYBx9QZ.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structTLyC86eODa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structTLyC86eODa.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structTSEu5hclTq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structTSEu5hclTq.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structTX5YCrOcOo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structTX5YCrOcOo.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structTX6rXf2RZh.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structTX6rXf2RZh.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structTaJbzfeDjo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structTaJbzfeDjo.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structTaYGLKdSM8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structTaYGLKdSM8.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structTgcZPmWOx2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structTgcZPmWOx2.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structTh5NbnUqzI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structTh5NbnUqzI.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structTknpxoQFvS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structTknpxoQFvS.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structTqu8KoZQjY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structTqu8KoZQjY.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structTuAcbBNnZm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structTuAcbBNnZm.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structTuWH3zeluv.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structTuWH3zeluv.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structTwjPuMKDiB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structTwjPuMKDiB.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structTxF88EuH4Q.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structTxF88EuH4Q.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structTzQ4rWvlZ3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structTzQ4rWvlZ3.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structU2kogkOlcf.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structU2kogkOlcf.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structU3dy6bkQcN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structU3dy6bkQcN.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structUA5Zgdsa4W.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structUA5Zgdsa4W.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structUC7urls6rG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structUC7urls6rG.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structUJ5RVg0xHN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structUJ5RVg0xHN.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structUL0XgKUiea.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structUL0XgKUiea.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structUYdnQvYvKk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structUYdnQvYvKk.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structUaTPRyIwWQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structUaTPRyIwWQ.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structUgp6Bg804O.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structUgp6Bg804O.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structUgsqUT0Fw8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structUgsqUT0Fw8.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structUomjJGDhS3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structUomjJGDhS3.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structUrJ7tMPYdi.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structUrJ7tMPYdi.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structUsGUm5feCJ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structUsGUm5feCJ.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structUx6sDnae6o.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structUx6sDnae6o.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structUyBELJkxhd.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structUyBELJkxhd.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structV1mFMqHDyz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structV1mFMqHDyz.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structV3DEOjYkAI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structV3DEOjYkAI.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structV4EcMh64Nu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structV4EcMh64Nu.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structVABFQlbdB8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structVABFQlbdB8.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structVCKWE5qXDQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structVCKWE5qXDQ.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structVF3eV6RT5A.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structVF3eV6RT5A.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structVGVFt2H4Jq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structVGVFt2H4Jq.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structVHmibu21U1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structVHmibu21U1.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structVJQMEbTTcW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structVJQMEbTTcW.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structVW9Wugrq8f.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structVW9Wugrq8f.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structVbui9U8nJN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structVbui9U8nJN.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structVqmZxmYjrS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structVqmZxmYjrS.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structVwumd12dMR.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structVwumd12dMR.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structW03TuqLzYH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structW03TuqLzYH.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structW6NGdR4FHA.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structW6NGdR4FHA.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structW8RwEte1K1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structW8RwEte1K1.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structWFr5O7xRwi.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structWFr5O7xRwi.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structWJw9ZLP7fK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structWJw9ZLP7fK.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structWODpD4eAmE.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structWODpD4eAmE.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structWOGNQBbIW7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structWOGNQBbIW7.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structWQN1KyUD5b.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structWQN1KyUD5b.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structWTDgYPieK1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structWTDgYPieK1.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structWVtboPH1aE.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structWVtboPH1aE.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structWiPM4vCvbR.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structWiPM4vCvbR.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structWk1zWo8r9K.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structWk1zWo8r9K.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structWkYOcVuG9r.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structWkYOcVuG9r.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structWqKLr6PuT3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structWqKLr6PuT3.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structWyFaNRxWDU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structWyFaNRxWDU.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structX0tLJiI6QS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structX0tLJiI6QS.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structX74WdLPgP3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structX74WdLPgP3.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structXLePVWtJFS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structXLePVWtJFS.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structXNJAbmwEpz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structXNJAbmwEpz.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structXOlFj8WTWU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structXOlFj8WTWU.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structXQpY9eJk4m.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structXQpY9eJk4m.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structXU2GzBHEnm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structXU2GzBHEnm.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structXWIUjIMjuc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structXWIUjIMjuc.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structXYOl2gpZhZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structXYOl2gpZhZ.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structXYrXq7Kz5O.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structXYrXq7Kz5O.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structXab1L6RKkc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structXab1L6RKkc.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structXcQSZS9Pq3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structXcQSZS9Pq3.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structXdOq3rooU7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structXdOq3rooU7.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structXpfvMzo3SU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structXpfvMzo3SU.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structXs0m0HB3Ve.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structXs0m0HB3Ve.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structXsoVym5xGF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structXsoVym5xGF.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structXxbrxyvfJK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structXxbrxyvfJK.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structY0sbuM1lf1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structY0sbuM1lf1.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structY2WI2qZBJc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structY2WI2qZBJc.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structY3MSP8GJLq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structY3MSP8GJLq.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structY7ZzgHzGVw.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structY7ZzgHzGVw.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structY8HkjRfwpg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structY8HkjRfwpg.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structYAzsftuDhx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structYAzsftuDhx.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structYE37gD7DoN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structYE37gD7DoN.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structYNODMJt0nI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structYNODMJt0nI.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structYOoQMQYEZo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structYOoQMQYEZo.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structYPtr2Dr86B.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structYPtr2Dr86B.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structYXRqKm5H9U.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structYXRqKm5H9U.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structYa2X1A0XlS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structYa2X1A0XlS.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structYj7TbLsdP4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structYj7TbLsdP4.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structYlF6RxCqVs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structYlF6RxCqVs.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structYo1jTzfuKl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structYo1jTzfuKl.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structYrew2qdBuH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structYrew2qdBuH.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structYwZwDfIvIG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structYwZwDfIvIG.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structZ3DY5gvzFY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structZ3DY5gvzFY.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structZBrvC38b8N.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structZBrvC38b8N.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structZC6ZaapQdD.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structZC6ZaapQdD.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structZGNK9Twr9S.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structZGNK9Twr9S.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structZGqp2bRDtx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structZGqp2bRDtx.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structZJSKolxfqc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structZJSKolxfqc.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structZR3LiJX7PO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structZR3LiJX7PO.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structZW26HGLchP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structZW26HGLchP.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structZi1RqmdSol.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structZi1RqmdSol.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structZoimFj6xEE.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structZoimFj6xEE.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structZpfDnRPksn.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structZpfDnRPksn.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structZr2k5TeLcE.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structZr2k5TeLcE.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structZtqbbnQjzj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structZtqbbnQjzj.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structZupKEHABUk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structZupKEHABUk.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structa0AhWFAoDG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structa0AhWFAoDG.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structa5eW784LQf.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structa5eW784LQf.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structa6BXYQAwEm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structa6BXYQAwEm.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structa6bL6toTDQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structa6bL6toTDQ.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structa85eS8wvGC.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structa85eS8wvGC.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structaBCMiwiL14.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structaBCMiwiL14.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structaCvUpfrOud.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structaCvUpfrOud.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structaMVAJ9INz0.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structaMVAJ9INz0.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structaNX02HPg7T.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structaNX02HPg7T.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structaacjP2BYDY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structaacjP2BYDY.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structafSLEQGtjb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structafSLEQGtjb.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structawZmlvXiXW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structawZmlvXiXW.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structaxV4fiWwZ7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structaxV4fiWwZ7.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structayNEhBBg4t.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structayNEhBBg4t.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structb265yb0csM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structb265yb0csM.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structb63fAzKNR7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structb63fAzKNR7.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structbBsug1Wd34.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structbBsug1Wd34.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structbNMyvNH8WM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structbNMyvNH8WM.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structbX4S27LXkH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structbX4S27LXkH.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structblpexlSs9M.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structblpexlSs9M.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structbmmnw9qu32.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structbmmnw9qu32.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structbsrrxTZOqn.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structbsrrxTZOqn.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structbtgnPXO5Rq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structbtgnPXO5Rq.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structbwtswCbHZn.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structbwtswCbHZn.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structc0ARtdYgED.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structc0ARtdYgED.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structc0K76QtGvt.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structc0K76QtGvt.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structc19BIAaEkY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structc19BIAaEkY.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structcIUFEZhrle.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structcIUFEZhrle.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structcU51DXcyE8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structcU51DXcyE8.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structcbnz0kvIwn.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structcbnz0kvIwn.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structcfbnUeCgbt.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structcfbnUeCgbt.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structcjMmD9Dwfx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structcjMmD9Dwfx.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structclmVkpAhb8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structclmVkpAhb8.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structcoAqE1boX6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structcoAqE1boX6.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structcormXUf4WS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structcormXUf4WS.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structcqdGRq2WNh.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structcqdGRq2WNh.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structczOiELiAB7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structczOiELiAB7.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structd2ojXxCaNW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structd2ojXxCaNW.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structd4OcbMDcGL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structd4OcbMDcGL.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structd9nB4x1U6u.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structd9nB4x1U6u.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structdEhJcrsORt.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structdEhJcrsORt.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structdKBNYvwyxK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structdKBNYvwyxK.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structdNGVHIlzAj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structdNGVHIlzAj.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structdSftno00MK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structdSftno00MK.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structdXZpHpuk3x.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structdXZpHpuk3x.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structdXgIF94ebo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structdXgIF94ebo.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structdhEH1P8yDX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structdhEH1P8yDX.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structdq0ytTGdT7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structdq0ytTGdT7.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structdr28D0z5ZH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structdr28D0z5ZH.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structe4z2kYEwsw.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structe4z2kYEwsw.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structe79Za4b7Ml.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structe79Za4b7Ml.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structeJF56nvsEj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structeJF56nvsEj.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structeW6hiVZjD9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structeW6hiVZjD9.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structegI0J6pwbq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structegI0J6pwbq.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structemjd05RWc3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structemjd05RWc3.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structeqBjnWgb5P.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structeqBjnWgb5P.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structf0akg4gumK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structf0akg4gumK.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structf32Rx1NpEm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structf32Rx1NpEm.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structf3hg4Duqet.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structf3hg4Duqet.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structf74ThK893J.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structf74ThK893J.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structfBkGsQBirP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structfBkGsQBirP.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structfCVtyydYxM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structfCVtyydYxM.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structfCayR9pma6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structfCayR9pma6.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structfG4ASdjUC9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structfG4ASdjUC9.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structfJdkVlyVac.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structfJdkVlyVac.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structfNnOzIDYzL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structfNnOzIDYzL.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structfOOjVzFOC9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structfOOjVzFOC9.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structfTXY9OU4mh.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structfTXY9OU4mh.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structfWEUc1K6FG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structfWEUc1K6FG.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structfYJ2Mkk1al.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structfYJ2Mkk1al.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structfcg2UqwprF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structfcg2UqwprF.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structfd0mCQVHBl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structfd0mCQVHBl.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structfwecOIJDmQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structfwecOIJDmQ.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structgBuG9DjtOU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structgBuG9DjtOU.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structgIAdPMClq9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structgIAdPMClq9.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structgJaEzQzHlG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structgJaEzQzHlG.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structgTI819u8oK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structgTI819u8oK.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structgaVRwvBYOY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structgaVRwvBYOY.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structgmDuxmO8uQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structgmDuxmO8uQ.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structgnTh8YZCI4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structgnTh8YZCI4.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structgnzwfueLCU.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structgnzwfueLCU.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structgodJTvsSrL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structgodJTvsSrL.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structgoyNOloADC.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structgoyNOloADC.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structgrMFKxp6Rp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structgrMFKxp6Rp.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structgu5AmoUnKH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structgu5AmoUnKH.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structgw0RpMV2f4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structgw0RpMV2f4.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structgzPFVO95T5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structgzPFVO95T5.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structh0wIvbjPFM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structh0wIvbjPFM.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structh0zYLuKys0.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structh0zYLuKys0.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structh4borQn8tt.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structh4borQn8tt.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structhEYyOpWNQA.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structhEYyOpWNQA.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structhKVOXTzhtj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structhKVOXTzhtj.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structhP7CI8CVIx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structhP7CI8CVIx.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structhRp6BjrXlq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structhRp6BjrXlq.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structhXluAaYGUP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structhXluAaYGUP.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structhc5U7IjcZc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structhc5U7IjcZc.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structhjYDoXKd1y.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structhjYDoXKd1y.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structhk5xXOFY3B.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structhk5xXOFY3B.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structhlXXNdntjL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structhlXXNdntjL.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structhnljKmvH1S.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structhnljKmvH1S.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structhsMP7WDnTb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structhsMP7WDnTb.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structi5tx16f99j.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structi5tx16f99j.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structi60i9flgEl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structi60i9flgEl.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structiGcBGhWkFg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structiGcBGhWkFg.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structiH2t1AudUv.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structiH2t1AudUv.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structiJO3yTUlA6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structiJO3yTUlA6.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structiMxQrDbyMm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structiMxQrDbyMm.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structiRTC8Ri5hh.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structiRTC8Ri5hh.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structiUTYiuw7nL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structiUTYiuw7nL.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structifVuZi4Efe.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structifVuZi4Efe.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structigySx6ywF4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structigySx6ywF4.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structimk6k6ZOQP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structimk6k6ZOQP.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structiyfYt6St4H.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structiyfYt6St4H.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structj0Jp6zlUkb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structj0Jp6zlUkb.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structj2noj6YBli.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structj2noj6YBli.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structj80X6OAWFM.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structj80X6OAWFM.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structjATzvt82Yc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structjATzvt82Yc.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structjHYdKd1qGS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structjHYdKd1qGS.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structjIn9JVMI49.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structjIn9JVMI49.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structjKvkQzPnI2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structjKvkQzPnI2.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structjPeWDdzelT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structjPeWDdzelT.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structjVynlgrJOg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structjVynlgrJOg.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structjXzq5dAQfq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structjXzq5dAQfq.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structjlEQy1XgIm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structjlEQy1XgIm.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structjpZYztDGZv.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structjpZYztDGZv.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structjyzBmrWLpD.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structjyzBmrWLpD.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structjzLZ1Fd1su.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structjzLZ1Fd1su.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structk0RWOtD4Cb.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structk0RWOtD4Cb.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structk5uhI551Ib.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structk5uhI551Ib.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structkBpo9DUgjg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structkBpo9DUgjg.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structkKCqpBwgSB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structkKCqpBwgSB.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structkMn4TDNnDw.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structkMn4TDNnDw.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structkTDa7zOTTq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structkTDa7zOTTq.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structkcnuBfgvqB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structkcnuBfgvqB.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structke5R4wNmaV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structke5R4wNmaV.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structkgOVznysHS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structkgOVznysHS.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structkjR2PqZPCx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structkjR2PqZPCx.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structkjvkPYElx2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structkjvkPYElx2.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structko3HKcubO4.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structko3HKcubO4.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structl1rwee6A0W.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structl1rwee6A0W.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structl9GK15NFfI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structl9GK15NFfI.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structl9dEcAYjZX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structl9dEcAYjZX.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structlCbFTLeEcO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structlCbFTLeEcO.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structlFoUTH7TGY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structlFoUTH7TGY.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structlFuagxP4pj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structlFuagxP4pj.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structlKqlZNIiTG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structlKqlZNIiTG.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structlM9nCK9mVa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structlM9nCK9mVa.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structlNxcettVbW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structlNxcettVbW.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structlOMWejTcie.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structlOMWejTcie.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structlPPzP90v2M.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structlPPzP90v2M.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structlWE7ijbTPg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structlWE7ijbTPg.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structlWZpr8mFUz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structlWZpr8mFUz.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structlfb6Bcmyzv.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structlfb6Bcmyzv.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structliZR39PG4B.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structliZR39PG4B.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structlilo17vqrO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structlilo17vqrO.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structlmBHuI2CdK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structlmBHuI2CdK.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structlsRnaxudRi.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structlsRnaxudRi.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structlwBBVufID9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structlwBBVufID9.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structmE7fFfuHjx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structmE7fFfuHjx.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structmPX6OOh4Nl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structmPX6OOh4Nl.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structmR2t9GgAZ5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structmR2t9GgAZ5.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structmU9k8N2S1x.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structmU9k8N2S1x.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structmUQioQKiXp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structmUQioQKiXp.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structmWBF30udKT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structmWBF30udKT.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structmaUySacG7e.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structmaUySacG7e.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structmj4Oyb3GgX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structmj4Oyb3GgX.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structmuAhuD4KVQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structmuAhuD4KVQ.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structmwjaO3Uyrs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structmwjaO3Uyrs.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structn5h1DHBxub.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structn5h1DHBxub.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structnAdqmBnbeg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structnAdqmBnbeg.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structnAvYhH07Gs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structnAvYhH07Gs.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structnHnX8P1WDq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structnHnX8P1WDq.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structnNkjJDcz0P.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structnNkjJDcz0P.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structnPwZk9I7YN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structnPwZk9I7YN.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structnUJfW4NMaA.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structnUJfW4NMaA.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structnXMZUp9V4V.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structnXMZUp9V4V.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structnjkuDZnOoQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structnjkuDZnOoQ.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structnq8k7vNWX3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structnq8k7vNWX3.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structnrVsGpyHSB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structnrVsGpyHSB.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structnsGvdkMRFZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structnsGvdkMRFZ.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structoAhXI74h9j.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structoAhXI74h9j.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structoahbTSUqku.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structoahbTSUqku.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structoiRn4GygF9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structoiRn4GygF9.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structov6aJQLXqu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structov6aJQLXqu.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structovm1h7N1tD.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structovm1h7N1tD.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structoypCXXMXYK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structoypCXXMXYK.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structp39x1W6Nmw.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structp39x1W6Nmw.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structp5F0SqEi1N.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structp5F0SqEi1N.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structpK1zdl2ooH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structpK1zdl2ooH.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structpLXABe2wJc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structpLXABe2wJc.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structpMr2v6juAQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structpMr2v6juAQ.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structpXZA41Y8fK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structpXZA41Y8fK.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structpkIouuiKqe.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structpkIouuiKqe.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structpnMhTmK3QH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structpnMhTmK3QH.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structpuA2r64pbW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structpuA2r64pbW.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structpwCAT0hshK.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structpwCAT0hshK.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structq1BEWkecYX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structq1BEWkecYX.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structq2gqs38KnH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structq2gqs38KnH.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structq5OjZ10BEs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structq5OjZ10BEs.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structqGa10MSSRs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structqGa10MSSRs.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structqGuE1lEn2E.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structqGuE1lEn2E.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structqK7XKTZI6a.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structqK7XKTZI6a.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structqRtOraogqy.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structqRtOraogqy.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structqTdD25cQMq.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structqTdD25cQMq.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structqVenFBZMmB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structqVenFBZMmB.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structqVymoyiTzO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structqVymoyiTzO.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structqYoMOdyW5o.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structqYoMOdyW5o.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structqZqGFZMAp0.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structqZqGFZMAp0.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structqceTFkotG1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structqceTFkotG1.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structqklsh0VtCj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structqklsh0VtCj.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structqkwGFodzYo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structqkwGFodzYo.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structqlynSYPIzj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structqlynSYPIzj.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structqmylEQUQxN.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structqmylEQUQxN.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structqsdnJQvtod.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structqsdnJQvtod.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structr1IUWdH7kS.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structr1IUWdH7kS.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structrDLhl5fFyI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structrDLhl5fFyI.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structrJ6A29EFD3.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structrJ6A29EFD3.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structrLI0qkdwNT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structrLI0qkdwNT.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structrNNNMoMUX5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structrNNNMoMUX5.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structrQyjIvxeGC.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structrQyjIvxeGC.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structrUZIsQzLzo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structrUZIsQzLzo.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structrUrNNgGYxl.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structrUrNNgGYxl.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structrZORE7saci.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structrZORE7saci.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structrnEvXbtOaJ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structrnEvXbtOaJ.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structrv6cJ7e4eI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structrv6cJ7e4eI.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structrvnG4DB0O9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structrvnG4DB0O9.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structrxuRIzLrOd.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structrxuRIzLrOd.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structs0wKthNJDH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structs0wKthNJDH.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structs6tlj8Ujb6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structs6tlj8Ujb6.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structs81xiTr3V2.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structs81xiTr3V2.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structs9FC686ssT.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structs9FC686ssT.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structsU7ru1S3Bn.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structsU7ru1S3Bn.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structsconExg82n.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structsconExg82n.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structsnl6YWFzw6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structsnl6YWFzw6.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structsr11hihvVP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structsr11hihvVP.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structsrFnuySLJZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structsrFnuySLJZ.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structsyMjE23XYL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structsyMjE23XYL.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structt1zhtoy3QG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structt1zhtoy3QG.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structt3vc10gLez.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structt3vc10gLez.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structt7Y6XwomUH.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structt7Y6XwomUH.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structtFfTsyMFtj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structtFfTsyMFtj.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structtKTQH67TAx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structtKTQH67TAx.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structtRnRKY1Nt9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structtRnRKY1Nt9.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structtVv0gLLUw6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structtVv0gLLUw6.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structtdu9UH9BR6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structtdu9UH9BR6.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structtkLijaINDB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structtkLijaINDB.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structtmi3Y4xjWJ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structtmi3Y4xjWJ.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structtoRHBeshpF.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structtoRHBeshpF.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structtoojZOxzYL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structtoojZOxzYL.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structuEWock0xfg.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structuEWock0xfg.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structuYFS57GpEz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structuYFS57GpEz.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structuZLTFqoTc9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structuZLTFqoTc9.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structuesCCsCmB9.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structuesCCsCmB9.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structuk9n40Ba1s.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structuk9n40Ba1s.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structurOByRIJr5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structurOByRIJr5.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structusM7i9eFda.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structusM7i9eFda.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structuzTdZWiu60.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structuzTdZWiu60.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structv4jF52UQ9H.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structv4jF52UQ9H.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structv9bmg59CEV.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structv9bmg59CEV.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structvE6YTruKB5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structvE6YTruKB5.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structvGYXxaXkfO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structvGYXxaXkfO.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structvIiPiag0AP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structvIiPiag0AP.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structvJXxV1TNGG.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structvJXxV1TNGG.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structvLrhLw24Yo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structvLrhLw24Yo.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structvPLGLtUGvc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structvPLGLtUGvc.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structvQ4tBtsFIQ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structvQ4tBtsFIQ.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structvetTPo8phL.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structvetTPo8phL.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structvh6HUMxCO1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structvh6HUMxCO1.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structvhPOJekCB6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structvhPOJekCB6.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structvqpjGCBNgC.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structvqpjGCBNgC.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structw1Jcuo2qcB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structw1Jcuo2qcB.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structw1LUTeHkEP.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structw1LUTeHkEP.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structw704rOrUeD.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structw704rOrUeD.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structwAVE8pzuIw.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structwAVE8pzuIw.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structwE9USHmMoa.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structwE9USHmMoa.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structwKyV6c3NXx.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structwKyV6c3NXx.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structwNNWk20409.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structwNNWk20409.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structwPjsuxb7PR.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structwPjsuxb7PR.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structwquRams9Fs.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structwquRams9Fs.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structwyz9cVcdwh.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structwyz9cVcdwh.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structx29mgYMw04.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structx29mgYMw04.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structx9kDs7ICzW.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structx9kDs7ICzW.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structxFTWeVz86X.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structxFTWeVz86X.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structxI8aw5DOBf.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structxI8aw5DOBf.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structxKJxcMqgXp.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structxKJxcMqgXp.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structxSyTOLVs2a.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structxSyTOLVs2a.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structxY83QlHYu8.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structxY83QlHYu8.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structxatoIPHwut.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structxatoIPHwut.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structxayiSk9poY.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structxayiSk9poY.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structxl0tHilNDj.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structxl0tHilNDj.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structxpKM8hQmHX.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structxpKM8hQmHX.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structxrKKgR1Fe1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structxrKKgR1Fe1.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structxsR9aAsAXm.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structxsR9aAsAXm.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structxwNsI8Zdb1.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structxwNsI8Zdb1.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structy2eHpFGRr5.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structy2eHpFGRr5.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structy5X9cuxDIn.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structy5X9cuxDIn.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structy5wbr5f4bB.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structy5wbr5f4bB.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structyAGnaq1EBc.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structyAGnaq1EBc.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structyGjRe5am7c.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structyGjRe5am7c.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structyKsJfDGXaz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structyKsJfDGXaz.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structyNBvxKIcti.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structyNBvxKIcti.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structyPEdNMH6Lo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structyPEdNMH6Lo.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structyTmtkFKqd7.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structyTmtkFKqd7.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structydbIqe0qPo.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structydbIqe0qPo.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structyhDvAbXvCv.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structyhDvAbXvCv.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structynitZhhUeJ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structynitZhhUeJ.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structyvVgkdYRXO.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structyvVgkdYRXO.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structz1JgTXpAuI.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structz1JgTXpAuI.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structz7dfzzL9Yk.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structz7dfzzL9Yk.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structzIXefsJFSz.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structzIXefsJFSz.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structzPWDt4oN6i.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structzPWDt4oN6i.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structzQUyc7Ws0e.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structzQUyc7Ws0e.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structzTIpN6ALMu.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structzTIpN6ALMu.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structzYoD4xKxnZ.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structzYoD4xKxnZ.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structzdXNEcof9V.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structzdXNEcof9V.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structzo3owhla9x.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structzo3owhla9x.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structzyowJj76a6.verified.txt
+++ b/tests/SnapshotTests/ConversionPermutations/snapshots/snap-v7.0/readonly-partial-structzyowJj76a6.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_structConversions_DapperTypeHandler@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_structConversions_DapperTypeHandler@record.@struct.@float.@decimal.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_structConversions_DapperTypeHandlerSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_structConversions_DapperTypeHandlerSystem.Guid.verified.txt
@@ -173,7 +173,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_structConversions_DapperTypeHandlerbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_structConversions_DapperTypeHandlerbyte.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_structConversions_DapperTypeHandlerdouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_structConversions_DapperTypeHandlerdouble.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_structConversions_DapperTypeHandlerstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_structConversions_DapperTypeHandlerstring.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_structConversions_EfCoreValueConverter@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_structConversions_EfCoreValueConverter@record.@struct.@float.@decimal.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_structConversions_EfCoreValueConverterSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_structConversions_EfCoreValueConverterSystem.Guid.verified.txt
@@ -173,7 +173,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_structConversions_EfCoreValueConverterbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_structConversions_EfCoreValueConverterbyte.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_structConversions_EfCoreValueConverterdouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_structConversions_EfCoreValueConverterdouble.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_structConversions_EfCoreValueConverterstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_structConversions_EfCoreValueConverterstring.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_structConversions_LinqToDbValueConverter@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_structConversions_LinqToDbValueConverter@record.@struct.@float.@decimal.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_structConversions_LinqToDbValueConverterSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_structConversions_LinqToDbValueConverterSystem.Guid.verified.txt
@@ -173,7 +173,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_structConversions_LinqToDbValueConverterbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_structConversions_LinqToDbValueConverterbyte.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_structConversions_LinqToDbValueConverterdouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_structConversions_LinqToDbValueConverterdouble.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_structConversions_LinqToDbValueConverterstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_structConversions_LinqToDbValueConverterstring.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJson@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJson@record.@struct.@float.@decimal.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.Guid.verified.txt
@@ -175,7 +175,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbyte.verified.txt
@@ -217,7 +217,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondouble.verified.txt
@@ -217,7 +217,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonstring.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_structConversions_NewtonsoftJson@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_structConversions_NewtonsoftJson@record.@struct.@float.@decimal.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_structConversions_NewtonsoftJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_structConversions_NewtonsoftJsonSystem.Guid.verified.txt
@@ -174,7 +174,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_structConversions_NewtonsoftJsonbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_structConversions_NewtonsoftJsonbyte.verified.txt
@@ -216,7 +216,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_structConversions_NewtonsoftJsondouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_structConversions_NewtonsoftJsondouble.verified.txt
@@ -216,7 +216,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_structConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_structConversions_NewtonsoftJsonstring.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_structConversions_None@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_structConversions_None@record.@struct.@float.@decimal.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_structConversions_NoneSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_structConversions_NoneSystem.Guid.verified.txt
@@ -173,7 +173,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_structConversions_Nonebyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_structConversions_Nonebyte.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_structConversions_Nonedouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_structConversions_Nonedouble.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_structConversions_Nonestring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_structConversions_Nonestring.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_structConversions_SystemTextJson@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_structConversions_SystemTextJson@record.@struct.@float.@decimal.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_structConversions_SystemTextJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_structConversions_SystemTextJsonSystem.Guid.verified.txt
@@ -174,7 +174,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_structConversions_SystemTextJsonbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_structConversions_SystemTextJsonbyte.verified.txt
@@ -216,7 +216,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_structConversions_SystemTextJsondouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_structConversions_SystemTextJsondouble.verified.txt
@@ -216,7 +216,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_structConversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_structConversions_SystemTextJsonstring.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_structConversions_TypeConverter@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_structConversions_TypeConverter@record.@struct.@float.@decimal.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_structConversions_TypeConverterSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_structConversions_TypeConverterSystem.Guid.verified.txt
@@ -174,7 +174,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_structConversions_TypeConverterbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_structConversions_TypeConverterbyte.verified.txt
@@ -216,7 +216,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_structConversions_TypeConverterdouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_structConversions_TypeConverterdouble.verified.txt
@@ -216,7 +216,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_structConversions_TypeConverterstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_partial_structConversions_TypeConverterstring.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_structConversions_DapperTypeHandler@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_structConversions_DapperTypeHandler@record.@struct.@float.@decimal.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_structConversions_DapperTypeHandlerSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_structConversions_DapperTypeHandlerSystem.Guid.verified.txt
@@ -173,7 +173,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_structConversions_DapperTypeHandlerbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_structConversions_DapperTypeHandlerbyte.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_structConversions_DapperTypeHandlerdouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_structConversions_DapperTypeHandlerdouble.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_structConversions_DapperTypeHandlerstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_structConversions_DapperTypeHandlerstring.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_structConversions_EfCoreValueConverter@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_structConversions_EfCoreValueConverter@record.@struct.@float.@decimal.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_structConversions_EfCoreValueConverterSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_structConversions_EfCoreValueConverterSystem.Guid.verified.txt
@@ -173,7 +173,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_structConversions_EfCoreValueConverterbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_structConversions_EfCoreValueConverterbyte.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_structConversions_EfCoreValueConverterdouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_structConversions_EfCoreValueConverterdouble.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_structConversions_EfCoreValueConverterstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_structConversions_EfCoreValueConverterstring.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_structConversions_LinqToDbValueConverter@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_structConversions_LinqToDbValueConverter@record.@struct.@float.@decimal.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_structConversions_LinqToDbValueConverterSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_structConversions_LinqToDbValueConverterSystem.Guid.verified.txt
@@ -173,7 +173,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_structConversions_LinqToDbValueConverterbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_structConversions_LinqToDbValueConverterbyte.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_structConversions_LinqToDbValueConverterdouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_structConversions_LinqToDbValueConverterdouble.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_structConversions_LinqToDbValueConverterstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_structConversions_LinqToDbValueConverterstring.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJson@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJson@record.@struct.@float.@decimal.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.Guid.verified.txt
@@ -175,7 +175,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbyte.verified.txt
@@ -217,7 +217,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondouble.verified.txt
@@ -217,7 +217,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonstring.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson@record.@struct.@float.@decimal.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonSystem.Guid.verified.txt
@@ -174,7 +174,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonbyte.verified.txt
@@ -216,7 +216,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsondouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsondouble.verified.txt
@@ -216,7 +216,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonstring.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_structConversions_None@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_structConversions_None@record.@struct.@float.@decimal.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_structConversions_NoneSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_structConversions_NoneSystem.Guid.verified.txt
@@ -173,7 +173,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_structConversions_Nonebyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_structConversions_Nonebyte.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_structConversions_Nonedouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_structConversions_Nonedouble.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_structConversions_Nonestring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_structConversions_Nonestring.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_structConversions_SystemTextJson@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_structConversions_SystemTextJson@record.@struct.@float.@decimal.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_structConversions_SystemTextJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_structConversions_SystemTextJsonSystem.Guid.verified.txt
@@ -174,7 +174,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_structConversions_SystemTextJsonbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_structConversions_SystemTextJsonbyte.verified.txt
@@ -216,7 +216,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_structConversions_SystemTextJsondouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_structConversions_SystemTextJsondouble.verified.txt
@@ -216,7 +216,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_structConversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_structConversions_SystemTextJsonstring.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_structConversions_TypeConverter@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_structConversions_TypeConverter@record.@struct.@float.@decimal.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_structConversions_TypeConverterSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_structConversions_TypeConverterSystem.Guid.verified.txt
@@ -174,7 +174,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_structConversions_TypeConverterbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_structConversions_TypeConverterbyte.verified.txt
@@ -216,7 +216,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_structConversions_TypeConverterdouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_structConversions_TypeConverterdouble.verified.txt
@@ -216,7 +216,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_structConversions_TypeConverterstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestsinternal_readonly_partial_structConversions_TypeConverterstring.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_structConversions_DapperTypeHandler@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_structConversions_DapperTypeHandler@record.@struct.@float.@decimal.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_structConversions_DapperTypeHandlerSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_structConversions_DapperTypeHandlerSystem.Guid.verified.txt
@@ -173,7 +173,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_structConversions_DapperTypeHandlerbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_structConversions_DapperTypeHandlerbyte.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_structConversions_DapperTypeHandlerdouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_structConversions_DapperTypeHandlerdouble.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_structConversions_DapperTypeHandlerstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_structConversions_DapperTypeHandlerstring.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_structConversions_EfCoreValueConverter@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_structConversions_EfCoreValueConverter@record.@struct.@float.@decimal.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_structConversions_EfCoreValueConverterSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_structConversions_EfCoreValueConverterSystem.Guid.verified.txt
@@ -173,7 +173,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_structConversions_EfCoreValueConverterbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_structConversions_EfCoreValueConverterbyte.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_structConversions_EfCoreValueConverterdouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_structConversions_EfCoreValueConverterdouble.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_structConversions_EfCoreValueConverterstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_structConversions_EfCoreValueConverterstring.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_structConversions_LinqToDbValueConverter@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_structConversions_LinqToDbValueConverter@record.@struct.@float.@decimal.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_structConversions_LinqToDbValueConverterSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_structConversions_LinqToDbValueConverterSystem.Guid.verified.txt
@@ -173,7 +173,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_structConversions_LinqToDbValueConverterbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_structConversions_LinqToDbValueConverterbyte.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_structConversions_LinqToDbValueConverterdouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_structConversions_LinqToDbValueConverterdouble.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_structConversions_LinqToDbValueConverterstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_structConversions_LinqToDbValueConverterstring.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJson@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJson@record.@struct.@float.@decimal.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.Guid.verified.txt
@@ -175,7 +175,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbyte.verified.txt
@@ -217,7 +217,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondouble.verified.txt
@@ -217,7 +217,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonstring.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_structConversions_NewtonsoftJson@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_structConversions_NewtonsoftJson@record.@struct.@float.@decimal.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_structConversions_NewtonsoftJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_structConversions_NewtonsoftJsonSystem.Guid.verified.txt
@@ -174,7 +174,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_structConversions_NewtonsoftJsonbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_structConversions_NewtonsoftJsonbyte.verified.txt
@@ -216,7 +216,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_structConversions_NewtonsoftJsondouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_structConversions_NewtonsoftJsondouble.verified.txt
@@ -216,7 +216,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_structConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_structConversions_NewtonsoftJsonstring.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_structConversions_None@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_structConversions_None@record.@struct.@float.@decimal.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_structConversions_NoneSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_structConversions_NoneSystem.Guid.verified.txt
@@ -173,7 +173,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_structConversions_Nonebyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_structConversions_Nonebyte.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_structConversions_Nonedouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_structConversions_Nonedouble.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_structConversions_Nonestring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_structConversions_Nonestring.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_structConversions_SystemTextJson@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_structConversions_SystemTextJson@record.@struct.@float.@decimal.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_structConversions_SystemTextJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_structConversions_SystemTextJsonSystem.Guid.verified.txt
@@ -174,7 +174,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_structConversions_SystemTextJsonbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_structConversions_SystemTextJsonbyte.verified.txt
@@ -216,7 +216,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_structConversions_SystemTextJsondouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_structConversions_SystemTextJsondouble.verified.txt
@@ -216,7 +216,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_structConversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_structConversions_SystemTextJsonstring.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_structConversions_TypeConverter@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_structConversions_TypeConverter@record.@struct.@float.@decimal.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_structConversions_TypeConverterSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_structConversions_TypeConverterSystem.Guid.verified.txt
@@ -174,7 +174,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_structConversions_TypeConverterbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_structConversions_TypeConverterbyte.verified.txt
@@ -216,7 +216,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_structConversions_TypeConverterdouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_structConversions_TypeConverterdouble.verified.txt
@@ -216,7 +216,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_structConversions_TypeConverterstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_partial_structConversions_TypeConverterstring.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_structConversions_DapperTypeHandler@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_structConversions_DapperTypeHandler@record.@struct.@float.@decimal.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_structConversions_DapperTypeHandlerSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_structConversions_DapperTypeHandlerSystem.Guid.verified.txt
@@ -173,7 +173,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_structConversions_DapperTypeHandlerbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_structConversions_DapperTypeHandlerbyte.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_structConversions_DapperTypeHandlerdouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_structConversions_DapperTypeHandlerdouble.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_structConversions_DapperTypeHandlerstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_structConversions_DapperTypeHandlerstring.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_structConversions_EfCoreValueConverter@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_structConversions_EfCoreValueConverter@record.@struct.@float.@decimal.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_structConversions_EfCoreValueConverterSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_structConversions_EfCoreValueConverterSystem.Guid.verified.txt
@@ -173,7 +173,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_structConversions_EfCoreValueConverterbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_structConversions_EfCoreValueConverterbyte.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_structConversions_EfCoreValueConverterdouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_structConversions_EfCoreValueConverterdouble.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_structConversions_EfCoreValueConverterstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_structConversions_EfCoreValueConverterstring.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_structConversions_LinqToDbValueConverter@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_structConversions_LinqToDbValueConverter@record.@struct.@float.@decimal.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_structConversions_LinqToDbValueConverterSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_structConversions_LinqToDbValueConverterSystem.Guid.verified.txt
@@ -173,7 +173,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_structConversions_LinqToDbValueConverterbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_structConversions_LinqToDbValueConverterbyte.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_structConversions_LinqToDbValueConverterdouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_structConversions_LinqToDbValueConverterdouble.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_structConversions_LinqToDbValueConverterstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_structConversions_LinqToDbValueConverterstring.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJson@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJson@record.@struct.@float.@decimal.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.Guid.verified.txt
@@ -175,7 +175,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbyte.verified.txt
@@ -217,7 +217,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondouble.verified.txt
@@ -217,7 +217,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonstring.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson@record.@struct.@float.@decimal.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonSystem.Guid.verified.txt
@@ -174,7 +174,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonbyte.verified.txt
@@ -216,7 +216,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsondouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsondouble.verified.txt
@@ -216,7 +216,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonstring.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_structConversions_None@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_structConversions_None@record.@struct.@float.@decimal.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_structConversions_NoneSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_structConversions_NoneSystem.Guid.verified.txt
@@ -173,7 +173,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_structConversions_Nonebyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_structConversions_Nonebyte.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_structConversions_Nonedouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_structConversions_Nonedouble.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_structConversions_Nonestring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_structConversions_Nonestring.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_structConversions_SystemTextJson@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_structConversions_SystemTextJson@record.@struct.@float.@decimal.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_structConversions_SystemTextJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_structConversions_SystemTextJsonSystem.Guid.verified.txt
@@ -174,7 +174,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_structConversions_SystemTextJsonbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_structConversions_SystemTextJsonbyte.verified.txt
@@ -216,7 +216,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_structConversions_SystemTextJsondouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_structConversions_SystemTextJsondouble.verified.txt
@@ -216,7 +216,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_structConversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_structConversions_SystemTextJsonstring.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_structConversions_TypeConverter@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_structConversions_TypeConverter@record.@struct.@float.@decimal.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_structConversions_TypeConverterSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_structConversions_TypeConverterSystem.Guid.verified.txt
@@ -174,7 +174,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_structConversions_TypeConverterbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_structConversions_TypeConverterbyte.verified.txt
@@ -216,7 +216,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_structConversions_TypeConverterdouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_structConversions_TypeConverterdouble.verified.txt
@@ -216,7 +216,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_structConversions_TypeConverterstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v3.1/escapedTestspublic_readonly_partial_structConversions_TypeConverterstring.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_structConversions_DapperTypeHandler@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_structConversions_DapperTypeHandler@record.@struct.@float.@decimal.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_structConversions_DapperTypeHandlerSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_structConversions_DapperTypeHandlerSystem.Guid.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_structConversions_DapperTypeHandlerbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_structConversions_DapperTypeHandlerbyte.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_structConversions_DapperTypeHandlerdouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_structConversions_DapperTypeHandlerdouble.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_structConversions_DapperTypeHandlerstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_structConversions_DapperTypeHandlerstring.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_structConversions_EfCoreValueConverter@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_structConversions_EfCoreValueConverter@record.@struct.@float.@decimal.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_structConversions_EfCoreValueConverterSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_structConversions_EfCoreValueConverterSystem.Guid.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_structConversions_EfCoreValueConverterbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_structConversions_EfCoreValueConverterbyte.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_structConversions_EfCoreValueConverterdouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_structConversions_EfCoreValueConverterdouble.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_structConversions_EfCoreValueConverterstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_structConversions_EfCoreValueConverterstring.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_structConversions_LinqToDbValueConverter@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_structConversions_LinqToDbValueConverter@record.@struct.@float.@decimal.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_structConversions_LinqToDbValueConverterSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_structConversions_LinqToDbValueConverterSystem.Guid.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_structConversions_LinqToDbValueConverterbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_structConversions_LinqToDbValueConverterbyte.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_structConversions_LinqToDbValueConverterdouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_structConversions_LinqToDbValueConverterdouble.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_structConversions_LinqToDbValueConverterstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_structConversions_LinqToDbValueConverterstring.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJson@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJson@record.@struct.@float.@decimal.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.Guid.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbyte.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondouble.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonstring.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_structConversions_NewtonsoftJson@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_structConversions_NewtonsoftJson@record.@struct.@float.@decimal.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_structConversions_NewtonsoftJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_structConversions_NewtonsoftJsonSystem.Guid.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_structConversions_NewtonsoftJsonbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_structConversions_NewtonsoftJsonbyte.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_structConversions_NewtonsoftJsondouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_structConversions_NewtonsoftJsondouble.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_structConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_structConversions_NewtonsoftJsonstring.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_structConversions_None@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_structConversions_None@record.@struct.@float.@decimal.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_structConversions_NoneSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_structConversions_NoneSystem.Guid.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_structConversions_Nonebyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_structConversions_Nonebyte.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_structConversions_Nonedouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_structConversions_Nonedouble.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_structConversions_Nonestring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_structConversions_Nonestring.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_structConversions_SystemTextJson@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_structConversions_SystemTextJson@record.@struct.@float.@decimal.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_structConversions_SystemTextJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_structConversions_SystemTextJsonSystem.Guid.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_structConversions_SystemTextJsonbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_structConversions_SystemTextJsonbyte.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_structConversions_SystemTextJsondouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_structConversions_SystemTextJsondouble.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_structConversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_structConversions_SystemTextJsonstring.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_structConversions_TypeConverter@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_structConversions_TypeConverter@record.@struct.@float.@decimal.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_structConversions_TypeConverterSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_structConversions_TypeConverterSystem.Guid.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_structConversions_TypeConverterbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_structConversions_TypeConverterbyte.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_structConversions_TypeConverterdouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_structConversions_TypeConverterdouble.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_structConversions_TypeConverterstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_partial_structConversions_TypeConverterstring.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_structConversions_DapperTypeHandler@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_structConversions_DapperTypeHandler@record.@struct.@float.@decimal.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_structConversions_DapperTypeHandlerSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_structConversions_DapperTypeHandlerSystem.Guid.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_structConversions_DapperTypeHandlerbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_structConversions_DapperTypeHandlerbyte.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_structConversions_DapperTypeHandlerdouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_structConversions_DapperTypeHandlerdouble.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_structConversions_DapperTypeHandlerstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_structConversions_DapperTypeHandlerstring.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_structConversions_EfCoreValueConverter@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_structConversions_EfCoreValueConverter@record.@struct.@float.@decimal.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_structConversions_EfCoreValueConverterSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_structConversions_EfCoreValueConverterSystem.Guid.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_structConversions_EfCoreValueConverterbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_structConversions_EfCoreValueConverterbyte.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_structConversions_EfCoreValueConverterdouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_structConversions_EfCoreValueConverterdouble.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_structConversions_EfCoreValueConverterstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_structConversions_EfCoreValueConverterstring.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_structConversions_LinqToDbValueConverter@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_structConversions_LinqToDbValueConverter@record.@struct.@float.@decimal.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_structConversions_LinqToDbValueConverterSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_structConversions_LinqToDbValueConverterSystem.Guid.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_structConversions_LinqToDbValueConverterbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_structConversions_LinqToDbValueConverterbyte.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_structConversions_LinqToDbValueConverterdouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_structConversions_LinqToDbValueConverterdouble.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_structConversions_LinqToDbValueConverterstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_structConversions_LinqToDbValueConverterstring.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJson@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJson@record.@struct.@float.@decimal.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.Guid.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbyte.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondouble.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonstring.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson@record.@struct.@float.@decimal.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonSystem.Guid.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonbyte.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsondouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsondouble.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonstring.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_structConversions_None@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_structConversions_None@record.@struct.@float.@decimal.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_structConversions_NoneSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_structConversions_NoneSystem.Guid.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_structConversions_Nonebyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_structConversions_Nonebyte.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_structConversions_Nonedouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_structConversions_Nonedouble.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_structConversions_Nonestring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_structConversions_Nonestring.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_structConversions_SystemTextJson@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_structConversions_SystemTextJson@record.@struct.@float.@decimal.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_structConversions_SystemTextJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_structConversions_SystemTextJsonSystem.Guid.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_structConversions_SystemTextJsonbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_structConversions_SystemTextJsonbyte.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_structConversions_SystemTextJsondouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_structConversions_SystemTextJsondouble.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_structConversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_structConversions_SystemTextJsonstring.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_structConversions_TypeConverter@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_structConversions_TypeConverter@record.@struct.@float.@decimal.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_structConversions_TypeConverterSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_structConversions_TypeConverterSystem.Guid.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_structConversions_TypeConverterbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_structConversions_TypeConverterbyte.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_structConversions_TypeConverterdouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_structConversions_TypeConverterdouble.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_structConversions_TypeConverterstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestsinternal_readonly_partial_structConversions_TypeConverterstring.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_structConversions_DapperTypeHandler@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_structConversions_DapperTypeHandler@record.@struct.@float.@decimal.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_structConversions_DapperTypeHandlerSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_structConversions_DapperTypeHandlerSystem.Guid.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_structConversions_DapperTypeHandlerbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_structConversions_DapperTypeHandlerbyte.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_structConversions_DapperTypeHandlerdouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_structConversions_DapperTypeHandlerdouble.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_structConversions_DapperTypeHandlerstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_structConversions_DapperTypeHandlerstring.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_structConversions_EfCoreValueConverter@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_structConversions_EfCoreValueConverter@record.@struct.@float.@decimal.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_structConversions_EfCoreValueConverterSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_structConversions_EfCoreValueConverterSystem.Guid.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_structConversions_EfCoreValueConverterbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_structConversions_EfCoreValueConverterbyte.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_structConversions_EfCoreValueConverterdouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_structConversions_EfCoreValueConverterdouble.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_structConversions_EfCoreValueConverterstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_structConversions_EfCoreValueConverterstring.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_structConversions_LinqToDbValueConverter@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_structConversions_LinqToDbValueConverter@record.@struct.@float.@decimal.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_structConversions_LinqToDbValueConverterSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_structConversions_LinqToDbValueConverterSystem.Guid.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_structConversions_LinqToDbValueConverterbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_structConversions_LinqToDbValueConverterbyte.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_structConversions_LinqToDbValueConverterdouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_structConversions_LinqToDbValueConverterdouble.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_structConversions_LinqToDbValueConverterstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_structConversions_LinqToDbValueConverterstring.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJson@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJson@record.@struct.@float.@decimal.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.Guid.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbyte.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondouble.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonstring.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_structConversions_NewtonsoftJson@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_structConversions_NewtonsoftJson@record.@struct.@float.@decimal.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_structConversions_NewtonsoftJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_structConversions_NewtonsoftJsonSystem.Guid.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_structConversions_NewtonsoftJsonbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_structConversions_NewtonsoftJsonbyte.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_structConversions_NewtonsoftJsondouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_structConversions_NewtonsoftJsondouble.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_structConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_structConversions_NewtonsoftJsonstring.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_structConversions_None@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_structConversions_None@record.@struct.@float.@decimal.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_structConversions_NoneSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_structConversions_NoneSystem.Guid.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_structConversions_Nonebyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_structConversions_Nonebyte.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_structConversions_Nonedouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_structConversions_Nonedouble.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_structConversions_Nonestring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_structConversions_Nonestring.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_structConversions_SystemTextJson@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_structConversions_SystemTextJson@record.@struct.@float.@decimal.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_structConversions_SystemTextJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_structConversions_SystemTextJsonSystem.Guid.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_structConversions_SystemTextJsonbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_structConversions_SystemTextJsonbyte.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_structConversions_SystemTextJsondouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_structConversions_SystemTextJsondouble.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_structConversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_structConversions_SystemTextJsonstring.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_structConversions_TypeConverter@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_structConversions_TypeConverter@record.@struct.@float.@decimal.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_structConversions_TypeConverterSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_structConversions_TypeConverterSystem.Guid.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_structConversions_TypeConverterbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_structConversions_TypeConverterbyte.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_structConversions_TypeConverterdouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_structConversions_TypeConverterdouble.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_structConversions_TypeConverterstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_partial_structConversions_TypeConverterstring.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_structConversions_DapperTypeHandler@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_structConversions_DapperTypeHandler@record.@struct.@float.@decimal.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_structConversions_DapperTypeHandlerSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_structConversions_DapperTypeHandlerSystem.Guid.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_structConversions_DapperTypeHandlerbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_structConversions_DapperTypeHandlerbyte.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_structConversions_DapperTypeHandlerdouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_structConversions_DapperTypeHandlerdouble.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_structConversions_DapperTypeHandlerstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_structConversions_DapperTypeHandlerstring.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_structConversions_EfCoreValueConverter@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_structConversions_EfCoreValueConverter@record.@struct.@float.@decimal.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_structConversions_EfCoreValueConverterSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_structConversions_EfCoreValueConverterSystem.Guid.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_structConversions_EfCoreValueConverterbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_structConversions_EfCoreValueConverterbyte.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_structConversions_EfCoreValueConverterdouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_structConversions_EfCoreValueConverterdouble.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_structConversions_EfCoreValueConverterstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_structConversions_EfCoreValueConverterstring.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_structConversions_LinqToDbValueConverter@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_structConversions_LinqToDbValueConverter@record.@struct.@float.@decimal.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_structConversions_LinqToDbValueConverterSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_structConversions_LinqToDbValueConverterSystem.Guid.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_structConversions_LinqToDbValueConverterbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_structConversions_LinqToDbValueConverterbyte.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_structConversions_LinqToDbValueConverterdouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_structConversions_LinqToDbValueConverterdouble.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_structConversions_LinqToDbValueConverterstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_structConversions_LinqToDbValueConverterstring.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJson@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJson@record.@struct.@float.@decimal.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.Guid.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbyte.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondouble.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonstring.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson@record.@struct.@float.@decimal.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonSystem.Guid.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonbyte.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsondouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsondouble.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonstring.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_structConversions_None@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_structConversions_None@record.@struct.@float.@decimal.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_structConversions_NoneSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_structConversions_NoneSystem.Guid.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_structConversions_Nonebyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_structConversions_Nonebyte.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_structConversions_Nonedouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_structConversions_Nonedouble.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_structConversions_Nonestring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_structConversions_Nonestring.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_structConversions_SystemTextJson@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_structConversions_SystemTextJson@record.@struct.@float.@decimal.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_structConversions_SystemTextJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_structConversions_SystemTextJsonSystem.Guid.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_structConversions_SystemTextJsonbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_structConversions_SystemTextJsonbyte.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_structConversions_SystemTextJsondouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_structConversions_SystemTextJsondouble.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_structConversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_structConversions_SystemTextJsonstring.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_structConversions_TypeConverter@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_structConversions_TypeConverter@record.@struct.@float.@decimal.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_structConversions_TypeConverterSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_structConversions_TypeConverterSystem.Guid.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_structConversions_TypeConverterbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_structConversions_TypeConverterbyte.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_structConversions_TypeConverterdouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_structConversions_TypeConverterdouble.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_structConversions_TypeConverterstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.6.1/escapedTestspublic_readonly_partial_structConversions_TypeConverterstring.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_structConversions_DapperTypeHandler@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_structConversions_DapperTypeHandler@record.@struct.@float.@decimal.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_structConversions_DapperTypeHandlerSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_structConversions_DapperTypeHandlerSystem.Guid.verified.txt
@@ -152,7 +152,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_structConversions_DapperTypeHandlerbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_structConversions_DapperTypeHandlerbyte.verified.txt
@@ -173,7 +173,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_structConversions_DapperTypeHandlerdouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_structConversions_DapperTypeHandlerdouble.verified.txt
@@ -173,7 +173,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_structConversions_DapperTypeHandlerstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_structConversions_DapperTypeHandlerstring.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_structConversions_EfCoreValueConverter@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_structConversions_EfCoreValueConverter@record.@struct.@float.@decimal.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_structConversions_EfCoreValueConverterSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_structConversions_EfCoreValueConverterSystem.Guid.verified.txt
@@ -152,7 +152,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_structConversions_EfCoreValueConverterbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_structConversions_EfCoreValueConverterbyte.verified.txt
@@ -173,7 +173,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_structConversions_EfCoreValueConverterdouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_structConversions_EfCoreValueConverterdouble.verified.txt
@@ -173,7 +173,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_structConversions_EfCoreValueConverterstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_structConversions_EfCoreValueConverterstring.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_structConversions_LinqToDbValueConverter@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_structConversions_LinqToDbValueConverter@record.@struct.@float.@decimal.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_structConversions_LinqToDbValueConverterSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_structConversions_LinqToDbValueConverterSystem.Guid.verified.txt
@@ -152,7 +152,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_structConversions_LinqToDbValueConverterbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_structConversions_LinqToDbValueConverterbyte.verified.txt
@@ -173,7 +173,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_structConversions_LinqToDbValueConverterdouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_structConversions_LinqToDbValueConverterdouble.verified.txt
@@ -173,7 +173,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_structConversions_LinqToDbValueConverterstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_structConversions_LinqToDbValueConverterstring.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJson@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJson@record.@struct.@float.@decimal.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.Guid.verified.txt
@@ -154,7 +154,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbyte.verified.txt
@@ -175,7 +175,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondouble.verified.txt
@@ -175,7 +175,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonstring.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_structConversions_NewtonsoftJson@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_structConversions_NewtonsoftJson@record.@struct.@float.@decimal.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_structConversions_NewtonsoftJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_structConversions_NewtonsoftJsonSystem.Guid.verified.txt
@@ -153,7 +153,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_structConversions_NewtonsoftJsonbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_structConversions_NewtonsoftJsonbyte.verified.txt
@@ -174,7 +174,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_structConversions_NewtonsoftJsondouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_structConversions_NewtonsoftJsondouble.verified.txt
@@ -174,7 +174,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_structConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_structConversions_NewtonsoftJsonstring.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_structConversions_None@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_structConversions_None@record.@struct.@float.@decimal.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_structConversions_NoneSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_structConversions_NoneSystem.Guid.verified.txt
@@ -152,7 +152,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_structConversions_Nonebyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_structConversions_Nonebyte.verified.txt
@@ -173,7 +173,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_structConversions_Nonedouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_structConversions_Nonedouble.verified.txt
@@ -173,7 +173,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_structConversions_Nonestring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_structConversions_Nonestring.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_structConversions_SystemTextJson@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_structConversions_SystemTextJson@record.@struct.@float.@decimal.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_structConversions_SystemTextJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_structConversions_SystemTextJsonSystem.Guid.verified.txt
@@ -153,7 +153,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_structConversions_SystemTextJsonbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_structConversions_SystemTextJsonbyte.verified.txt
@@ -174,7 +174,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_structConversions_SystemTextJsondouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_structConversions_SystemTextJsondouble.verified.txt
@@ -174,7 +174,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_structConversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_structConversions_SystemTextJsonstring.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_structConversions_TypeConverter@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_structConversions_TypeConverter@record.@struct.@float.@decimal.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_structConversions_TypeConverterSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_structConversions_TypeConverterSystem.Guid.verified.txt
@@ -153,7 +153,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_structConversions_TypeConverterbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_structConversions_TypeConverterbyte.verified.txt
@@ -174,7 +174,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_structConversions_TypeConverterdouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_structConversions_TypeConverterdouble.verified.txt
@@ -174,7 +174,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_structConversions_TypeConverterstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_partial_structConversions_TypeConverterstring.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_structConversions_DapperTypeHandler@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_structConversions_DapperTypeHandler@record.@struct.@float.@decimal.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_structConversions_DapperTypeHandlerSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_structConversions_DapperTypeHandlerSystem.Guid.verified.txt
@@ -152,7 +152,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_structConversions_DapperTypeHandlerbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_structConversions_DapperTypeHandlerbyte.verified.txt
@@ -173,7 +173,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_structConversions_DapperTypeHandlerdouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_structConversions_DapperTypeHandlerdouble.verified.txt
@@ -173,7 +173,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_structConversions_DapperTypeHandlerstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_structConversions_DapperTypeHandlerstring.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_structConversions_EfCoreValueConverter@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_structConversions_EfCoreValueConverter@record.@struct.@float.@decimal.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_structConversions_EfCoreValueConverterSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_structConversions_EfCoreValueConverterSystem.Guid.verified.txt
@@ -152,7 +152,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_structConversions_EfCoreValueConverterbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_structConversions_EfCoreValueConverterbyte.verified.txt
@@ -173,7 +173,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_structConversions_EfCoreValueConverterdouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_structConversions_EfCoreValueConverterdouble.verified.txt
@@ -173,7 +173,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_structConversions_EfCoreValueConverterstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_structConversions_EfCoreValueConverterstring.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_structConversions_LinqToDbValueConverter@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_structConversions_LinqToDbValueConverter@record.@struct.@float.@decimal.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_structConversions_LinqToDbValueConverterSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_structConversions_LinqToDbValueConverterSystem.Guid.verified.txt
@@ -152,7 +152,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_structConversions_LinqToDbValueConverterbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_structConversions_LinqToDbValueConverterbyte.verified.txt
@@ -173,7 +173,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_structConversions_LinqToDbValueConverterdouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_structConversions_LinqToDbValueConverterdouble.verified.txt
@@ -173,7 +173,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_structConversions_LinqToDbValueConverterstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_structConversions_LinqToDbValueConverterstring.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJson@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJson@record.@struct.@float.@decimal.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.Guid.verified.txt
@@ -154,7 +154,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbyte.verified.txt
@@ -175,7 +175,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondouble.verified.txt
@@ -175,7 +175,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonstring.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson@record.@struct.@float.@decimal.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonSystem.Guid.verified.txt
@@ -153,7 +153,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonbyte.verified.txt
@@ -174,7 +174,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsondouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsondouble.verified.txt
@@ -174,7 +174,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonstring.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_structConversions_None@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_structConversions_None@record.@struct.@float.@decimal.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_structConversions_NoneSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_structConversions_NoneSystem.Guid.verified.txt
@@ -152,7 +152,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_structConversions_Nonebyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_structConversions_Nonebyte.verified.txt
@@ -173,7 +173,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_structConversions_Nonedouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_structConversions_Nonedouble.verified.txt
@@ -173,7 +173,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_structConversions_Nonestring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_structConversions_Nonestring.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_structConversions_SystemTextJson@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_structConversions_SystemTextJson@record.@struct.@float.@decimal.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_structConversions_SystemTextJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_structConversions_SystemTextJsonSystem.Guid.verified.txt
@@ -153,7 +153,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_structConversions_SystemTextJsonbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_structConversions_SystemTextJsonbyte.verified.txt
@@ -174,7 +174,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_structConversions_SystemTextJsondouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_structConversions_SystemTextJsondouble.verified.txt
@@ -174,7 +174,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_structConversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_structConversions_SystemTextJsonstring.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_structConversions_TypeConverter@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_structConversions_TypeConverter@record.@struct.@float.@decimal.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_structConversions_TypeConverterSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_structConversions_TypeConverterSystem.Guid.verified.txt
@@ -153,7 +153,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_structConversions_TypeConverterbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_structConversions_TypeConverterbyte.verified.txt
@@ -174,7 +174,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_structConversions_TypeConverterdouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_structConversions_TypeConverterdouble.verified.txt
@@ -174,7 +174,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_structConversions_TypeConverterstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestsinternal_readonly_partial_structConversions_TypeConverterstring.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_structConversions_DapperTypeHandler@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_structConversions_DapperTypeHandler@record.@struct.@float.@decimal.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_structConversions_DapperTypeHandlerSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_structConversions_DapperTypeHandlerSystem.Guid.verified.txt
@@ -152,7 +152,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_structConversions_DapperTypeHandlerbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_structConversions_DapperTypeHandlerbyte.verified.txt
@@ -173,7 +173,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_structConversions_DapperTypeHandlerdouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_structConversions_DapperTypeHandlerdouble.verified.txt
@@ -173,7 +173,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_structConversions_DapperTypeHandlerstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_structConversions_DapperTypeHandlerstring.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_structConversions_EfCoreValueConverter@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_structConversions_EfCoreValueConverter@record.@struct.@float.@decimal.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_structConversions_EfCoreValueConverterSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_structConversions_EfCoreValueConverterSystem.Guid.verified.txt
@@ -152,7 +152,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_structConversions_EfCoreValueConverterbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_structConversions_EfCoreValueConverterbyte.verified.txt
@@ -173,7 +173,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_structConversions_EfCoreValueConverterdouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_structConversions_EfCoreValueConverterdouble.verified.txt
@@ -173,7 +173,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_structConversions_EfCoreValueConverterstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_structConversions_EfCoreValueConverterstring.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_structConversions_LinqToDbValueConverter@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_structConversions_LinqToDbValueConverter@record.@struct.@float.@decimal.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_structConversions_LinqToDbValueConverterSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_structConversions_LinqToDbValueConverterSystem.Guid.verified.txt
@@ -152,7 +152,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_structConversions_LinqToDbValueConverterbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_structConversions_LinqToDbValueConverterbyte.verified.txt
@@ -173,7 +173,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_structConversions_LinqToDbValueConverterdouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_structConversions_LinqToDbValueConverterdouble.verified.txt
@@ -173,7 +173,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_structConversions_LinqToDbValueConverterstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_structConversions_LinqToDbValueConverterstring.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJson@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJson@record.@struct.@float.@decimal.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.Guid.verified.txt
@@ -154,7 +154,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbyte.verified.txt
@@ -175,7 +175,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondouble.verified.txt
@@ -175,7 +175,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonstring.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_structConversions_NewtonsoftJson@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_structConversions_NewtonsoftJson@record.@struct.@float.@decimal.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_structConversions_NewtonsoftJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_structConversions_NewtonsoftJsonSystem.Guid.verified.txt
@@ -153,7 +153,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_structConversions_NewtonsoftJsonbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_structConversions_NewtonsoftJsonbyte.verified.txt
@@ -174,7 +174,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_structConversions_NewtonsoftJsondouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_structConversions_NewtonsoftJsondouble.verified.txt
@@ -174,7 +174,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_structConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_structConversions_NewtonsoftJsonstring.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_structConversions_None@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_structConversions_None@record.@struct.@float.@decimal.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_structConversions_NoneSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_structConversions_NoneSystem.Guid.verified.txt
@@ -152,7 +152,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_structConversions_Nonebyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_structConversions_Nonebyte.verified.txt
@@ -173,7 +173,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_structConversions_Nonedouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_structConversions_Nonedouble.verified.txt
@@ -173,7 +173,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_structConversions_Nonestring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_structConversions_Nonestring.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_structConversions_SystemTextJson@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_structConversions_SystemTextJson@record.@struct.@float.@decimal.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_structConversions_SystemTextJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_structConversions_SystemTextJsonSystem.Guid.verified.txt
@@ -153,7 +153,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_structConversions_SystemTextJsonbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_structConversions_SystemTextJsonbyte.verified.txt
@@ -174,7 +174,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_structConversions_SystemTextJsondouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_structConversions_SystemTextJsondouble.verified.txt
@@ -174,7 +174,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_structConversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_structConversions_SystemTextJsonstring.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_structConversions_TypeConverter@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_structConversions_TypeConverter@record.@struct.@float.@decimal.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_structConversions_TypeConverterSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_structConversions_TypeConverterSystem.Guid.verified.txt
@@ -153,7 +153,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_structConversions_TypeConverterbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_structConversions_TypeConverterbyte.verified.txt
@@ -174,7 +174,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_structConversions_TypeConverterdouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_structConversions_TypeConverterdouble.verified.txt
@@ -174,7 +174,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_structConversions_TypeConverterstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_partial_structConversions_TypeConverterstring.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_structConversions_DapperTypeHandler@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_structConversions_DapperTypeHandler@record.@struct.@float.@decimal.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_structConversions_DapperTypeHandlerSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_structConversions_DapperTypeHandlerSystem.Guid.verified.txt
@@ -152,7 +152,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_structConversions_DapperTypeHandlerbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_structConversions_DapperTypeHandlerbyte.verified.txt
@@ -173,7 +173,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_structConversions_DapperTypeHandlerdouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_structConversions_DapperTypeHandlerdouble.verified.txt
@@ -173,7 +173,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_structConversions_DapperTypeHandlerstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_structConversions_DapperTypeHandlerstring.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_structConversions_EfCoreValueConverter@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_structConversions_EfCoreValueConverter@record.@struct.@float.@decimal.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_structConversions_EfCoreValueConverterSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_structConversions_EfCoreValueConverterSystem.Guid.verified.txt
@@ -152,7 +152,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_structConversions_EfCoreValueConverterbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_structConversions_EfCoreValueConverterbyte.verified.txt
@@ -173,7 +173,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_structConversions_EfCoreValueConverterdouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_structConversions_EfCoreValueConverterdouble.verified.txt
@@ -173,7 +173,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_structConversions_EfCoreValueConverterstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_structConversions_EfCoreValueConverterstring.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_structConversions_LinqToDbValueConverter@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_structConversions_LinqToDbValueConverter@record.@struct.@float.@decimal.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_structConversions_LinqToDbValueConverterSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_structConversions_LinqToDbValueConverterSystem.Guid.verified.txt
@@ -152,7 +152,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_structConversions_LinqToDbValueConverterbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_structConversions_LinqToDbValueConverterbyte.verified.txt
@@ -173,7 +173,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_structConversions_LinqToDbValueConverterdouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_structConversions_LinqToDbValueConverterdouble.verified.txt
@@ -173,7 +173,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_structConversions_LinqToDbValueConverterstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_structConversions_LinqToDbValueConverterstring.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJson@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJson@record.@struct.@float.@decimal.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.Guid.verified.txt
@@ -154,7 +154,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbyte.verified.txt
@@ -175,7 +175,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondouble.verified.txt
@@ -175,7 +175,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonstring.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson@record.@struct.@float.@decimal.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonSystem.Guid.verified.txt
@@ -153,7 +153,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonbyte.verified.txt
@@ -174,7 +174,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsondouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsondouble.verified.txt
@@ -174,7 +174,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonstring.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_structConversions_None@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_structConversions_None@record.@struct.@float.@decimal.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_structConversions_NoneSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_structConversions_NoneSystem.Guid.verified.txt
@@ -152,7 +152,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_structConversions_Nonebyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_structConversions_Nonebyte.verified.txt
@@ -173,7 +173,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_structConversions_Nonedouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_structConversions_Nonedouble.verified.txt
@@ -173,7 +173,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_structConversions_Nonestring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_structConversions_Nonestring.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_structConversions_SystemTextJson@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_structConversions_SystemTextJson@record.@struct.@float.@decimal.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_structConversions_SystemTextJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_structConversions_SystemTextJsonSystem.Guid.verified.txt
@@ -153,7 +153,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_structConversions_SystemTextJsonbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_structConversions_SystemTextJsonbyte.verified.txt
@@ -174,7 +174,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_structConversions_SystemTextJsondouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_structConversions_SystemTextJsondouble.verified.txt
@@ -174,7 +174,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_structConversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_structConversions_SystemTextJsonstring.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_structConversions_TypeConverter@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_structConversions_TypeConverter@record.@struct.@float.@decimal.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_structConversions_TypeConverterSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_structConversions_TypeConverterSystem.Guid.verified.txt
@@ -153,7 +153,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_structConversions_TypeConverterbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_structConversions_TypeConverterbyte.verified.txt
@@ -174,7 +174,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_structConversions_TypeConverterdouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_structConversions_TypeConverterdouble.verified.txt
@@ -174,7 +174,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_structConversions_TypeConverterstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v4.8/escapedTestspublic_readonly_partial_structConversions_TypeConverterstring.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_structConversions_DapperTypeHandler@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_structConversions_DapperTypeHandler@record.@struct.@float.@decimal.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_structConversions_DapperTypeHandlerSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_structConversions_DapperTypeHandlerSystem.Guid.verified.txt
@@ -173,7 +173,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_structConversions_DapperTypeHandlerbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_structConversions_DapperTypeHandlerbyte.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_structConversions_DapperTypeHandlerdouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_structConversions_DapperTypeHandlerdouble.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_structConversions_DapperTypeHandlerstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_structConversions_DapperTypeHandlerstring.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_structConversions_EfCoreValueConverter@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_structConversions_EfCoreValueConverter@record.@struct.@float.@decimal.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_structConversions_EfCoreValueConverterSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_structConversions_EfCoreValueConverterSystem.Guid.verified.txt
@@ -173,7 +173,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_structConversions_EfCoreValueConverterbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_structConversions_EfCoreValueConverterbyte.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_structConversions_EfCoreValueConverterdouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_structConversions_EfCoreValueConverterdouble.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_structConversions_EfCoreValueConverterstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_structConversions_EfCoreValueConverterstring.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_structConversions_LinqToDbValueConverter@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_structConversions_LinqToDbValueConverter@record.@struct.@float.@decimal.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_structConversions_LinqToDbValueConverterSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_structConversions_LinqToDbValueConverterSystem.Guid.verified.txt
@@ -173,7 +173,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_structConversions_LinqToDbValueConverterbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_structConversions_LinqToDbValueConverterbyte.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_structConversions_LinqToDbValueConverterdouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_structConversions_LinqToDbValueConverterdouble.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_structConversions_LinqToDbValueConverterstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_structConversions_LinqToDbValueConverterstring.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJson@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJson@record.@struct.@float.@decimal.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.Guid.verified.txt
@@ -175,7 +175,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbyte.verified.txt
@@ -217,7 +217,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondouble.verified.txt
@@ -217,7 +217,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonstring.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_structConversions_NewtonsoftJson@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_structConversions_NewtonsoftJson@record.@struct.@float.@decimal.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_structConversions_NewtonsoftJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_structConversions_NewtonsoftJsonSystem.Guid.verified.txt
@@ -174,7 +174,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_structConversions_NewtonsoftJsonbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_structConversions_NewtonsoftJsonbyte.verified.txt
@@ -216,7 +216,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_structConversions_NewtonsoftJsondouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_structConversions_NewtonsoftJsondouble.verified.txt
@@ -216,7 +216,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_structConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_structConversions_NewtonsoftJsonstring.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_structConversions_None@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_structConversions_None@record.@struct.@float.@decimal.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_structConversions_NoneSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_structConversions_NoneSystem.Guid.verified.txt
@@ -173,7 +173,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_structConversions_Nonebyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_structConversions_Nonebyte.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_structConversions_Nonedouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_structConversions_Nonedouble.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_structConversions_Nonestring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_structConversions_Nonestring.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_structConversions_SystemTextJson@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_structConversions_SystemTextJson@record.@struct.@float.@decimal.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_structConversions_SystemTextJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_structConversions_SystemTextJsonSystem.Guid.verified.txt
@@ -174,7 +174,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_structConversions_SystemTextJsonbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_structConversions_SystemTextJsonbyte.verified.txt
@@ -216,7 +216,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_structConversions_SystemTextJsondouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_structConversions_SystemTextJsondouble.verified.txt
@@ -216,7 +216,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_structConversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_structConversions_SystemTextJsonstring.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_structConversions_TypeConverter@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_structConversions_TypeConverter@record.@struct.@float.@decimal.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_structConversions_TypeConverterSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_structConversions_TypeConverterSystem.Guid.verified.txt
@@ -174,7 +174,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_structConversions_TypeConverterbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_structConversions_TypeConverterbyte.verified.txt
@@ -216,7 +216,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_structConversions_TypeConverterdouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_structConversions_TypeConverterdouble.verified.txt
@@ -216,7 +216,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_structConversions_TypeConverterstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_partial_structConversions_TypeConverterstring.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_structConversions_DapperTypeHandler@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_structConversions_DapperTypeHandler@record.@struct.@float.@decimal.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_structConversions_DapperTypeHandlerSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_structConversions_DapperTypeHandlerSystem.Guid.verified.txt
@@ -173,7 +173,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_structConversions_DapperTypeHandlerbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_structConversions_DapperTypeHandlerbyte.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_structConversions_DapperTypeHandlerdouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_structConversions_DapperTypeHandlerdouble.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_structConversions_DapperTypeHandlerstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_structConversions_DapperTypeHandlerstring.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_structConversions_EfCoreValueConverter@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_structConversions_EfCoreValueConverter@record.@struct.@float.@decimal.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_structConversions_EfCoreValueConverterSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_structConversions_EfCoreValueConverterSystem.Guid.verified.txt
@@ -173,7 +173,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_structConversions_EfCoreValueConverterbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_structConversions_EfCoreValueConverterbyte.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_structConversions_EfCoreValueConverterdouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_structConversions_EfCoreValueConverterdouble.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_structConversions_EfCoreValueConverterstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_structConversions_EfCoreValueConverterstring.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_structConversions_LinqToDbValueConverter@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_structConversions_LinqToDbValueConverter@record.@struct.@float.@decimal.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_structConversions_LinqToDbValueConverterSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_structConversions_LinqToDbValueConverterSystem.Guid.verified.txt
@@ -173,7 +173,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_structConversions_LinqToDbValueConverterbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_structConversions_LinqToDbValueConverterbyte.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_structConversions_LinqToDbValueConverterdouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_structConversions_LinqToDbValueConverterdouble.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_structConversions_LinqToDbValueConverterstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_structConversions_LinqToDbValueConverterstring.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJson@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJson@record.@struct.@float.@decimal.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.Guid.verified.txt
@@ -175,7 +175,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbyte.verified.txt
@@ -217,7 +217,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondouble.verified.txt
@@ -217,7 +217,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonstring.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson@record.@struct.@float.@decimal.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonSystem.Guid.verified.txt
@@ -174,7 +174,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonbyte.verified.txt
@@ -216,7 +216,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsondouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsondouble.verified.txt
@@ -216,7 +216,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonstring.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_structConversions_None@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_structConversions_None@record.@struct.@float.@decimal.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_structConversions_NoneSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_structConversions_NoneSystem.Guid.verified.txt
@@ -173,7 +173,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_structConversions_Nonebyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_structConversions_Nonebyte.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_structConversions_Nonedouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_structConversions_Nonedouble.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_structConversions_Nonestring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_structConversions_Nonestring.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_structConversions_SystemTextJson@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_structConversions_SystemTextJson@record.@struct.@float.@decimal.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_structConversions_SystemTextJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_structConversions_SystemTextJsonSystem.Guid.verified.txt
@@ -174,7 +174,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_structConversions_SystemTextJsonbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_structConversions_SystemTextJsonbyte.verified.txt
@@ -216,7 +216,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_structConversions_SystemTextJsondouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_structConversions_SystemTextJsondouble.verified.txt
@@ -216,7 +216,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_structConversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_structConversions_SystemTextJsonstring.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_structConversions_TypeConverter@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_structConversions_TypeConverter@record.@struct.@float.@decimal.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_structConversions_TypeConverterSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_structConversions_TypeConverterSystem.Guid.verified.txt
@@ -174,7 +174,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_structConversions_TypeConverterbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_structConversions_TypeConverterbyte.verified.txt
@@ -216,7 +216,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_structConversions_TypeConverterdouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_structConversions_TypeConverterdouble.verified.txt
@@ -216,7 +216,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_structConversions_TypeConverterstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestsinternal_readonly_partial_structConversions_TypeConverterstring.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_structConversions_DapperTypeHandler@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_structConversions_DapperTypeHandler@record.@struct.@float.@decimal.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_structConversions_DapperTypeHandlerSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_structConversions_DapperTypeHandlerSystem.Guid.verified.txt
@@ -173,7 +173,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_structConversions_DapperTypeHandlerbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_structConversions_DapperTypeHandlerbyte.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_structConversions_DapperTypeHandlerdouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_structConversions_DapperTypeHandlerdouble.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_structConversions_DapperTypeHandlerstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_structConversions_DapperTypeHandlerstring.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_structConversions_EfCoreValueConverter@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_structConversions_EfCoreValueConverter@record.@struct.@float.@decimal.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_structConversions_EfCoreValueConverterSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_structConversions_EfCoreValueConverterSystem.Guid.verified.txt
@@ -173,7 +173,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_structConversions_EfCoreValueConverterbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_structConversions_EfCoreValueConverterbyte.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_structConversions_EfCoreValueConverterdouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_structConversions_EfCoreValueConverterdouble.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_structConversions_EfCoreValueConverterstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_structConversions_EfCoreValueConverterstring.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_structConversions_LinqToDbValueConverter@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_structConversions_LinqToDbValueConverter@record.@struct.@float.@decimal.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_structConversions_LinqToDbValueConverterSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_structConversions_LinqToDbValueConverterSystem.Guid.verified.txt
@@ -173,7 +173,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_structConversions_LinqToDbValueConverterbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_structConversions_LinqToDbValueConverterbyte.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_structConversions_LinqToDbValueConverterdouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_structConversions_LinqToDbValueConverterdouble.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_structConversions_LinqToDbValueConverterstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_structConversions_LinqToDbValueConverterstring.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJson@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJson@record.@struct.@float.@decimal.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.Guid.verified.txt
@@ -175,7 +175,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbyte.verified.txt
@@ -217,7 +217,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondouble.verified.txt
@@ -217,7 +217,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonstring.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_structConversions_NewtonsoftJson@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_structConversions_NewtonsoftJson@record.@struct.@float.@decimal.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_structConversions_NewtonsoftJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_structConversions_NewtonsoftJsonSystem.Guid.verified.txt
@@ -174,7 +174,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_structConversions_NewtonsoftJsonbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_structConversions_NewtonsoftJsonbyte.verified.txt
@@ -216,7 +216,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_structConversions_NewtonsoftJsondouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_structConversions_NewtonsoftJsondouble.verified.txt
@@ -216,7 +216,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_structConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_structConversions_NewtonsoftJsonstring.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_structConversions_None@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_structConversions_None@record.@struct.@float.@decimal.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_structConversions_NoneSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_structConversions_NoneSystem.Guid.verified.txt
@@ -173,7 +173,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_structConversions_Nonebyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_structConversions_Nonebyte.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_structConversions_Nonedouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_structConversions_Nonedouble.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_structConversions_Nonestring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_structConversions_Nonestring.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_structConversions_SystemTextJson@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_structConversions_SystemTextJson@record.@struct.@float.@decimal.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_structConversions_SystemTextJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_structConversions_SystemTextJsonSystem.Guid.verified.txt
@@ -174,7 +174,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_structConversions_SystemTextJsonbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_structConversions_SystemTextJsonbyte.verified.txt
@@ -216,7 +216,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_structConversions_SystemTextJsondouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_structConversions_SystemTextJsondouble.verified.txt
@@ -216,7 +216,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_structConversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_structConversions_SystemTextJsonstring.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_structConversions_TypeConverter@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_structConversions_TypeConverter@record.@struct.@float.@decimal.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_structConversions_TypeConverterSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_structConversions_TypeConverterSystem.Guid.verified.txt
@@ -174,7 +174,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_structConversions_TypeConverterbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_structConversions_TypeConverterbyte.verified.txt
@@ -216,7 +216,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_structConversions_TypeConverterdouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_structConversions_TypeConverterdouble.verified.txt
@@ -216,7 +216,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_structConversions_TypeConverterstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_partial_structConversions_TypeConverterstring.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_structConversions_DapperTypeHandler@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_structConversions_DapperTypeHandler@record.@struct.@float.@decimal.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_structConversions_DapperTypeHandlerSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_structConversions_DapperTypeHandlerSystem.Guid.verified.txt
@@ -173,7 +173,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_structConversions_DapperTypeHandlerbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_structConversions_DapperTypeHandlerbyte.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_structConversions_DapperTypeHandlerdouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_structConversions_DapperTypeHandlerdouble.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_structConversions_DapperTypeHandlerstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_structConversions_DapperTypeHandlerstring.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_structConversions_EfCoreValueConverter@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_structConversions_EfCoreValueConverter@record.@struct.@float.@decimal.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_structConversions_EfCoreValueConverterSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_structConversions_EfCoreValueConverterSystem.Guid.verified.txt
@@ -173,7 +173,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_structConversions_EfCoreValueConverterbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_structConversions_EfCoreValueConverterbyte.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_structConversions_EfCoreValueConverterdouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_structConversions_EfCoreValueConverterdouble.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_structConversions_EfCoreValueConverterstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_structConversions_EfCoreValueConverterstring.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_structConversions_LinqToDbValueConverter@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_structConversions_LinqToDbValueConverter@record.@struct.@float.@decimal.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_structConversions_LinqToDbValueConverterSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_structConversions_LinqToDbValueConverterSystem.Guid.verified.txt
@@ -173,7 +173,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_structConversions_LinqToDbValueConverterbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_structConversions_LinqToDbValueConverterbyte.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_structConversions_LinqToDbValueConverterdouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_structConversions_LinqToDbValueConverterdouble.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_structConversions_LinqToDbValueConverterstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_structConversions_LinqToDbValueConverterstring.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJson@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJson@record.@struct.@float.@decimal.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.Guid.verified.txt
@@ -175,7 +175,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbyte.verified.txt
@@ -217,7 +217,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondouble.verified.txt
@@ -217,7 +217,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonstring.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson@record.@struct.@float.@decimal.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonSystem.Guid.verified.txt
@@ -174,7 +174,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonbyte.verified.txt
@@ -216,7 +216,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsondouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsondouble.verified.txt
@@ -216,7 +216,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonstring.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_structConversions_None@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_structConversions_None@record.@struct.@float.@decimal.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_structConversions_NoneSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_structConversions_NoneSystem.Guid.verified.txt
@@ -173,7 +173,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_structConversions_Nonebyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_structConversions_Nonebyte.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_structConversions_Nonedouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_structConversions_Nonedouble.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_structConversions_Nonestring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_structConversions_Nonestring.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_structConversions_SystemTextJson@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_structConversions_SystemTextJson@record.@struct.@float.@decimal.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_structConversions_SystemTextJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_structConversions_SystemTextJsonSystem.Guid.verified.txt
@@ -174,7 +174,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_structConversions_SystemTextJsonbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_structConversions_SystemTextJsonbyte.verified.txt
@@ -216,7 +216,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_structConversions_SystemTextJsondouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_structConversions_SystemTextJsondouble.verified.txt
@@ -216,7 +216,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_structConversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_structConversions_SystemTextJsonstring.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_structConversions_TypeConverter@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_structConversions_TypeConverter@record.@struct.@float.@decimal.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_structConversions_TypeConverterSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_structConversions_TypeConverterSystem.Guid.verified.txt
@@ -174,7 +174,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_structConversions_TypeConverterbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_structConversions_TypeConverterbyte.verified.txt
@@ -216,7 +216,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_structConversions_TypeConverterdouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_structConversions_TypeConverterdouble.verified.txt
@@ -216,7 +216,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_structConversions_TypeConverterstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v5.0/escapedTestspublic_readonly_partial_structConversions_TypeConverterstring.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_structConversions_DapperTypeHandler@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_structConversions_DapperTypeHandler@record.@struct.@float.@decimal.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_structConversions_DapperTypeHandlerSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_structConversions_DapperTypeHandlerSystem.Guid.verified.txt
@@ -173,7 +173,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_structConversions_DapperTypeHandlerbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_structConversions_DapperTypeHandlerbyte.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_structConversions_DapperTypeHandlerdouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_structConversions_DapperTypeHandlerdouble.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_structConversions_DapperTypeHandlerstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_structConversions_DapperTypeHandlerstring.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_structConversions_EfCoreValueConverter@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_structConversions_EfCoreValueConverter@record.@struct.@float.@decimal.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_structConversions_EfCoreValueConverterSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_structConversions_EfCoreValueConverterSystem.Guid.verified.txt
@@ -173,7 +173,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_structConversions_EfCoreValueConverterbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_structConversions_EfCoreValueConverterbyte.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_structConversions_EfCoreValueConverterdouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_structConversions_EfCoreValueConverterdouble.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_structConversions_EfCoreValueConverterstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_structConversions_EfCoreValueConverterstring.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_structConversions_LinqToDbValueConverter@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_structConversions_LinqToDbValueConverter@record.@struct.@float.@decimal.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_structConversions_LinqToDbValueConverterSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_structConversions_LinqToDbValueConverterSystem.Guid.verified.txt
@@ -173,7 +173,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_structConversions_LinqToDbValueConverterbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_structConversions_LinqToDbValueConverterbyte.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_structConversions_LinqToDbValueConverterdouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_structConversions_LinqToDbValueConverterdouble.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_structConversions_LinqToDbValueConverterstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_structConversions_LinqToDbValueConverterstring.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJson@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJson@record.@struct.@float.@decimal.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.Guid.verified.txt
@@ -175,7 +175,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbyte.verified.txt
@@ -217,7 +217,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondouble.verified.txt
@@ -217,7 +217,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonstring.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_structConversions_NewtonsoftJson@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_structConversions_NewtonsoftJson@record.@struct.@float.@decimal.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_structConversions_NewtonsoftJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_structConversions_NewtonsoftJsonSystem.Guid.verified.txt
@@ -174,7 +174,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_structConversions_NewtonsoftJsonbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_structConversions_NewtonsoftJsonbyte.verified.txt
@@ -216,7 +216,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_structConversions_NewtonsoftJsondouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_structConversions_NewtonsoftJsondouble.verified.txt
@@ -216,7 +216,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_structConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_structConversions_NewtonsoftJsonstring.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_structConversions_None@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_structConversions_None@record.@struct.@float.@decimal.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_structConversions_NoneSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_structConversions_NoneSystem.Guid.verified.txt
@@ -173,7 +173,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_structConversions_Nonebyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_structConversions_Nonebyte.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_structConversions_Nonedouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_structConversions_Nonedouble.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_structConversions_Nonestring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_structConversions_Nonestring.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_structConversions_SystemTextJson@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_structConversions_SystemTextJson@record.@struct.@float.@decimal.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_structConversions_SystemTextJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_structConversions_SystemTextJsonSystem.Guid.verified.txt
@@ -174,7 +174,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_structConversions_SystemTextJsonbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_structConversions_SystemTextJsonbyte.verified.txt
@@ -216,7 +216,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_structConversions_SystemTextJsondouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_structConversions_SystemTextJsondouble.verified.txt
@@ -216,7 +216,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_structConversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_structConversions_SystemTextJsonstring.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_structConversions_TypeConverter@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_structConversions_TypeConverter@record.@struct.@float.@decimal.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_structConversions_TypeConverterSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_structConversions_TypeConverterSystem.Guid.verified.txt
@@ -174,7 +174,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_structConversions_TypeConverterbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_structConversions_TypeConverterbyte.verified.txt
@@ -216,7 +216,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_structConversions_TypeConverterdouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_structConversions_TypeConverterdouble.verified.txt
@@ -216,7 +216,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_structConversions_TypeConverterstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_partial_structConversions_TypeConverterstring.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_structConversions_DapperTypeHandler@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_structConversions_DapperTypeHandler@record.@struct.@float.@decimal.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_structConversions_DapperTypeHandlerSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_structConversions_DapperTypeHandlerSystem.Guid.verified.txt
@@ -173,7 +173,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_structConversions_DapperTypeHandlerbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_structConversions_DapperTypeHandlerbyte.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_structConversions_DapperTypeHandlerdouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_structConversions_DapperTypeHandlerdouble.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_structConversions_DapperTypeHandlerstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_structConversions_DapperTypeHandlerstring.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_structConversions_EfCoreValueConverter@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_structConversions_EfCoreValueConverter@record.@struct.@float.@decimal.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_structConversions_EfCoreValueConverterSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_structConversions_EfCoreValueConverterSystem.Guid.verified.txt
@@ -173,7 +173,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_structConversions_EfCoreValueConverterbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_structConversions_EfCoreValueConverterbyte.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_structConversions_EfCoreValueConverterdouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_structConversions_EfCoreValueConverterdouble.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_structConversions_EfCoreValueConverterstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_structConversions_EfCoreValueConverterstring.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_structConversions_LinqToDbValueConverter@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_structConversions_LinqToDbValueConverter@record.@struct.@float.@decimal.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_structConversions_LinqToDbValueConverterSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_structConversions_LinqToDbValueConverterSystem.Guid.verified.txt
@@ -173,7 +173,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_structConversions_LinqToDbValueConverterbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_structConversions_LinqToDbValueConverterbyte.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_structConversions_LinqToDbValueConverterdouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_structConversions_LinqToDbValueConverterdouble.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_structConversions_LinqToDbValueConverterstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_structConversions_LinqToDbValueConverterstring.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJson@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJson@record.@struct.@float.@decimal.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.Guid.verified.txt
@@ -175,7 +175,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbyte.verified.txt
@@ -217,7 +217,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondouble.verified.txt
@@ -217,7 +217,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonstring.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson@record.@struct.@float.@decimal.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonSystem.Guid.verified.txt
@@ -174,7 +174,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonbyte.verified.txt
@@ -216,7 +216,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsondouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsondouble.verified.txt
@@ -216,7 +216,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonstring.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_structConversions_None@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_structConversions_None@record.@struct.@float.@decimal.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_structConversions_NoneSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_structConversions_NoneSystem.Guid.verified.txt
@@ -173,7 +173,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_structConversions_Nonebyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_structConversions_Nonebyte.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_structConversions_Nonedouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_structConversions_Nonedouble.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_structConversions_Nonestring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_structConversions_Nonestring.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_structConversions_SystemTextJson@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_structConversions_SystemTextJson@record.@struct.@float.@decimal.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_structConversions_SystemTextJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_structConversions_SystemTextJsonSystem.Guid.verified.txt
@@ -174,7 +174,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_structConversions_SystemTextJsonbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_structConversions_SystemTextJsonbyte.verified.txt
@@ -216,7 +216,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_structConversions_SystemTextJsondouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_structConversions_SystemTextJsondouble.verified.txt
@@ -216,7 +216,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_structConversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_structConversions_SystemTextJsonstring.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_structConversions_TypeConverter@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_structConversions_TypeConverter@record.@struct.@float.@decimal.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_structConversions_TypeConverterSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_structConversions_TypeConverterSystem.Guid.verified.txt
@@ -174,7 +174,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_structConversions_TypeConverterbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_structConversions_TypeConverterbyte.verified.txt
@@ -216,7 +216,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_structConversions_TypeConverterdouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_structConversions_TypeConverterdouble.verified.txt
@@ -216,7 +216,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_structConversions_TypeConverterstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestsinternal_readonly_partial_structConversions_TypeConverterstring.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_structConversions_DapperTypeHandler@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_structConversions_DapperTypeHandler@record.@struct.@float.@decimal.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_structConversions_DapperTypeHandlerSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_structConversions_DapperTypeHandlerSystem.Guid.verified.txt
@@ -173,7 +173,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_structConversions_DapperTypeHandlerbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_structConversions_DapperTypeHandlerbyte.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_structConversions_DapperTypeHandlerdouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_structConversions_DapperTypeHandlerdouble.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_structConversions_DapperTypeHandlerstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_structConversions_DapperTypeHandlerstring.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_structConversions_EfCoreValueConverter@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_structConversions_EfCoreValueConverter@record.@struct.@float.@decimal.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_structConversions_EfCoreValueConverterSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_structConversions_EfCoreValueConverterSystem.Guid.verified.txt
@@ -173,7 +173,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_structConversions_EfCoreValueConverterbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_structConversions_EfCoreValueConverterbyte.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_structConversions_EfCoreValueConverterdouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_structConversions_EfCoreValueConverterdouble.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_structConversions_EfCoreValueConverterstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_structConversions_EfCoreValueConverterstring.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_structConversions_LinqToDbValueConverter@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_structConversions_LinqToDbValueConverter@record.@struct.@float.@decimal.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_structConversions_LinqToDbValueConverterSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_structConversions_LinqToDbValueConverterSystem.Guid.verified.txt
@@ -173,7 +173,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_structConversions_LinqToDbValueConverterbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_structConversions_LinqToDbValueConverterbyte.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_structConversions_LinqToDbValueConverterdouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_structConversions_LinqToDbValueConverterdouble.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_structConversions_LinqToDbValueConverterstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_structConversions_LinqToDbValueConverterstring.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJson@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJson@record.@struct.@float.@decimal.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.Guid.verified.txt
@@ -175,7 +175,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbyte.verified.txt
@@ -217,7 +217,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondouble.verified.txt
@@ -217,7 +217,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonstring.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_structConversions_NewtonsoftJson@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_structConversions_NewtonsoftJson@record.@struct.@float.@decimal.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_structConversions_NewtonsoftJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_structConversions_NewtonsoftJsonSystem.Guid.verified.txt
@@ -174,7 +174,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_structConversions_NewtonsoftJsonbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_structConversions_NewtonsoftJsonbyte.verified.txt
@@ -216,7 +216,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_structConversions_NewtonsoftJsondouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_structConversions_NewtonsoftJsondouble.verified.txt
@@ -216,7 +216,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_structConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_structConversions_NewtonsoftJsonstring.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_structConversions_None@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_structConversions_None@record.@struct.@float.@decimal.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_structConversions_NoneSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_structConversions_NoneSystem.Guid.verified.txt
@@ -173,7 +173,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_structConversions_Nonebyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_structConversions_Nonebyte.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_structConversions_Nonedouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_structConversions_Nonedouble.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_structConversions_Nonestring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_structConversions_Nonestring.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_structConversions_SystemTextJson@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_structConversions_SystemTextJson@record.@struct.@float.@decimal.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_structConversions_SystemTextJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_structConversions_SystemTextJsonSystem.Guid.verified.txt
@@ -174,7 +174,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_structConversions_SystemTextJsonbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_structConversions_SystemTextJsonbyte.verified.txt
@@ -216,7 +216,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_structConversions_SystemTextJsondouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_structConversions_SystemTextJsondouble.verified.txt
@@ -216,7 +216,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_structConversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_structConversions_SystemTextJsonstring.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_structConversions_TypeConverter@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_structConversions_TypeConverter@record.@struct.@float.@decimal.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_structConversions_TypeConverterSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_structConversions_TypeConverterSystem.Guid.verified.txt
@@ -174,7 +174,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_structConversions_TypeConverterbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_structConversions_TypeConverterbyte.verified.txt
@@ -216,7 +216,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_structConversions_TypeConverterdouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_structConversions_TypeConverterdouble.verified.txt
@@ -216,7 +216,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_structConversions_TypeConverterstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_partial_structConversions_TypeConverterstring.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_structConversions_DapperTypeHandler@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_structConversions_DapperTypeHandler@record.@struct.@float.@decimal.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_structConversions_DapperTypeHandlerSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_structConversions_DapperTypeHandlerSystem.Guid.verified.txt
@@ -173,7 +173,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_structConversions_DapperTypeHandlerbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_structConversions_DapperTypeHandlerbyte.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_structConversions_DapperTypeHandlerdouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_structConversions_DapperTypeHandlerdouble.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_structConversions_DapperTypeHandlerstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_structConversions_DapperTypeHandlerstring.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_structConversions_EfCoreValueConverter@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_structConversions_EfCoreValueConverter@record.@struct.@float.@decimal.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_structConversions_EfCoreValueConverterSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_structConversions_EfCoreValueConverterSystem.Guid.verified.txt
@@ -173,7 +173,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_structConversions_EfCoreValueConverterbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_structConversions_EfCoreValueConverterbyte.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_structConversions_EfCoreValueConverterdouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_structConversions_EfCoreValueConverterdouble.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_structConversions_EfCoreValueConverterstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_structConversions_EfCoreValueConverterstring.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_structConversions_LinqToDbValueConverter@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_structConversions_LinqToDbValueConverter@record.@struct.@float.@decimal.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_structConversions_LinqToDbValueConverterSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_structConversions_LinqToDbValueConverterSystem.Guid.verified.txt
@@ -173,7 +173,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_structConversions_LinqToDbValueConverterbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_structConversions_LinqToDbValueConverterbyte.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_structConversions_LinqToDbValueConverterdouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_structConversions_LinqToDbValueConverterdouble.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_structConversions_LinqToDbValueConverterstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_structConversions_LinqToDbValueConverterstring.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJson@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJson@record.@struct.@float.@decimal.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.Guid.verified.txt
@@ -175,7 +175,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbyte.verified.txt
@@ -217,7 +217,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondouble.verified.txt
@@ -217,7 +217,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonstring.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson@record.@struct.@float.@decimal.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonSystem.Guid.verified.txt
@@ -174,7 +174,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonbyte.verified.txt
@@ -216,7 +216,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsondouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsondouble.verified.txt
@@ -216,7 +216,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonstring.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_structConversions_None@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_structConversions_None@record.@struct.@float.@decimal.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_structConversions_NoneSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_structConversions_NoneSystem.Guid.verified.txt
@@ -173,7 +173,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_structConversions_Nonebyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_structConversions_Nonebyte.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_structConversions_Nonedouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_structConversions_Nonedouble.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_structConversions_Nonestring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_structConversions_Nonestring.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_structConversions_SystemTextJson@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_structConversions_SystemTextJson@record.@struct.@float.@decimal.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_structConversions_SystemTextJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_structConversions_SystemTextJsonSystem.Guid.verified.txt
@@ -174,7 +174,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_structConversions_SystemTextJsonbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_structConversions_SystemTextJsonbyte.verified.txt
@@ -216,7 +216,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_structConversions_SystemTextJsondouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_structConversions_SystemTextJsondouble.verified.txt
@@ -216,7 +216,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_structConversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_structConversions_SystemTextJsonstring.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_structConversions_TypeConverter@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_structConversions_TypeConverter@record.@struct.@float.@decimal.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_structConversions_TypeConverterSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_structConversions_TypeConverterSystem.Guid.verified.txt
@@ -174,7 +174,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_structConversions_TypeConverterbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_structConversions_TypeConverterbyte.verified.txt
@@ -216,7 +216,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_structConversions_TypeConverterdouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_structConversions_TypeConverterdouble.verified.txt
@@ -216,7 +216,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_structConversions_TypeConverterstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v6.0/escapedTestspublic_readonly_partial_structConversions_TypeConverterstring.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_structConversions_DapperTypeHandler@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_structConversions_DapperTypeHandler@record.@struct.@float.@decimal.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_structConversions_DapperTypeHandlerSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_structConversions_DapperTypeHandlerSystem.Guid.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_structConversions_DapperTypeHandlerbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_structConversions_DapperTypeHandlerbyte.verified.txt
@@ -257,7 +257,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_structConversions_DapperTypeHandlerdouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_structConversions_DapperTypeHandlerdouble.verified.txt
@@ -257,7 +257,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_structConversions_DapperTypeHandlerstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_structConversions_DapperTypeHandlerstring.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_structConversions_EfCoreValueConverter@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_structConversions_EfCoreValueConverter@record.@struct.@float.@decimal.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_structConversions_EfCoreValueConverterSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_structConversions_EfCoreValueConverterSystem.Guid.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_structConversions_EfCoreValueConverterbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_structConversions_EfCoreValueConverterbyte.verified.txt
@@ -257,7 +257,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_structConversions_EfCoreValueConverterdouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_structConversions_EfCoreValueConverterdouble.verified.txt
@@ -257,7 +257,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_structConversions_EfCoreValueConverterstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_structConversions_EfCoreValueConverterstring.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_structConversions_LinqToDbValueConverter@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_structConversions_LinqToDbValueConverter@record.@struct.@float.@decimal.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_structConversions_LinqToDbValueConverterSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_structConversions_LinqToDbValueConverterSystem.Guid.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_structConversions_LinqToDbValueConverterbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_structConversions_LinqToDbValueConverterbyte.verified.txt
@@ -257,7 +257,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_structConversions_LinqToDbValueConverterdouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_structConversions_LinqToDbValueConverterdouble.verified.txt
@@ -257,7 +257,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_structConversions_LinqToDbValueConverterstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_structConversions_LinqToDbValueConverterstring.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJson@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJson@record.@struct.@float.@decimal.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.Guid.verified.txt
@@ -217,7 +217,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbyte.verified.txt
@@ -259,7 +259,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondouble.verified.txt
@@ -259,7 +259,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonstring.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_structConversions_NewtonsoftJson@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_structConversions_NewtonsoftJson@record.@struct.@float.@decimal.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_structConversions_NewtonsoftJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_structConversions_NewtonsoftJsonSystem.Guid.verified.txt
@@ -216,7 +216,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_structConversions_NewtonsoftJsonbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_structConversions_NewtonsoftJsonbyte.verified.txt
@@ -258,7 +258,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_structConversions_NewtonsoftJsondouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_structConversions_NewtonsoftJsondouble.verified.txt
@@ -258,7 +258,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_structConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_structConversions_NewtonsoftJsonstring.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_structConversions_None@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_structConversions_None@record.@struct.@float.@decimal.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_structConversions_NoneSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_structConversions_NoneSystem.Guid.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_structConversions_Nonebyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_structConversions_Nonebyte.verified.txt
@@ -257,7 +257,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_structConversions_Nonedouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_structConversions_Nonedouble.verified.txt
@@ -257,7 +257,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_structConversions_Nonestring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_structConversions_Nonestring.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_structConversions_SystemTextJson@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_structConversions_SystemTextJson@record.@struct.@float.@decimal.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_structConversions_SystemTextJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_structConversions_SystemTextJsonSystem.Guid.verified.txt
@@ -216,7 +216,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_structConversions_SystemTextJsonbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_structConversions_SystemTextJsonbyte.verified.txt
@@ -258,7 +258,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_structConversions_SystemTextJsondouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_structConversions_SystemTextJsondouble.verified.txt
@@ -258,7 +258,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_structConversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_structConversions_SystemTextJsonstring.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_structConversions_TypeConverter@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_structConversions_TypeConverter@record.@struct.@float.@decimal.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_structConversions_TypeConverterSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_structConversions_TypeConverterSystem.Guid.verified.txt
@@ -216,7 +216,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_structConversions_TypeConverterbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_structConversions_TypeConverterbyte.verified.txt
@@ -258,7 +258,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_structConversions_TypeConverterdouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_structConversions_TypeConverterdouble.verified.txt
@@ -258,7 +258,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_structConversions_TypeConverterstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_partial_structConversions_TypeConverterstring.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_structConversions_DapperTypeHandler@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_structConversions_DapperTypeHandler@record.@struct.@float.@decimal.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_structConversions_DapperTypeHandlerSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_structConversions_DapperTypeHandlerSystem.Guid.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_structConversions_DapperTypeHandlerbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_structConversions_DapperTypeHandlerbyte.verified.txt
@@ -257,7 +257,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_structConversions_DapperTypeHandlerdouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_structConversions_DapperTypeHandlerdouble.verified.txt
@@ -257,7 +257,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_structConversions_DapperTypeHandlerstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_structConversions_DapperTypeHandlerstring.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_structConversions_EfCoreValueConverter@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_structConversions_EfCoreValueConverter@record.@struct.@float.@decimal.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_structConversions_EfCoreValueConverterSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_structConversions_EfCoreValueConverterSystem.Guid.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_structConversions_EfCoreValueConverterbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_structConversions_EfCoreValueConverterbyte.verified.txt
@@ -257,7 +257,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_structConversions_EfCoreValueConverterdouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_structConversions_EfCoreValueConverterdouble.verified.txt
@@ -257,7 +257,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_structConversions_EfCoreValueConverterstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_structConversions_EfCoreValueConverterstring.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_structConversions_LinqToDbValueConverter@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_structConversions_LinqToDbValueConverter@record.@struct.@float.@decimal.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_structConversions_LinqToDbValueConverterSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_structConversions_LinqToDbValueConverterSystem.Guid.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_structConversions_LinqToDbValueConverterbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_structConversions_LinqToDbValueConverterbyte.verified.txt
@@ -257,7 +257,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_structConversions_LinqToDbValueConverterdouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_structConversions_LinqToDbValueConverterdouble.verified.txt
@@ -257,7 +257,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_structConversions_LinqToDbValueConverterstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_structConversions_LinqToDbValueConverterstring.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJson@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJson@record.@struct.@float.@decimal.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.Guid.verified.txt
@@ -217,7 +217,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbyte.verified.txt
@@ -259,7 +259,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondouble.verified.txt
@@ -259,7 +259,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonstring.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJson@record.@struct.@float.@decimal.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonSystem.Guid.verified.txt
@@ -216,7 +216,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonbyte.verified.txt
@@ -258,7 +258,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsondouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsondouble.verified.txt
@@ -258,7 +258,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_structConversions_NewtonsoftJsonstring.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_structConversions_None@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_structConversions_None@record.@struct.@float.@decimal.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_structConversions_NoneSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_structConversions_NoneSystem.Guid.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_structConversions_Nonebyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_structConversions_Nonebyte.verified.txt
@@ -257,7 +257,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_structConversions_Nonedouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_structConversions_Nonedouble.verified.txt
@@ -257,7 +257,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_structConversions_Nonestring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_structConversions_Nonestring.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_structConversions_SystemTextJson@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_structConversions_SystemTextJson@record.@struct.@float.@decimal.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_structConversions_SystemTextJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_structConversions_SystemTextJsonSystem.Guid.verified.txt
@@ -216,7 +216,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_structConversions_SystemTextJsonbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_structConversions_SystemTextJsonbyte.verified.txt
@@ -258,7 +258,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_structConversions_SystemTextJsondouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_structConversions_SystemTextJsondouble.verified.txt
@@ -258,7 +258,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_structConversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_structConversions_SystemTextJsonstring.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_structConversions_TypeConverter@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_structConversions_TypeConverter@record.@struct.@float.@decimal.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_structConversions_TypeConverterSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_structConversions_TypeConverterSystem.Guid.verified.txt
@@ -216,7 +216,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_structConversions_TypeConverterbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_structConversions_TypeConverterbyte.verified.txt
@@ -258,7 +258,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_structConversions_TypeConverterdouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_structConversions_TypeConverterdouble.verified.txt
@@ -258,7 +258,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_structConversions_TypeConverterstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestsinternal_readonly_partial_structConversions_TypeConverterstring.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_structConversions_DapperTypeHandler@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_structConversions_DapperTypeHandler@record.@struct.@float.@decimal.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_structConversions_DapperTypeHandlerSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_structConversions_DapperTypeHandlerSystem.Guid.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_structConversions_DapperTypeHandlerbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_structConversions_DapperTypeHandlerbyte.verified.txt
@@ -257,7 +257,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_structConversions_DapperTypeHandlerdouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_structConversions_DapperTypeHandlerdouble.verified.txt
@@ -257,7 +257,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_structConversions_DapperTypeHandlerstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_structConversions_DapperTypeHandlerstring.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_structConversions_EfCoreValueConverter@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_structConversions_EfCoreValueConverter@record.@struct.@float.@decimal.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_structConversions_EfCoreValueConverterSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_structConversions_EfCoreValueConverterSystem.Guid.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_structConversions_EfCoreValueConverterbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_structConversions_EfCoreValueConverterbyte.verified.txt
@@ -257,7 +257,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_structConversions_EfCoreValueConverterdouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_structConversions_EfCoreValueConverterdouble.verified.txt
@@ -257,7 +257,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_structConversions_EfCoreValueConverterstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_structConversions_EfCoreValueConverterstring.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_structConversions_LinqToDbValueConverter@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_structConversions_LinqToDbValueConverter@record.@struct.@float.@decimal.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_structConversions_LinqToDbValueConverterSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_structConversions_LinqToDbValueConverterSystem.Guid.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_structConversions_LinqToDbValueConverterbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_structConversions_LinqToDbValueConverterbyte.verified.txt
@@ -257,7 +257,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_structConversions_LinqToDbValueConverterdouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_structConversions_LinqToDbValueConverterdouble.verified.txt
@@ -257,7 +257,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_structConversions_LinqToDbValueConverterstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_structConversions_LinqToDbValueConverterstring.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJson@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJson@record.@struct.@float.@decimal.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.Guid.verified.txt
@@ -217,7 +217,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbyte.verified.txt
@@ -259,7 +259,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondouble.verified.txt
@@ -259,7 +259,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonstring.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_structConversions_NewtonsoftJson@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_structConversions_NewtonsoftJson@record.@struct.@float.@decimal.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_structConversions_NewtonsoftJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_structConversions_NewtonsoftJsonSystem.Guid.verified.txt
@@ -216,7 +216,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_structConversions_NewtonsoftJsonbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_structConversions_NewtonsoftJsonbyte.verified.txt
@@ -258,7 +258,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_structConversions_NewtonsoftJsondouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_structConversions_NewtonsoftJsondouble.verified.txt
@@ -258,7 +258,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_structConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_structConversions_NewtonsoftJsonstring.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_structConversions_None@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_structConversions_None@record.@struct.@float.@decimal.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_structConversions_NoneSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_structConversions_NoneSystem.Guid.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_structConversions_Nonebyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_structConversions_Nonebyte.verified.txt
@@ -257,7 +257,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_structConversions_Nonedouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_structConversions_Nonedouble.verified.txt
@@ -257,7 +257,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_structConversions_Nonestring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_structConversions_Nonestring.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_structConversions_SystemTextJson@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_structConversions_SystemTextJson@record.@struct.@float.@decimal.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_structConversions_SystemTextJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_structConversions_SystemTextJsonSystem.Guid.verified.txt
@@ -216,7 +216,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_structConversions_SystemTextJsonbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_structConversions_SystemTextJsonbyte.verified.txt
@@ -258,7 +258,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_structConversions_SystemTextJsondouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_structConversions_SystemTextJsondouble.verified.txt
@@ -258,7 +258,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_structConversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_structConversions_SystemTextJsonstring.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_structConversions_TypeConverter@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_structConversions_TypeConverter@record.@struct.@float.@decimal.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_structConversions_TypeConverterSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_structConversions_TypeConverterSystem.Guid.verified.txt
@@ -216,7 +216,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_structConversions_TypeConverterbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_structConversions_TypeConverterbyte.verified.txt
@@ -258,7 +258,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_structConversions_TypeConverterdouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_structConversions_TypeConverterdouble.verified.txt
@@ -258,7 +258,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_structConversions_TypeConverterstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_partial_structConversions_TypeConverterstring.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_structConversions_DapperTypeHandler@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_structConversions_DapperTypeHandler@record.@struct.@float.@decimal.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_structConversions_DapperTypeHandlerSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_structConversions_DapperTypeHandlerSystem.Guid.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_structConversions_DapperTypeHandlerbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_structConversions_DapperTypeHandlerbyte.verified.txt
@@ -257,7 +257,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_structConversions_DapperTypeHandlerdouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_structConversions_DapperTypeHandlerdouble.verified.txt
@@ -257,7 +257,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_structConversions_DapperTypeHandlerstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_structConversions_DapperTypeHandlerstring.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_structConversions_EfCoreValueConverter@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_structConversions_EfCoreValueConverter@record.@struct.@float.@decimal.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_structConversions_EfCoreValueConverterSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_structConversions_EfCoreValueConverterSystem.Guid.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_structConversions_EfCoreValueConverterbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_structConversions_EfCoreValueConverterbyte.verified.txt
@@ -257,7 +257,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_structConversions_EfCoreValueConverterdouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_structConversions_EfCoreValueConverterdouble.verified.txt
@@ -257,7 +257,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_structConversions_EfCoreValueConverterstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_structConversions_EfCoreValueConverterstring.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_structConversions_LinqToDbValueConverter@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_structConversions_LinqToDbValueConverter@record.@struct.@float.@decimal.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_structConversions_LinqToDbValueConverterSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_structConversions_LinqToDbValueConverterSystem.Guid.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_structConversions_LinqToDbValueConverterbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_structConversions_LinqToDbValueConverterbyte.verified.txt
@@ -257,7 +257,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_structConversions_LinqToDbValueConverterdouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_structConversions_LinqToDbValueConverterdouble.verified.txt
@@ -257,7 +257,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_structConversions_LinqToDbValueConverterstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_structConversions_LinqToDbValueConverterstring.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJson@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJson@record.@struct.@float.@decimal.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.Guid.verified.txt
@@ -217,7 +217,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbyte.verified.txt
@@ -259,7 +259,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondouble.verified.txt
@@ -259,7 +259,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonstring.verified.txt
@@ -133,7 +133,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJson@record.@struct.@float.@decimal.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonSystem.Guid.verified.txt
@@ -216,7 +216,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonbyte.verified.txt
@@ -258,7 +258,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsondouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsondouble.verified.txt
@@ -258,7 +258,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_structConversions_NewtonsoftJsonstring.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_structConversions_None@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_structConversions_None@record.@struct.@float.@decimal.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_structConversions_NoneSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_structConversions_NoneSystem.Guid.verified.txt
@@ -215,7 +215,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_structConversions_Nonebyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_structConversions_Nonebyte.verified.txt
@@ -257,7 +257,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_structConversions_Nonedouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_structConversions_Nonedouble.verified.txt
@@ -257,7 +257,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_structConversions_Nonestring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_structConversions_Nonestring.verified.txt
@@ -131,7 +131,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_structConversions_SystemTextJson@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_structConversions_SystemTextJson@record.@struct.@float.@decimal.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_structConversions_SystemTextJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_structConversions_SystemTextJsonSystem.Guid.verified.txt
@@ -216,7 +216,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_structConversions_SystemTextJsonbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_structConversions_SystemTextJsonbyte.verified.txt
@@ -258,7 +258,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_structConversions_SystemTextJsondouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_structConversions_SystemTextJsondouble.verified.txt
@@ -258,7 +258,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_structConversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_structConversions_SystemTextJsonstring.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_structConversions_TypeConverter@record.@struct.@float.@decimal.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_structConversions_TypeConverter@record.@struct.@float.@decimal.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<@class.record.@struct.@float.decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="@class.@record.@struct.@float.@decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_structConversions_TypeConverterSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_structConversions_TypeConverterSystem.Guid.verified.txt
@@ -216,7 +216,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_structConversions_TypeConverterbyte.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_structConversions_TypeConverterbyte.verified.txt
@@ -258,7 +258,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_structConversions_TypeConverterdouble.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_structConversions_TypeConverterdouble.verified.txt
@@ -258,7 +258,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_structConversions_TypeConverterstring.verified.txt
+++ b/tests/SnapshotTests/Escaping/snapshots/snap-v7.0/escapedTestspublic_readonly_partial_structConversions_TypeConverterstring.verified.txt
@@ -132,7 +132,7 @@ namespace @class
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GeneralStuff/snapshots/snap-v3.1/GeneralTests.Namespace_names_can_have_reserved_keywords.verified.txt
+++ b/tests/SnapshotTests/GeneralStuff/snapshots/snap-v3.1/GeneralTests.Namespace_names_can_have_reserved_keywords.verified.txt
@@ -146,7 +146,7 @@ var validation = @class.validate(value);
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GeneralStuff/snapshots/snap-v3.1/GeneralTests.No_namespace.verified.txt
+++ b/tests/SnapshotTests/GeneralStuff/snapshots/snap-v3.1/GeneralTests.No_namespace.verified.txt
@@ -215,7 +215,7 @@ using Vogen;
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GeneralStuff/snapshots/snap-v3.1/GeneralTests.Partial_struct_created_successfully.verified.txt
+++ b/tests/SnapshotTests/GeneralStuff/snapshots/snap-v3.1/GeneralTests.Partial_struct_created_successfully.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GeneralStuff/snapshots/snap-v3.1/GeneralTests.Produces_instances.verified.txt
+++ b/tests/SnapshotTests/GeneralStuff/snapshots/snap-v3.1/GeneralTests.Produces_instances.verified.txt
@@ -222,7 +222,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GeneralStuff/snapshots/snap-v3.1/GeneralTests.Validation_with_PascalCased_validate_method.verified.txt
+++ b/tests/SnapshotTests/GeneralStuff/snapshots/snap-v3.1/GeneralTests.Validation_with_PascalCased_validate_method.verified.txt
@@ -227,7 +227,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GeneralStuff/snapshots/snap-v3.1/GeneralTests.Validation_with_camelCased_validate_method.verified.txt
+++ b/tests/SnapshotTests/GeneralStuff/snapshots/snap-v3.1/GeneralTests.Validation_with_camelCased_validate_method.verified.txt
@@ -227,7 +227,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GeneralStuff/snapshots/snap-v4.6.1/GeneralTests.Namespace_names_can_have_reserved_keywords.verified.txt
+++ b/tests/SnapshotTests/GeneralStuff/snapshots/snap-v4.6.1/GeneralTests.Namespace_names_can_have_reserved_keywords.verified.txt
@@ -143,7 +143,7 @@ namespace @double
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GeneralStuff/snapshots/snap-v4.6.1/GeneralTests.No_namespace.verified.txt
+++ b/tests/SnapshotTests/GeneralStuff/snapshots/snap-v4.6.1/GeneralTests.No_namespace.verified.txt
@@ -131,7 +131,7 @@ using Vogen;
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GeneralStuff/snapshots/snap-v4.6.1/GeneralTests.Partial_struct_created_successfully.verified.txt
+++ b/tests/SnapshotTests/GeneralStuff/snapshots/snap-v4.6.1/GeneralTests.Partial_struct_created_successfully.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GeneralStuff/snapshots/snap-v4.6.1/GeneralTests.Produces_instances.verified.txt
+++ b/tests/SnapshotTests/GeneralStuff/snapshots/snap-v4.6.1/GeneralTests.Produces_instances.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GeneralStuff/snapshots/snap-v4.6.1/GeneralTests.Validation_with_PascalCased_validate_method.verified.txt
+++ b/tests/SnapshotTests/GeneralStuff/snapshots/snap-v4.6.1/GeneralTests.Validation_with_PascalCased_validate_method.verified.txt
@@ -143,7 +143,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GeneralStuff/snapshots/snap-v4.6.1/GeneralTests.Validation_with_camelCased_validate_method.verified.txt
+++ b/tests/SnapshotTests/GeneralStuff/snapshots/snap-v4.6.1/GeneralTests.Validation_with_camelCased_validate_method.verified.txt
@@ -143,7 +143,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GeneralStuff/snapshots/snap-v4.8/GeneralTests.Namespace_names_can_have_reserved_keywords.verified.txt
+++ b/tests/SnapshotTests/GeneralStuff/snapshots/snap-v4.8/GeneralTests.Namespace_names_can_have_reserved_keywords.verified.txt
@@ -146,7 +146,7 @@ var validation = @class.validate(value);
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GeneralStuff/snapshots/snap-v4.8/GeneralTests.No_namespace.verified.txt
+++ b/tests/SnapshotTests/GeneralStuff/snapshots/snap-v4.8/GeneralTests.No_namespace.verified.txt
@@ -173,7 +173,7 @@ using Vogen;
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GeneralStuff/snapshots/snap-v4.8/GeneralTests.Partial_struct_created_successfully.verified.txt
+++ b/tests/SnapshotTests/GeneralStuff/snapshots/snap-v4.8/GeneralTests.Partial_struct_created_successfully.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GeneralStuff/snapshots/snap-v4.8/GeneralTests.Produces_instances.verified.txt
+++ b/tests/SnapshotTests/GeneralStuff/snapshots/snap-v4.8/GeneralTests.Produces_instances.verified.txt
@@ -180,7 +180,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GeneralStuff/snapshots/snap-v4.8/GeneralTests.Validation_with_PascalCased_validate_method.verified.txt
+++ b/tests/SnapshotTests/GeneralStuff/snapshots/snap-v4.8/GeneralTests.Validation_with_PascalCased_validate_method.verified.txt
@@ -185,7 +185,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GeneralStuff/snapshots/snap-v4.8/GeneralTests.Validation_with_camelCased_validate_method.verified.txt
+++ b/tests/SnapshotTests/GeneralStuff/snapshots/snap-v4.8/GeneralTests.Validation_with_camelCased_validate_method.verified.txt
@@ -185,7 +185,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GeneralStuff/snapshots/snap-v5.0/GeneralTests.Namespace_names_can_have_reserved_keywords.verified.txt
+++ b/tests/SnapshotTests/GeneralStuff/snapshots/snap-v5.0/GeneralTests.Namespace_names_can_have_reserved_keywords.verified.txt
@@ -146,7 +146,7 @@ var validation = @class.validate(value);
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GeneralStuff/snapshots/snap-v5.0/GeneralTests.No_namespace.verified.txt
+++ b/tests/SnapshotTests/GeneralStuff/snapshots/snap-v5.0/GeneralTests.No_namespace.verified.txt
@@ -215,7 +215,7 @@ using Vogen;
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GeneralStuff/snapshots/snap-v5.0/GeneralTests.Partial_struct_created_successfully.verified.txt
+++ b/tests/SnapshotTests/GeneralStuff/snapshots/snap-v5.0/GeneralTests.Partial_struct_created_successfully.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GeneralStuff/snapshots/snap-v5.0/GeneralTests.Produces_instances.verified.txt
+++ b/tests/SnapshotTests/GeneralStuff/snapshots/snap-v5.0/GeneralTests.Produces_instances.verified.txt
@@ -222,7 +222,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GeneralStuff/snapshots/snap-v5.0/GeneralTests.Validation_with_PascalCased_validate_method.verified.txt
+++ b/tests/SnapshotTests/GeneralStuff/snapshots/snap-v5.0/GeneralTests.Validation_with_PascalCased_validate_method.verified.txt
@@ -227,7 +227,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GeneralStuff/snapshots/snap-v5.0/GeneralTests.Validation_with_camelCased_validate_method.verified.txt
+++ b/tests/SnapshotTests/GeneralStuff/snapshots/snap-v5.0/GeneralTests.Validation_with_camelCased_validate_method.verified.txt
@@ -227,7 +227,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GeneralStuff/snapshots/snap-v6.0/GeneralTests.Namespace_names_can_have_reserved_keywords.verified.txt
+++ b/tests/SnapshotTests/GeneralStuff/snapshots/snap-v6.0/GeneralTests.Namespace_names_can_have_reserved_keywords.verified.txt
@@ -146,7 +146,7 @@ var validation = @class.validate(value);
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GeneralStuff/snapshots/snap-v6.0/GeneralTests.No_namespace.verified.txt
+++ b/tests/SnapshotTests/GeneralStuff/snapshots/snap-v6.0/GeneralTests.No_namespace.verified.txt
@@ -215,7 +215,7 @@ using Vogen;
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GeneralStuff/snapshots/snap-v6.0/GeneralTests.Partial_struct_created_successfully.verified.txt
+++ b/tests/SnapshotTests/GeneralStuff/snapshots/snap-v6.0/GeneralTests.Partial_struct_created_successfully.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GeneralStuff/snapshots/snap-v6.0/GeneralTests.Produces_instances.verified.txt
+++ b/tests/SnapshotTests/GeneralStuff/snapshots/snap-v6.0/GeneralTests.Produces_instances.verified.txt
@@ -222,7 +222,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GeneralStuff/snapshots/snap-v6.0/GeneralTests.Validation_with_PascalCased_validate_method.verified.txt
+++ b/tests/SnapshotTests/GeneralStuff/snapshots/snap-v6.0/GeneralTests.Validation_with_PascalCased_validate_method.verified.txt
@@ -227,7 +227,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GeneralStuff/snapshots/snap-v6.0/GeneralTests.Validation_with_camelCased_validate_method.verified.txt
+++ b/tests/SnapshotTests/GeneralStuff/snapshots/snap-v6.0/GeneralTests.Validation_with_camelCased_validate_method.verified.txt
@@ -227,7 +227,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GeneralStuff/snapshots/snap-v7.0/GeneralTests.Namespace_names_can_have_reserved_keywords.verified.txt
+++ b/tests/SnapshotTests/GeneralStuff/snapshots/snap-v7.0/GeneralTests.Namespace_names_can_have_reserved_keywords.verified.txt
@@ -146,7 +146,7 @@ var validation = @class.validate(value);
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GeneralStuff/snapshots/snap-v7.0/GeneralTests.No_namespace.verified.txt
+++ b/tests/SnapshotTests/GeneralStuff/snapshots/snap-v7.0/GeneralTests.No_namespace.verified.txt
@@ -257,7 +257,7 @@ using Vogen;
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GeneralStuff/snapshots/snap-v7.0/GeneralTests.Partial_struct_created_successfully.verified.txt
+++ b/tests/SnapshotTests/GeneralStuff/snapshots/snap-v7.0/GeneralTests.Partial_struct_created_successfully.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GeneralStuff/snapshots/snap-v7.0/GeneralTests.Produces_instances.verified.txt
+++ b/tests/SnapshotTests/GeneralStuff/snapshots/snap-v7.0/GeneralTests.Produces_instances.verified.txt
@@ -264,7 +264,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GeneralStuff/snapshots/snap-v7.0/GeneralTests.Validation_with_PascalCased_validate_method.verified.txt
+++ b/tests/SnapshotTests/GeneralStuff/snapshots/snap-v7.0/GeneralTests.Validation_with_PascalCased_validate_method.verified.txt
@@ -269,7 +269,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GeneralStuff/snapshots/snap-v7.0/GeneralTests.Validation_with_camelCased_validate_method.verified.txt
+++ b/tests/SnapshotTests/GeneralStuff/snapshots/snap-v7.0/GeneralTests.Validation_with_camelCased_validate_method.verified.txt
@@ -269,7 +269,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/06T2RNzfTz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/06T2RNzfTz.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/07aN2OB1qj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/07aN2OB1qj.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/0JTPBSFvcC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/0JTPBSFvcC.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/0McUuUDCYj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/0McUuUDCYj.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/0T3L0HU9F5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/0T3L0HU9F5.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/0UrWNfXMbn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/0UrWNfXMbn.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/0We2g9ZRI1.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/0We2g9ZRI1.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/0crDi3Beji.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/0crDi3Beji.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/0dN19RtMpy.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/0dN19RtMpy.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/0nyPk4lS5G.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/0nyPk4lS5G.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/0sV5NP6Raj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/0sV5NP6Raj.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/0tlxl8JzK2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/0tlxl8JzK2.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/13VaDTQa1F.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/13VaDTQa1F.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/177ObAyjaW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/177ObAyjaW.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/1SIwphdqPw.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/1SIwphdqPw.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/1Wku3If0yF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/1Wku3If0yF.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/1fkLnqEKq5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/1fkLnqEKq5.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/1guqW4QDJq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/1guqW4QDJq.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/1zvL3jc30s.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/1zvL3jc30s.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/2BK4YBngu6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/2BK4YBngu6.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/2DcJnHQ1Wc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/2DcJnHQ1Wc.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/2EmGTjbMHL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/2EmGTjbMHL.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/2bgBJIgdGy.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/2bgBJIgdGy.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/3DKPTxt9nK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/3DKPTxt9nK.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/3K5GXTKPrP.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/3K5GXTKPrP.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/3QFEobjwmC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/3QFEobjwmC.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/3RDZKRFFEV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/3RDZKRFFEV.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/3s0rgujAIg.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/3s0rgujAIg.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/4Ax5wLUa4c.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/4Ax5wLUa4c.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/4EsYZXHdpa.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/4EsYZXHdpa.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/4MA1GGxtB2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/4MA1GGxtB2.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/4TA0dltn8Z.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/4TA0dltn8Z.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/4XwovA4lrF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/4XwovA4lrF.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/4iwufNM5Y6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/4iwufNM5Y6.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/4kQSb8Mpxb.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/4kQSb8Mpxb.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/4knxgNV22P.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/4knxgNV22P.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/4prVlpN79q.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/4prVlpN79q.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/54K50WUaKI.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/54K50WUaKI.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/5E9QwsWPit.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/5E9QwsWPit.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/5JUr6L7hij.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/5JUr6L7hij.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/5WMn1FI8mr.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/5WMn1FI8mr.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/5ejPdcXoEW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/5ejPdcXoEW.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/5h6yFrKLct.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/5h6yFrKLct.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/6ezYN7Hv0Z.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/6ezYN7Hv0Z.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/6l2wTrG0a6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/6l2wTrG0a6.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/6oA6qi8Lpj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/6oA6qi8Lpj.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/6pwxM7x9RG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/6pwxM7x9RG.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/70gJ0d6ueN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/70gJ0d6ueN.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/7NBB4SlixM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/7NBB4SlixM.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/7PDb7B0Y2N.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/7PDb7B0Y2N.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/7Pcw6lts4T.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/7Pcw6lts4T.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/7Xcf56RyAr.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/7Xcf56RyAr.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/7n3s1BSMBo.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/7n3s1BSMBo.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/7s32eactiP.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/7s32eactiP.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/81lR1cSmfJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/81lR1cSmfJ.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/8dnUV6Vg0Y.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/8dnUV6Vg0Y.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/8tTziwEdcI.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/8tTziwEdcI.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/8zROpBby2x.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/8zROpBby2x.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/90J1b35WV8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/90J1b35WV8.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/91wjEMiEX6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/91wjEMiEX6.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/9EdR9Yk7ca.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/9EdR9Yk7ca.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/9RZxZPNxIu.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/9RZxZPNxIu.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/9TOztQhkC4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/9TOztQhkC4.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/9jWBrTk7UB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/9jWBrTk7UB.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/9lMN6zFkKE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/9lMN6zFkKE.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/9s6IGHapL2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/9s6IGHapL2.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/A01FvWmA8l.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/A01FvWmA8l.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/A3USVyZwFP.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/A3USVyZwFP.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/AGJgFoElmB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/AGJgFoElmB.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/AKEOkMAk9E.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/AKEOkMAk9E.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/ALzR9tiyk8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/ALzR9tiyk8.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/AenL9akVZ7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/AenL9akVZ7.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/AutcanQMIS.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/AutcanQMIS.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/B19N6aMdz3.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/B19N6aMdz3.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/B1EGKnhW9e.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/B1EGKnhW9e.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/B1oQQ08HGH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/B1oQQ08HGH.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/B54wYu3oDA.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/B54wYu3oDA.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/BBTptRbtCv.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/BBTptRbtCv.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/BGGCRglxce.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/BGGCRglxce.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/BP8ChaEEsu.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/BP8ChaEEsu.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/BWk4SOKZaL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/BWk4SOKZaL.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/Bj2rdZWLh7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/Bj2rdZWLh7.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/C0qtj9qPDQ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/C0qtj9qPDQ.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/C9re7IuLWT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/C9re7IuLWT.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/CNHSzPEwGH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/CNHSzPEwGH.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/CP3AlJWqrp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/CP3AlJWqrp.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/CWYcYC8app.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/CWYcYC8app.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/Cb3SuEIO21.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/Cb3SuEIO21.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/CoZ4zNyWGC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/CoZ4zNyWGC.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/D1CTthvE4P.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/D1CTthvE4P.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/DFn3iuttpy.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/DFn3iuttpy.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/Dc9KyR2b2p.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/Dc9KyR2b2p.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/Dph3kXOCic.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/Dph3kXOCic.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/Dvpv1gBrUQ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/Dvpv1gBrUQ.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/E4qThSDcnD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/E4qThSDcnD.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/EC4qtMsceH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/EC4qtMsceH.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/ERsIqJPx5L.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/ERsIqJPx5L.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/EZXLjw31Dl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/EZXLjw31Dl.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/EsvI0BL049.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/EsvI0BL049.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/F2Pe3EMY8l.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/F2Pe3EMY8l.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/F5lnyEc8P7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/F5lnyEc8P7.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/FCqK7dSpWU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/FCqK7dSpWU.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/FNBWotecr1.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/FNBWotecr1.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/FV6eIbtnYG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/FV6eIbtnYG.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/FXHmkUJdzB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/FXHmkUJdzB.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/Fn00VgWg5Y.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/Fn00VgWg5Y.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/G2sYQwPkhJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/G2sYQwPkhJ.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/G5mzA5SBhk.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/G5mzA5SBhk.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/GDxA5zEvt0.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/GDxA5zEvt0.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/GXsAoZzuGz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/GXsAoZzuGz.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/GgA3nIlfrr.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/GgA3nIlfrr.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/Gl9QSM0HL9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/Gl9QSM0HL9.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/HWdd0atzlF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/HWdd0atzlF.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/HjAQJGqXYX.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/HjAQJGqXYX.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/HzjTooszyT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/HzjTooszyT.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/I3R2n3iDwp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/I3R2n3iDwp.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/I5jP7AdXUO.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/I5jP7AdXUO.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/I8b2lta2dV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/I8b2lta2dV.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/IFfft0YbVF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/IFfft0YbVF.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/IcZKeRjvKW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/IcZKeRjvKW.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/IiI7gJ520W.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/IiI7gJ520W.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/Ij3DQuVRk7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/Ij3DQuVRk7.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/IuHoP54Wlc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/IuHoP54Wlc.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/IwYqIz3EHD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/IwYqIz3EHD.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/J0cKBlje4u.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/J0cKBlje4u.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/J1zbYLAkpc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/J1zbYLAkpc.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/J6HXfDOVhX.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/J6HXfDOVhX.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/JH4VhArCNR.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/JH4VhArCNR.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/JXkrGa9mJm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/JXkrGa9mJm.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/JjTVAGnAQr.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/JjTVAGnAQr.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/JptCVz4qEd.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/JptCVz4qEd.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/JtusM5o9mV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/JtusM5o9mV.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/K8foSEhEd6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/K8foSEhEd6.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/KCFf7gu3Y4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/KCFf7gu3Y4.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/KRrQYpA7NN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/KRrQYpA7NN.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/KkW0XInSXe.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/KkW0XInSXe.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/KmUJvvIFQM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/KmUJvvIFQM.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/KwZarRNYrG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/KwZarRNYrG.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/L2R0Fdeoqj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/L2R0Fdeoqj.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/L6Togn7pnd.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/L6Togn7pnd.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/LGFBsMx1Ue.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/LGFBsMx1Ue.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/LKPjaqZzne.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/LKPjaqZzne.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/LTwPCkotqR.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/LTwPCkotqR.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/LlojbpWjs9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/LlojbpWjs9.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/LnGkF3PV4B.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/LnGkF3PV4B.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/Lw6juAfLhZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/Lw6juAfLhZ.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/M2wCQaSIkx.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/M2wCQaSIkx.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/M7p8sbE3VI.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/M7p8sbE3VI.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/MAaNEFkxNx.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/MAaNEFkxNx.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/MN57efcLju.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/MN57efcLju.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/MTonphGglM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/MTonphGglM.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/MWxYsdcQAm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/MWxYsdcQAm.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/MiEtLwCnzM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/MiEtLwCnzM.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/Mm2925bgtf.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/Mm2925bgtf.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/MnCQlmeEpx.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/MnCQlmeEpx.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/Mnn3wVQyPT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/Mnn3wVQyPT.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/MwWzEyFzMN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/MwWzEyFzMN.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/N3qbcpPajg.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/N3qbcpPajg.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/NBM2jrtjUt.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/NBM2jrtjUt.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/NDycAe2PMg.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/NDycAe2PMg.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/NVaQ8JUMmp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/NVaQ8JUMmp.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/NauzwofxwH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/NauzwofxwH.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/Ngx37kpASZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/Ngx37kpASZ.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/NhzifMsgk2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/NhzifMsgk2.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/NpGzSptAcC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/NpGzSptAcC.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/NpRS0S6JWC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/NpRS0S6JWC.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/NqADIATboI.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/NqADIATboI.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/NwHv5RB2rz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/NwHv5RB2rz.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/O953QNNUI0.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/O953QNNUI0.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/OCchs83O6Y.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/OCchs83O6Y.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/OGxNUCIKC2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/OGxNUCIKC2.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/OJyyKz5GVv.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/OJyyKz5GVv.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/OMOINSyhgb.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/OMOINSyhgb.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/ON96VWl2eE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/ON96VWl2eE.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/OYhonKADC9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/OYhonKADC9.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/OZwHXjKDnl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/OZwHXjKDnl.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/OdEuAfadOv.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/OdEuAfadOv.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/OxyGJylIwW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/OxyGJylIwW.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/PHurkwqv4Z.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/PHurkwqv4Z.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/PXNopPwCXl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/PXNopPwCXl.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/QArvYA1I5y.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/QArvYA1I5y.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/QKdvStkUZD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/QKdvStkUZD.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/QkWxbTjqEQ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/QkWxbTjqEQ.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/QoD4gdBKht.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/QoD4gdBKht.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/QxOTHR8Vr5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/QxOTHR8Vr5.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/R4BCKWzeKK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/R4BCKWzeKK.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/RBTWh9W2wN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/RBTWh9W2wN.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/RSdIxOjWTU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/RSdIxOjWTU.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/RVXzOJsITX.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/RVXzOJsITX.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/RVsXeoSc9F.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/RVsXeoSc9F.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/RWTGsJXzQz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/RWTGsJXzQz.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/RYuyMUd2gk.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/RYuyMUd2gk.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/RpX90PHiU0.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/RpX90PHiU0.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/RvpGNGwBDO.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/RvpGNGwBDO.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/RykGa318Dx.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/RykGa318Dx.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/S4670YUK50.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/S4670YUK50.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/S6gLS26ZJ4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/S6gLS26ZJ4.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/S9LbD4Pr4R.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/S9LbD4Pr4R.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/SAOrYUiv3f.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/SAOrYUiv3f.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/SCkYQvq0A9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/SCkYQvq0A9.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/SDPXeHAEsY.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/SDPXeHAEsY.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/SFVT3QJAYW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/SFVT3QJAYW.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/SNuFk4PnW2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/SNuFk4PnW2.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/ShzxZhno8O.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/ShzxZhno8O.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/SnDPKIXHDi.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/SnDPKIXHDi.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/SzCgZ3qNN5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/SzCgZ3qNN5.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/T520ZP6L8T.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/T520ZP6L8T.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/TJTFd5hAYj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/TJTFd5hAYj.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/TRuTR85WZK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/TRuTR85WZK.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/TgwFqiQRdp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/TgwFqiQRdp.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/Tj8JfMPQOP.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/Tj8JfMPQOP.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/TrSKsrbw64.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/TrSKsrbw64.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/TtsQu77nNc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/TtsQu77nNc.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/U5ugQslU2z.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/U5ugQslU2z.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/UP8fkuONg2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/UP8fkuONg2.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/UQd9WJKHHq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/UQd9WJKHHq.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/UdYGjLjpzk.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/UdYGjLjpzk.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/UeKNqkUYqr.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/UeKNqkUYqr.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/UfKa2OpfYT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/UfKa2OpfYT.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/UmSdXFQzs5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/UmSdXFQzs5.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/Uwk8g9mKl8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/Uwk8g9mKl8.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/V39a2Wfhny.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/V39a2Wfhny.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/V6Alb9zB67.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/V6Alb9zB67.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/VBCxRuQlyS.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/VBCxRuQlyS.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/VCeH9ZweWA.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/VCeH9ZweWA.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/VLXVn8J66H.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/VLXVn8J66H.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/VWVKSidnGZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/VWVKSidnGZ.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/VYon30GsHO.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/VYon30GsHO.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/Vdgc0ZvuWs.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/Vdgc0ZvuWs.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/VfmDAdXzKM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/VfmDAdXzKM.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/VhYMLsMLrL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/VhYMLsMLrL.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/VxqkIhG88M.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/VxqkIhG88M.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/W5bnoMpunF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/W5bnoMpunF.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/WOpGodfIa8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/WOpGodfIa8.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/WVz16ttXmN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/WVz16ttXmN.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/WZDWUF8ibK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/WZDWUF8ibK.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/X5FuWfVgX6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/X5FuWfVgX6.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/XLacQhFM5v.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/XLacQhFM5v.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/XOK5FCR5BV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/XOK5FCR5BV.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/XSCVXLUIBn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/XSCVXLUIBn.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/XpelL4dfYJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/XpelL4dfYJ.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/Y0nmeL8Mk6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/Y0nmeL8Mk6.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/Y3mvjkMqPV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/Y3mvjkMqPV.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/Y5EXqXazv8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/Y5EXqXazv8.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/YGlCkfra9u.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/YGlCkfra9u.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/YHnNk2wz6l.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/YHnNk2wz6l.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/YJDISUV0P9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/YJDISUV0P9.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/YNZk56sw8a.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/YNZk56sw8a.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/YSjosSoyxD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/YSjosSoyxD.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/YYPqiV1dMh.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/YYPqiV1dMh.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/YcFI3Qezx8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/YcFI3Qezx8.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/Z7wOsOEcI7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/Z7wOsOEcI7.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/ZEkMAMmFrT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/ZEkMAMmFrT.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/ZHV48dd3xb.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/ZHV48dd3xb.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/ZPpTfz3cuC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/ZPpTfz3cuC.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/ZSKbzDVpdh.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/ZSKbzDVpdh.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/ZV0dzO1N3D.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/ZV0dzO1N3D.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/ZfCQZQ3Yi4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/ZfCQZQ3Yi4.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/ZgH9SeepAW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/ZgH9SeepAW.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/Zzt021tkHA.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/Zzt021tkHA.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/a1DiihgGoN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/a1DiihgGoN.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/aAzECToODG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/aAzECToODG.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/acAvcgb9wR.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/acAvcgb9wR.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/al6GdI6HHq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/al6GdI6HHq.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/b6lOjv1QB9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/b6lOjv1QB9.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/bCdroQZubL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/bCdroQZubL.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/bGXLKzz8DB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/bGXLKzz8DB.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/bOJODCt4Nj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/bOJODCt4Nj.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/bZMWPiINDJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/bZMWPiINDJ.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/bcY4kDXEiL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/bcY4kDXEiL.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/c6ixLi9Yns.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/c6ixLi9Yns.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/cC1vOfH1YD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/cC1vOfH1YD.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/cKgcqJQFSi.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/cKgcqJQFSi.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/cM7YAi3zbW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/cM7YAi3zbW.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/cZb1hdO5AT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/cZb1hdO5AT.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/cjKn08z80L.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/cjKn08z80L.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/cnoFERqEX9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/cnoFERqEX9.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/dBQTDFizrM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/dBQTDFizrM.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/dBXjMyQ6v5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/dBXjMyQ6v5.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/dQcYTBwxmD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/dQcYTBwxmD.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/dVvABT62C9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/dVvABT62C9.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/e3r8e0DiFz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/e3r8e0DiFz.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/eFsp09gaZX.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/eFsp09gaZX.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/eKleS2KN9V.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/eKleS2KN9V.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/eSoalgVCBH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/eSoalgVCBH.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/eVz6pfc2Aq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/eVz6pfc2Aq.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/eYtwlKx3DL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/eYtwlKx3DL.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/ecmluorkUs.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/ecmluorkUs.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/encSaFhW3u.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/encSaFhW3u.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/fEVDUjY0o4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/fEVDUjY0o4.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/fNBZi3EAxz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/fNBZi3EAxz.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/fQ6iyzZG4E.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/fQ6iyzZG4E.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/fkSI356192.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/fkSI356192.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/fqaD1J6KEH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/fqaD1J6KEH.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/fsCqVRe2XV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/fsCqVRe2XV.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/g32LIqIkv7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/g32LIqIkv7.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/g7NcHJ0Dqm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/g7NcHJ0Dqm.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/gKDRuR0huT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/gKDRuR0huT.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/gjl4ArLhJm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/gjl4ArLhJm.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/gvU8LsfGOx.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/gvU8LsfGOx.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/h9Y4PiPY6w.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/h9Y4PiPY6w.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/hchuG3s1rY.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/hchuG3s1rY.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/hnhVAIsmxU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/hnhVAIsmxU.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/hqtR9072e5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/hqtR9072e5.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/i53vKZdcnE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/i53vKZdcnE.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/iBn3UOpKdu.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/iBn3UOpKdu.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/iI6pw0QLBV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/iI6pw0QLBV.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/iQAGO67miB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/iQAGO67miB.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/iTg6zX0H2i.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/iTg6zX0H2i.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/iq57t3NYGm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/iq57t3NYGm.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/ixUQwlLoQl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/ixUQwlLoQl.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/ixp5a4MCzH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/ixp5a4MCzH.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/izrpe1H39g.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/izrpe1H39g.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/j0gOb12WG7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/j0gOb12WG7.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/j41I8z5Dbm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/j41I8z5Dbm.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/j9KVlh9Elu.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/j9KVlh9Elu.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/jEPN6e30lK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/jEPN6e30lK.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/jHoO30hDWC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/jHoO30hDWC.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/jOEODojhaI.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/jOEODojhaI.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/jSdYYlxIPu.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/jSdYYlxIPu.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/kDrpkD1xK6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/kDrpkD1xK6.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/kODlOvWLVJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/kODlOvWLVJ.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/koWMEughuG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/koWMEughuG.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/kpmo31UbcA.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/kpmo31UbcA.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/kuu79cE7XV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/kuu79cE7XV.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/ky7lfFDW6q.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/ky7lfFDW6q.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/kyEHvPp7Gk.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/kyEHvPp7Gk.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/lOk975L1YB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/lOk975L1YB.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/lW11AhH3pd.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/lW11AhH3pd.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/llHMuoBQb8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/llHMuoBQb8.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/m8AHxnkobT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/m8AHxnkobT.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/mBub665Sw1.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/mBub665Sw1.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/mKU2FtqWwc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/mKU2FtqWwc.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/mN75YcjhNl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/mN75YcjhNl.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/mhhBA6GJJy.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/mhhBA6GJJy.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/nE3Qa1apaH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/nE3Qa1apaH.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/nT8J5haK6F.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/nT8J5haK6F.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/nUWnom5eaz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/nUWnom5eaz.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/nY4f0rBQfZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/nY4f0rBQfZ.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/nenm6c9K9H.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/nenm6c9K9H.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/nrmmmwvAB3.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/nrmmmwvAB3.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/nzdiNgzpBk.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/nzdiNgzpBk.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/oEmtybut45.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/oEmtybut45.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/oV4NuQJ94t.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/oV4NuQJ94t.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/oklahTMTmf.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/oklahTMTmf.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/ors0bDh2bc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/ors0bDh2bc.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/pc50J7VwEQ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/pc50J7VwEQ.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/pqukhkAth1.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/pqukhkAth1.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/q5p595DJ6Q.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/q5p595DJ6Q.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/qE0fojpqnw.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/qE0fojpqnw.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/qGpRbiQ2ae.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/qGpRbiQ2ae.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/qoLqfVeYjg.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/qoLqfVeYjg.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/qxfXnYfFUG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/qxfXnYfFUG.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/r8w1v3Z6lL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/r8w1v3Z6lL.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/rMw8A9V28h.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/rMw8A9V28h.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/rZI5VmbmH8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/rZI5VmbmH8.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/rdy3COwDJ8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/rdy3COwDJ8.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/rlmBhex75r.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/rlmBhex75r.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/rn7ZDhqfGn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/rn7ZDhqfGn.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/rse9BAjK8p.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/rse9BAjK8p.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/rxLnaPSdKY.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/rxLnaPSdKY.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/sDb6wxVAlp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/sDb6wxVAlp.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/sHN8Z0s7Zl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/sHN8Z0s7Zl.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/sIk16HKXOH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/sIk16HKXOH.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/sfXrv8XKuT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/sfXrv8XKuT.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/spAP90Xdxo.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/spAP90Xdxo.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/t2LfLuggKw.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/t2LfLuggKw.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/t6anM049gM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/t6anM049gM.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/t6b9ipJFco.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/t6b9ipJFco.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/t88runt2vt.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/t88runt2vt.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/t96N3ukmC2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/t96N3ukmC2.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/tFHSIUZTRU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/tFHSIUZTRU.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/tOBEeyrzR5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/tOBEeyrzR5.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/tqmxPtSV5e.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/tqmxPtSV5e.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/ttgDLEo0YY.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/ttgDLEo0YY.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/tyDsoFs45y.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/tyDsoFs45y.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/tyrqHRTjct.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/tyrqHRTjct.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/uMrfngv4qE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/uMrfngv4qE.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/ufp5xt5UlZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/ufp5xt5UlZ.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/ukDSDTeRKn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/ukDSDTeRKn.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/vAhi6T2iCs.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/vAhi6T2iCs.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/vDddl4MmlU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/vDddl4MmlU.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/vLwvkrUp8m.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/vLwvkrUp8m.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/vO7uWdob4g.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/vO7uWdob4g.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/vUjLCf2llh.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/vUjLCf2llh.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/vdOsQV2zZZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/vdOsQV2zZZ.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/vqoyQGzxwZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/vqoyQGzxwZ.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/vuum3mHSut.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/vuum3mHSut.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/wff7vOGYXM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/wff7vOGYXM.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/wkgn6vRUUp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/wkgn6vRUUp.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/wmDBp8f0Z2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/wmDBp8f0Z2.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/woqch6WNMH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/woqch6WNMH.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/x1AVtHbq4f.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/x1AVtHbq4f.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/xEOJNLq3je.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/xEOJNLq3je.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/xM6CnVshaE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/xM6CnVshaE.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/xOe1maF1HZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/xOe1maF1HZ.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/xVFVQAk3u3.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/xVFVQAk3u3.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/xWEhNnxjgn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/xWEhNnxjgn.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/xmhnIZPlm0.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/xmhnIZPlm0.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/xqXMSXBMl8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/xqXMSXBMl8.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/xqemv5BeQH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/xqemv5BeQH.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/y8Wf7aTXFb.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/y8Wf7aTXFb.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/yCWOaOd0DH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/yCWOaOd0DH.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/yI34mPjVtK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/yI34mPjVtK.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/yQu5xEnWkt.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/yQu5xEnWkt.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/yVvQYsdxaq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/yVvQYsdxaq.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/yaMxpb9T34.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/yaMxpb9T34.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/ygTzDOCr3r.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/ygTzDOCr3r.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/z4XWuGECC2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/z4XWuGECC2.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/z9nNYIgtFz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/z9nNYIgtFz.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/zFiwaVTd6p.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/zFiwaVTd6p.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/zI6QHiNniJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/zI6QHiNniJ.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/zVrQLGqXwe.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/zVrQLGqXwe.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/zYVWOnWkq4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/zYVWOnWkq4.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/zZ91YoJG9X.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/zZ91YoJG9X.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/zuxZ6Tg1Ha.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-fr/zuxZ6Tg1Ha.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/06T2RNzfTz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/06T2RNzfTz.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/07aN2OB1qj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/07aN2OB1qj.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/0JTPBSFvcC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/0JTPBSFvcC.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/0McUuUDCYj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/0McUuUDCYj.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/0T3L0HU9F5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/0T3L0HU9F5.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/0UrWNfXMbn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/0UrWNfXMbn.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/0We2g9ZRI1.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/0We2g9ZRI1.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/0crDi3Beji.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/0crDi3Beji.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/0dN19RtMpy.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/0dN19RtMpy.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/0nyPk4lS5G.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/0nyPk4lS5G.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/0sV5NP6Raj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/0sV5NP6Raj.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/0tlxl8JzK2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/0tlxl8JzK2.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/13VaDTQa1F.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/13VaDTQa1F.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/177ObAyjaW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/177ObAyjaW.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/1SIwphdqPw.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/1SIwphdqPw.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/1Wku3If0yF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/1Wku3If0yF.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/1fkLnqEKq5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/1fkLnqEKq5.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/1guqW4QDJq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/1guqW4QDJq.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/1zvL3jc30s.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/1zvL3jc30s.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/2BK4YBngu6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/2BK4YBngu6.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/2DcJnHQ1Wc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/2DcJnHQ1Wc.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/2EmGTjbMHL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/2EmGTjbMHL.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/2bgBJIgdGy.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/2bgBJIgdGy.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/3DKPTxt9nK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/3DKPTxt9nK.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/3K5GXTKPrP.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/3K5GXTKPrP.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/3QFEobjwmC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/3QFEobjwmC.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/3RDZKRFFEV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/3RDZKRFFEV.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/3s0rgujAIg.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/3s0rgujAIg.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/4Ax5wLUa4c.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/4Ax5wLUa4c.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/4EsYZXHdpa.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/4EsYZXHdpa.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/4MA1GGxtB2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/4MA1GGxtB2.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/4TA0dltn8Z.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/4TA0dltn8Z.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/4XwovA4lrF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/4XwovA4lrF.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/4iwufNM5Y6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/4iwufNM5Y6.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/4kQSb8Mpxb.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/4kQSb8Mpxb.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/4knxgNV22P.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/4knxgNV22P.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/4prVlpN79q.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/4prVlpN79q.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/54K50WUaKI.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/54K50WUaKI.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/5E9QwsWPit.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/5E9QwsWPit.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/5JUr6L7hij.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/5JUr6L7hij.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/5WMn1FI8mr.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/5WMn1FI8mr.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/5ejPdcXoEW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/5ejPdcXoEW.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/5h6yFrKLct.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/5h6yFrKLct.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/6ezYN7Hv0Z.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/6ezYN7Hv0Z.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/6l2wTrG0a6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/6l2wTrG0a6.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/6oA6qi8Lpj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/6oA6qi8Lpj.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/6pwxM7x9RG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/6pwxM7x9RG.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/70gJ0d6ueN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/70gJ0d6ueN.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/7NBB4SlixM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/7NBB4SlixM.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/7PDb7B0Y2N.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/7PDb7B0Y2N.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/7Pcw6lts4T.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/7Pcw6lts4T.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/7Xcf56RyAr.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/7Xcf56RyAr.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/7n3s1BSMBo.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/7n3s1BSMBo.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/7s32eactiP.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/7s32eactiP.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/81lR1cSmfJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/81lR1cSmfJ.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/8dnUV6Vg0Y.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/8dnUV6Vg0Y.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/8tTziwEdcI.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/8tTziwEdcI.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/8zROpBby2x.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/8zROpBby2x.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/90J1b35WV8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/90J1b35WV8.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/91wjEMiEX6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/91wjEMiEX6.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/9EdR9Yk7ca.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/9EdR9Yk7ca.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/9RZxZPNxIu.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/9RZxZPNxIu.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/9TOztQhkC4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/9TOztQhkC4.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/9jWBrTk7UB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/9jWBrTk7UB.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/9lMN6zFkKE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/9lMN6zFkKE.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/9s6IGHapL2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/9s6IGHapL2.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/A01FvWmA8l.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/A01FvWmA8l.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/A3USVyZwFP.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/A3USVyZwFP.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/AGJgFoElmB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/AGJgFoElmB.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/AKEOkMAk9E.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/AKEOkMAk9E.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/ALzR9tiyk8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/ALzR9tiyk8.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/AenL9akVZ7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/AenL9akVZ7.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/AutcanQMIS.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/AutcanQMIS.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/B19N6aMdz3.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/B19N6aMdz3.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/B1EGKnhW9e.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/B1EGKnhW9e.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/B1oQQ08HGH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/B1oQQ08HGH.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/B54wYu3oDA.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/B54wYu3oDA.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/BBTptRbtCv.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/BBTptRbtCv.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/BGGCRglxce.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/BGGCRglxce.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/BP8ChaEEsu.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/BP8ChaEEsu.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/BWk4SOKZaL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/BWk4SOKZaL.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/Bj2rdZWLh7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/Bj2rdZWLh7.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/C0qtj9qPDQ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/C0qtj9qPDQ.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/C9re7IuLWT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/C9re7IuLWT.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/CNHSzPEwGH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/CNHSzPEwGH.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/CP3AlJWqrp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/CP3AlJWqrp.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/CWYcYC8app.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/CWYcYC8app.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/Cb3SuEIO21.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/Cb3SuEIO21.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/CoZ4zNyWGC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/CoZ4zNyWGC.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/D1CTthvE4P.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/D1CTthvE4P.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/DFn3iuttpy.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/DFn3iuttpy.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/Dc9KyR2b2p.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/Dc9KyR2b2p.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/Dph3kXOCic.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/Dph3kXOCic.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/Dvpv1gBrUQ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/Dvpv1gBrUQ.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/E4qThSDcnD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/E4qThSDcnD.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/EC4qtMsceH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/EC4qtMsceH.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/ERsIqJPx5L.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/ERsIqJPx5L.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/EZXLjw31Dl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/EZXLjw31Dl.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/EsvI0BL049.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/EsvI0BL049.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/F2Pe3EMY8l.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/F2Pe3EMY8l.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/F5lnyEc8P7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/F5lnyEc8P7.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/FCqK7dSpWU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/FCqK7dSpWU.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/FNBWotecr1.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/FNBWotecr1.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/FV6eIbtnYG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/FV6eIbtnYG.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/FXHmkUJdzB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/FXHmkUJdzB.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/Fn00VgWg5Y.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/Fn00VgWg5Y.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/G2sYQwPkhJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/G2sYQwPkhJ.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/G5mzA5SBhk.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/G5mzA5SBhk.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/GDxA5zEvt0.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/GDxA5zEvt0.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/GXsAoZzuGz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/GXsAoZzuGz.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/GgA3nIlfrr.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/GgA3nIlfrr.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/Gl9QSM0HL9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/Gl9QSM0HL9.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/HWdd0atzlF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/HWdd0atzlF.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/HjAQJGqXYX.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/HjAQJGqXYX.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/HzjTooszyT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/HzjTooszyT.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/I3R2n3iDwp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/I3R2n3iDwp.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/I5jP7AdXUO.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/I5jP7AdXUO.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/I8b2lta2dV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/I8b2lta2dV.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/IFfft0YbVF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/IFfft0YbVF.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/IcZKeRjvKW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/IcZKeRjvKW.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/IiI7gJ520W.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/IiI7gJ520W.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/Ij3DQuVRk7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/Ij3DQuVRk7.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/IuHoP54Wlc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/IuHoP54Wlc.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/IwYqIz3EHD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/IwYqIz3EHD.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/J0cKBlje4u.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/J0cKBlje4u.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/J1zbYLAkpc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/J1zbYLAkpc.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/J6HXfDOVhX.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/J6HXfDOVhX.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/JH4VhArCNR.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/JH4VhArCNR.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/JXkrGa9mJm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/JXkrGa9mJm.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/JjTVAGnAQr.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/JjTVAGnAQr.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/JptCVz4qEd.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/JptCVz4qEd.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/JtusM5o9mV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/JtusM5o9mV.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/K8foSEhEd6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/K8foSEhEd6.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/KCFf7gu3Y4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/KCFf7gu3Y4.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/KRrQYpA7NN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/KRrQYpA7NN.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/KkW0XInSXe.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/KkW0XInSXe.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/KmUJvvIFQM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/KmUJvvIFQM.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/KwZarRNYrG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/KwZarRNYrG.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/L2R0Fdeoqj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/L2R0Fdeoqj.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/L6Togn7pnd.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/L6Togn7pnd.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/LGFBsMx1Ue.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/LGFBsMx1Ue.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/LKPjaqZzne.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/LKPjaqZzne.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/LTwPCkotqR.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/LTwPCkotqR.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/LlojbpWjs9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/LlojbpWjs9.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/LnGkF3PV4B.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/LnGkF3PV4B.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/Lw6juAfLhZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/Lw6juAfLhZ.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/M2wCQaSIkx.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/M2wCQaSIkx.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/M7p8sbE3VI.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/M7p8sbE3VI.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/MAaNEFkxNx.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/MAaNEFkxNx.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/MN57efcLju.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/MN57efcLju.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/MTonphGglM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/MTonphGglM.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/MWxYsdcQAm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/MWxYsdcQAm.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/MiEtLwCnzM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/MiEtLwCnzM.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/Mm2925bgtf.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/Mm2925bgtf.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/MnCQlmeEpx.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/MnCQlmeEpx.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/Mnn3wVQyPT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/Mnn3wVQyPT.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/MwWzEyFzMN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/MwWzEyFzMN.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/N3qbcpPajg.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/N3qbcpPajg.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/NBM2jrtjUt.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/NBM2jrtjUt.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/NDycAe2PMg.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/NDycAe2PMg.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/NVaQ8JUMmp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/NVaQ8JUMmp.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/NauzwofxwH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/NauzwofxwH.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/Ngx37kpASZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/Ngx37kpASZ.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/NhzifMsgk2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/NhzifMsgk2.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/NpGzSptAcC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/NpGzSptAcC.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/NpRS0S6JWC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/NpRS0S6JWC.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/NqADIATboI.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/NqADIATboI.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/NwHv5RB2rz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/NwHv5RB2rz.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/O953QNNUI0.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/O953QNNUI0.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/OCchs83O6Y.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/OCchs83O6Y.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/OGxNUCIKC2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/OGxNUCIKC2.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/OJyyKz5GVv.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/OJyyKz5GVv.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/OMOINSyhgb.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/OMOINSyhgb.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/ON96VWl2eE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/ON96VWl2eE.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/OYhonKADC9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/OYhonKADC9.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/OZwHXjKDnl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/OZwHXjKDnl.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/OdEuAfadOv.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/OdEuAfadOv.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/OxyGJylIwW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/OxyGJylIwW.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/PHurkwqv4Z.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/PHurkwqv4Z.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/PXNopPwCXl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/PXNopPwCXl.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/QArvYA1I5y.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/QArvYA1I5y.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/QKdvStkUZD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/QKdvStkUZD.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/QkWxbTjqEQ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/QkWxbTjqEQ.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/QoD4gdBKht.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/QoD4gdBKht.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/QxOTHR8Vr5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/QxOTHR8Vr5.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/R4BCKWzeKK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/R4BCKWzeKK.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/RBTWh9W2wN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/RBTWh9W2wN.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/RSdIxOjWTU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/RSdIxOjWTU.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/RVXzOJsITX.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/RVXzOJsITX.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/RVsXeoSc9F.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/RVsXeoSc9F.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/RWTGsJXzQz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/RWTGsJXzQz.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/RYuyMUd2gk.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/RYuyMUd2gk.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/RpX90PHiU0.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/RpX90PHiU0.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/RvpGNGwBDO.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/RvpGNGwBDO.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/RykGa318Dx.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/RykGa318Dx.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/S4670YUK50.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/S4670YUK50.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/S6gLS26ZJ4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/S6gLS26ZJ4.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/S9LbD4Pr4R.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/S9LbD4Pr4R.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/SAOrYUiv3f.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/SAOrYUiv3f.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/SCkYQvq0A9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/SCkYQvq0A9.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/SDPXeHAEsY.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/SDPXeHAEsY.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/SFVT3QJAYW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/SFVT3QJAYW.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/SNuFk4PnW2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/SNuFk4PnW2.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/ShzxZhno8O.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/ShzxZhno8O.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/SnDPKIXHDi.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/SnDPKIXHDi.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/SzCgZ3qNN5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/SzCgZ3qNN5.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/T520ZP6L8T.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/T520ZP6L8T.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/TJTFd5hAYj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/TJTFd5hAYj.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/TRuTR85WZK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/TRuTR85WZK.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/TgwFqiQRdp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/TgwFqiQRdp.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/Tj8JfMPQOP.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/Tj8JfMPQOP.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/TrSKsrbw64.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/TrSKsrbw64.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/TtsQu77nNc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/TtsQu77nNc.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/U5ugQslU2z.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/U5ugQslU2z.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/UP8fkuONg2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/UP8fkuONg2.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/UQd9WJKHHq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/UQd9WJKHHq.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/UdYGjLjpzk.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/UdYGjLjpzk.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/UeKNqkUYqr.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/UeKNqkUYqr.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/UfKa2OpfYT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/UfKa2OpfYT.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/UmSdXFQzs5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/UmSdXFQzs5.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/Uwk8g9mKl8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/Uwk8g9mKl8.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/V39a2Wfhny.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/V39a2Wfhny.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/V6Alb9zB67.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/V6Alb9zB67.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/VBCxRuQlyS.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/VBCxRuQlyS.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/VCeH9ZweWA.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/VCeH9ZweWA.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/VLXVn8J66H.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/VLXVn8J66H.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/VWVKSidnGZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/VWVKSidnGZ.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/VYon30GsHO.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/VYon30GsHO.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/Vdgc0ZvuWs.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/Vdgc0ZvuWs.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/VfmDAdXzKM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/VfmDAdXzKM.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/VhYMLsMLrL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/VhYMLsMLrL.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/VxqkIhG88M.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/VxqkIhG88M.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/W5bnoMpunF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/W5bnoMpunF.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/WOpGodfIa8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/WOpGodfIa8.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/WVz16ttXmN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/WVz16ttXmN.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/WZDWUF8ibK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/WZDWUF8ibK.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/X5FuWfVgX6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/X5FuWfVgX6.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/XLacQhFM5v.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/XLacQhFM5v.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/XOK5FCR5BV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/XOK5FCR5BV.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/XSCVXLUIBn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/XSCVXLUIBn.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/XpelL4dfYJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/XpelL4dfYJ.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/Y0nmeL8Mk6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/Y0nmeL8Mk6.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/Y3mvjkMqPV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/Y3mvjkMqPV.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/Y5EXqXazv8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/Y5EXqXazv8.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/YGlCkfra9u.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/YGlCkfra9u.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/YHnNk2wz6l.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/YHnNk2wz6l.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/YJDISUV0P9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/YJDISUV0P9.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/YNZk56sw8a.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/YNZk56sw8a.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/YSjosSoyxD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/YSjosSoyxD.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/YYPqiV1dMh.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/YYPqiV1dMh.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/YcFI3Qezx8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/YcFI3Qezx8.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/Z7wOsOEcI7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/Z7wOsOEcI7.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/ZEkMAMmFrT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/ZEkMAMmFrT.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/ZHV48dd3xb.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/ZHV48dd3xb.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/ZPpTfz3cuC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/ZPpTfz3cuC.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/ZSKbzDVpdh.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/ZSKbzDVpdh.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/ZV0dzO1N3D.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/ZV0dzO1N3D.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/ZfCQZQ3Yi4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/ZfCQZQ3Yi4.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/ZgH9SeepAW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/ZgH9SeepAW.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/Zzt021tkHA.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/Zzt021tkHA.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/a1DiihgGoN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/a1DiihgGoN.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/aAzECToODG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/aAzECToODG.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/acAvcgb9wR.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/acAvcgb9wR.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/al6GdI6HHq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/al6GdI6HHq.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/b6lOjv1QB9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/b6lOjv1QB9.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/bCdroQZubL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/bCdroQZubL.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/bGXLKzz8DB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/bGXLKzz8DB.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/bOJODCt4Nj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/bOJODCt4Nj.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/bZMWPiINDJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/bZMWPiINDJ.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/bcY4kDXEiL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/bcY4kDXEiL.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/c6ixLi9Yns.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/c6ixLi9Yns.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/cC1vOfH1YD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/cC1vOfH1YD.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/cKgcqJQFSi.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/cKgcqJQFSi.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/cM7YAi3zbW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/cM7YAi3zbW.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/cZb1hdO5AT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/cZb1hdO5AT.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/cjKn08z80L.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/cjKn08z80L.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/cnoFERqEX9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/cnoFERqEX9.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/dBQTDFizrM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/dBQTDFizrM.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/dBXjMyQ6v5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/dBXjMyQ6v5.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/dQcYTBwxmD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/dQcYTBwxmD.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/dVvABT62C9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/dVvABT62C9.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/e3r8e0DiFz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/e3r8e0DiFz.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/eFsp09gaZX.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/eFsp09gaZX.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/eKleS2KN9V.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/eKleS2KN9V.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/eSoalgVCBH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/eSoalgVCBH.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/eVz6pfc2Aq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/eVz6pfc2Aq.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/eYtwlKx3DL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/eYtwlKx3DL.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/ecmluorkUs.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/ecmluorkUs.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/encSaFhW3u.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/encSaFhW3u.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/fEVDUjY0o4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/fEVDUjY0o4.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/fNBZi3EAxz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/fNBZi3EAxz.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/fQ6iyzZG4E.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/fQ6iyzZG4E.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/fkSI356192.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/fkSI356192.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/fqaD1J6KEH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/fqaD1J6KEH.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/fsCqVRe2XV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/fsCqVRe2XV.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/g32LIqIkv7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/g32LIqIkv7.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/g7NcHJ0Dqm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/g7NcHJ0Dqm.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/gKDRuR0huT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/gKDRuR0huT.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/gjl4ArLhJm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/gjl4ArLhJm.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/gvU8LsfGOx.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/gvU8LsfGOx.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/h9Y4PiPY6w.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/h9Y4PiPY6w.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/hchuG3s1rY.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/hchuG3s1rY.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/hnhVAIsmxU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/hnhVAIsmxU.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/hqtR9072e5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/hqtR9072e5.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/i53vKZdcnE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/i53vKZdcnE.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/iBn3UOpKdu.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/iBn3UOpKdu.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/iI6pw0QLBV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/iI6pw0QLBV.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/iQAGO67miB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/iQAGO67miB.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/iTg6zX0H2i.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/iTg6zX0H2i.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/iq57t3NYGm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/iq57t3NYGm.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/ixUQwlLoQl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/ixUQwlLoQl.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/ixp5a4MCzH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/ixp5a4MCzH.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/izrpe1H39g.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/izrpe1H39g.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/j0gOb12WG7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/j0gOb12WG7.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/j41I8z5Dbm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/j41I8z5Dbm.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/j9KVlh9Elu.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/j9KVlh9Elu.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/jEPN6e30lK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/jEPN6e30lK.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/jHoO30hDWC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/jHoO30hDWC.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/jOEODojhaI.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/jOEODojhaI.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/jSdYYlxIPu.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/jSdYYlxIPu.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/kDrpkD1xK6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/kDrpkD1xK6.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/kODlOvWLVJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/kODlOvWLVJ.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/koWMEughuG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/koWMEughuG.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/kpmo31UbcA.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/kpmo31UbcA.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/kuu79cE7XV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/kuu79cE7XV.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/ky7lfFDW6q.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/ky7lfFDW6q.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/kyEHvPp7Gk.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/kyEHvPp7Gk.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/lOk975L1YB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/lOk975L1YB.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/lW11AhH3pd.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/lW11AhH3pd.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/llHMuoBQb8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/llHMuoBQb8.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/m8AHxnkobT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/m8AHxnkobT.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/mBub665Sw1.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/mBub665Sw1.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/mKU2FtqWwc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/mKU2FtqWwc.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/mN75YcjhNl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/mN75YcjhNl.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/mhhBA6GJJy.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/mhhBA6GJJy.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/nE3Qa1apaH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/nE3Qa1apaH.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/nT8J5haK6F.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/nT8J5haK6F.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/nUWnom5eaz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/nUWnom5eaz.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/nY4f0rBQfZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/nY4f0rBQfZ.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/nenm6c9K9H.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/nenm6c9K9H.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/nrmmmwvAB3.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/nrmmmwvAB3.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/nzdiNgzpBk.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/nzdiNgzpBk.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/oEmtybut45.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/oEmtybut45.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/oV4NuQJ94t.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/oV4NuQJ94t.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/oklahTMTmf.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/oklahTMTmf.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/ors0bDh2bc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/ors0bDh2bc.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/pc50J7VwEQ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/pc50J7VwEQ.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/pqukhkAth1.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/pqukhkAth1.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/q5p595DJ6Q.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/q5p595DJ6Q.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/qE0fojpqnw.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/qE0fojpqnw.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/qGpRbiQ2ae.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/qGpRbiQ2ae.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/qoLqfVeYjg.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/qoLqfVeYjg.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/qxfXnYfFUG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/qxfXnYfFUG.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/r8w1v3Z6lL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/r8w1v3Z6lL.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/rMw8A9V28h.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/rMw8A9V28h.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/rZI5VmbmH8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/rZI5VmbmH8.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/rdy3COwDJ8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/rdy3COwDJ8.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/rlmBhex75r.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/rlmBhex75r.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/rn7ZDhqfGn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/rn7ZDhqfGn.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/rse9BAjK8p.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/rse9BAjK8p.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/rxLnaPSdKY.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/rxLnaPSdKY.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/sDb6wxVAlp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/sDb6wxVAlp.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/sHN8Z0s7Zl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/sHN8Z0s7Zl.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/sIk16HKXOH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/sIk16HKXOH.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/sfXrv8XKuT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/sfXrv8XKuT.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/spAP90Xdxo.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/spAP90Xdxo.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/t2LfLuggKw.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/t2LfLuggKw.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/t6anM049gM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/t6anM049gM.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/t6b9ipJFco.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/t6b9ipJFco.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/t88runt2vt.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/t88runt2vt.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/t96N3ukmC2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/t96N3ukmC2.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/tFHSIUZTRU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/tFHSIUZTRU.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/tOBEeyrzR5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/tOBEeyrzR5.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/tqmxPtSV5e.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/tqmxPtSV5e.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/ttgDLEo0YY.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/ttgDLEo0YY.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/tyDsoFs45y.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/tyDsoFs45y.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/tyrqHRTjct.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/tyrqHRTjct.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/uMrfngv4qE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/uMrfngv4qE.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/ufp5xt5UlZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/ufp5xt5UlZ.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/ukDSDTeRKn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/ukDSDTeRKn.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/vAhi6T2iCs.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/vAhi6T2iCs.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/vDddl4MmlU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/vDddl4MmlU.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/vLwvkrUp8m.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/vLwvkrUp8m.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/vO7uWdob4g.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/vO7uWdob4g.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/vUjLCf2llh.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/vUjLCf2llh.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/vdOsQV2zZZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/vdOsQV2zZZ.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/vqoyQGzxwZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/vqoyQGzxwZ.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/vuum3mHSut.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/vuum3mHSut.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/wff7vOGYXM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/wff7vOGYXM.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/wkgn6vRUUp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/wkgn6vRUUp.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/wmDBp8f0Z2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/wmDBp8f0Z2.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/woqch6WNMH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/woqch6WNMH.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/x1AVtHbq4f.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/x1AVtHbq4f.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/xEOJNLq3je.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/xEOJNLq3je.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/xM6CnVshaE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/xM6CnVshaE.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/xOe1maF1HZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/xOe1maF1HZ.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/xVFVQAk3u3.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/xVFVQAk3u3.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/xWEhNnxjgn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/xWEhNnxjgn.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/xmhnIZPlm0.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/xmhnIZPlm0.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/xqXMSXBMl8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/xqXMSXBMl8.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/xqemv5BeQH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/xqemv5BeQH.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/y8Wf7aTXFb.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/y8Wf7aTXFb.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/yCWOaOd0DH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/yCWOaOd0DH.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/yI34mPjVtK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/yI34mPjVtK.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/yQu5xEnWkt.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/yQu5xEnWkt.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/yVvQYsdxaq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/yVvQYsdxaq.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/yaMxpb9T34.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/yaMxpb9T34.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/ygTzDOCr3r.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/ygTzDOCr3r.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/z4XWuGECC2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/z4XWuGECC2.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/z9nNYIgtFz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/z9nNYIgtFz.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/zFiwaVTd6p.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/zFiwaVTd6p.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/zI6QHiNniJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/zI6QHiNniJ.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/zVrQLGqXwe.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/zVrQLGqXwe.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/zYVWOnWkq4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/zYVWOnWkq4.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/zZ91YoJG9X.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/zZ91YoJG9X.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/zuxZ6Tg1Ha.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1-us/zuxZ6Tg1Ha.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/06T2RNzfTz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/06T2RNzfTz.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/07aN2OB1qj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/07aN2OB1qj.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/0JTPBSFvcC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/0JTPBSFvcC.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/0McUuUDCYj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/0McUuUDCYj.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/0T3L0HU9F5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/0T3L0HU9F5.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/0UrWNfXMbn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/0UrWNfXMbn.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/0We2g9ZRI1.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/0We2g9ZRI1.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/0crDi3Beji.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/0crDi3Beji.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/0dN19RtMpy.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/0dN19RtMpy.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/0nyPk4lS5G.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/0nyPk4lS5G.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/0sV5NP6Raj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/0sV5NP6Raj.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/0tlxl8JzK2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/0tlxl8JzK2.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/13VaDTQa1F.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/13VaDTQa1F.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/177ObAyjaW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/177ObAyjaW.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/1SIwphdqPw.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/1SIwphdqPw.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/1Wku3If0yF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/1Wku3If0yF.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/1fkLnqEKq5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/1fkLnqEKq5.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/1guqW4QDJq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/1guqW4QDJq.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/1zvL3jc30s.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/1zvL3jc30s.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/2BK4YBngu6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/2BK4YBngu6.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/2DcJnHQ1Wc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/2DcJnHQ1Wc.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/2EmGTjbMHL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/2EmGTjbMHL.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/2bgBJIgdGy.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/2bgBJIgdGy.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/3DKPTxt9nK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/3DKPTxt9nK.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/3K5GXTKPrP.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/3K5GXTKPrP.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/3QFEobjwmC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/3QFEobjwmC.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/3RDZKRFFEV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/3RDZKRFFEV.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/3s0rgujAIg.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/3s0rgujAIg.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/4Ax5wLUa4c.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/4Ax5wLUa4c.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/4EsYZXHdpa.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/4EsYZXHdpa.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/4MA1GGxtB2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/4MA1GGxtB2.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/4TA0dltn8Z.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/4TA0dltn8Z.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/4XwovA4lrF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/4XwovA4lrF.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/4iwufNM5Y6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/4iwufNM5Y6.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/4kQSb8Mpxb.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/4kQSb8Mpxb.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/4knxgNV22P.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/4knxgNV22P.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/4prVlpN79q.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/4prVlpN79q.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/54K50WUaKI.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/54K50WUaKI.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/5E9QwsWPit.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/5E9QwsWPit.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/5JUr6L7hij.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/5JUr6L7hij.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/5WMn1FI8mr.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/5WMn1FI8mr.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/5ejPdcXoEW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/5ejPdcXoEW.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/5h6yFrKLct.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/5h6yFrKLct.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/6ezYN7Hv0Z.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/6ezYN7Hv0Z.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/6l2wTrG0a6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/6l2wTrG0a6.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/6oA6qi8Lpj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/6oA6qi8Lpj.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/6pwxM7x9RG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/6pwxM7x9RG.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/70gJ0d6ueN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/70gJ0d6ueN.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/7NBB4SlixM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/7NBB4SlixM.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/7PDb7B0Y2N.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/7PDb7B0Y2N.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/7Pcw6lts4T.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/7Pcw6lts4T.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/7Xcf56RyAr.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/7Xcf56RyAr.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/7n3s1BSMBo.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/7n3s1BSMBo.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/7s32eactiP.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/7s32eactiP.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/81lR1cSmfJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/81lR1cSmfJ.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/8dnUV6Vg0Y.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/8dnUV6Vg0Y.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/8tTziwEdcI.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/8tTziwEdcI.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/8zROpBby2x.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/8zROpBby2x.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/90J1b35WV8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/90J1b35WV8.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/91wjEMiEX6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/91wjEMiEX6.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/9EdR9Yk7ca.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/9EdR9Yk7ca.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/9RZxZPNxIu.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/9RZxZPNxIu.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/9TOztQhkC4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/9TOztQhkC4.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/9jWBrTk7UB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/9jWBrTk7UB.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/9lMN6zFkKE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/9lMN6zFkKE.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/9s6IGHapL2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/9s6IGHapL2.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/A01FvWmA8l.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/A01FvWmA8l.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/A3USVyZwFP.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/A3USVyZwFP.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/AGJgFoElmB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/AGJgFoElmB.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/AKEOkMAk9E.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/AKEOkMAk9E.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/ALzR9tiyk8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/ALzR9tiyk8.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/AenL9akVZ7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/AenL9akVZ7.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/AutcanQMIS.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/AutcanQMIS.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/B19N6aMdz3.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/B19N6aMdz3.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/B1EGKnhW9e.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/B1EGKnhW9e.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/B1oQQ08HGH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/B1oQQ08HGH.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/B54wYu3oDA.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/B54wYu3oDA.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/BBTptRbtCv.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/BBTptRbtCv.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/BGGCRglxce.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/BGGCRglxce.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/BP8ChaEEsu.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/BP8ChaEEsu.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/BWk4SOKZaL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/BWk4SOKZaL.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/Bj2rdZWLh7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/Bj2rdZWLh7.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/C0qtj9qPDQ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/C0qtj9qPDQ.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/C9re7IuLWT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/C9re7IuLWT.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/CNHSzPEwGH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/CNHSzPEwGH.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/CP3AlJWqrp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/CP3AlJWqrp.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/CWYcYC8app.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/CWYcYC8app.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/Cb3SuEIO21.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/Cb3SuEIO21.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/CoZ4zNyWGC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/CoZ4zNyWGC.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/D1CTthvE4P.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/D1CTthvE4P.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/DFn3iuttpy.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/DFn3iuttpy.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/Dc9KyR2b2p.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/Dc9KyR2b2p.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/Dph3kXOCic.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/Dph3kXOCic.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/Dvpv1gBrUQ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/Dvpv1gBrUQ.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/E4qThSDcnD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/E4qThSDcnD.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/EC4qtMsceH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/EC4qtMsceH.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/ERsIqJPx5L.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/ERsIqJPx5L.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/EZXLjw31Dl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/EZXLjw31Dl.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/EsvI0BL049.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/EsvI0BL049.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/F2Pe3EMY8l.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/F2Pe3EMY8l.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/F5lnyEc8P7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/F5lnyEc8P7.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/FCqK7dSpWU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/FCqK7dSpWU.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/FNBWotecr1.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/FNBWotecr1.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/FV6eIbtnYG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/FV6eIbtnYG.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/FXHmkUJdzB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/FXHmkUJdzB.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/Fn00VgWg5Y.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/Fn00VgWg5Y.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/G2sYQwPkhJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/G2sYQwPkhJ.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/G5mzA5SBhk.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/G5mzA5SBhk.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/GDxA5zEvt0.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/GDxA5zEvt0.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/GXsAoZzuGz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/GXsAoZzuGz.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/GgA3nIlfrr.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/GgA3nIlfrr.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/Gl9QSM0HL9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/Gl9QSM0HL9.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/HWdd0atzlF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/HWdd0atzlF.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/HjAQJGqXYX.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/HjAQJGqXYX.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/HzjTooszyT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/HzjTooszyT.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/I3R2n3iDwp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/I3R2n3iDwp.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/I5jP7AdXUO.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/I5jP7AdXUO.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/I8b2lta2dV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/I8b2lta2dV.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/IFfft0YbVF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/IFfft0YbVF.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/IcZKeRjvKW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/IcZKeRjvKW.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/IiI7gJ520W.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/IiI7gJ520W.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/Ij3DQuVRk7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/Ij3DQuVRk7.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/IuHoP54Wlc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/IuHoP54Wlc.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/IwYqIz3EHD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/IwYqIz3EHD.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/J0cKBlje4u.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/J0cKBlje4u.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/J1zbYLAkpc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/J1zbYLAkpc.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/J6HXfDOVhX.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/J6HXfDOVhX.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/JH4VhArCNR.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/JH4VhArCNR.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/JXkrGa9mJm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/JXkrGa9mJm.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/JjTVAGnAQr.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/JjTVAGnAQr.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/JptCVz4qEd.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/JptCVz4qEd.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/JtusM5o9mV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/JtusM5o9mV.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/K8foSEhEd6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/K8foSEhEd6.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/KCFf7gu3Y4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/KCFf7gu3Y4.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/KRrQYpA7NN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/KRrQYpA7NN.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/KkW0XInSXe.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/KkW0XInSXe.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/KmUJvvIFQM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/KmUJvvIFQM.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/KwZarRNYrG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/KwZarRNYrG.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/L2R0Fdeoqj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/L2R0Fdeoqj.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/L6Togn7pnd.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/L6Togn7pnd.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/LGFBsMx1Ue.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/LGFBsMx1Ue.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/LKPjaqZzne.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/LKPjaqZzne.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/LTwPCkotqR.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/LTwPCkotqR.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/LlojbpWjs9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/LlojbpWjs9.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/LnGkF3PV4B.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/LnGkF3PV4B.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/Lw6juAfLhZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/Lw6juAfLhZ.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/M2wCQaSIkx.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/M2wCQaSIkx.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/M7p8sbE3VI.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/M7p8sbE3VI.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/MAaNEFkxNx.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/MAaNEFkxNx.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/MN57efcLju.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/MN57efcLju.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/MTonphGglM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/MTonphGglM.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/MWxYsdcQAm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/MWxYsdcQAm.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/MiEtLwCnzM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/MiEtLwCnzM.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/Mm2925bgtf.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/Mm2925bgtf.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/MnCQlmeEpx.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/MnCQlmeEpx.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/Mnn3wVQyPT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/Mnn3wVQyPT.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/MwWzEyFzMN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/MwWzEyFzMN.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/N3qbcpPajg.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/N3qbcpPajg.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/NBM2jrtjUt.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/NBM2jrtjUt.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/NDycAe2PMg.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/NDycAe2PMg.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/NVaQ8JUMmp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/NVaQ8JUMmp.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/NauzwofxwH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/NauzwofxwH.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/Ngx37kpASZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/Ngx37kpASZ.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/NhzifMsgk2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/NhzifMsgk2.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/NpGzSptAcC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/NpGzSptAcC.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/NpRS0S6JWC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/NpRS0S6JWC.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/NqADIATboI.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/NqADIATboI.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/NwHv5RB2rz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/NwHv5RB2rz.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/O953QNNUI0.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/O953QNNUI0.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/OCchs83O6Y.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/OCchs83O6Y.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/OGxNUCIKC2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/OGxNUCIKC2.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/OJyyKz5GVv.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/OJyyKz5GVv.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/OMOINSyhgb.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/OMOINSyhgb.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/ON96VWl2eE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/ON96VWl2eE.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/OYhonKADC9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/OYhonKADC9.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/OZwHXjKDnl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/OZwHXjKDnl.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/OdEuAfadOv.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/OdEuAfadOv.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/OxyGJylIwW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/OxyGJylIwW.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/PHurkwqv4Z.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/PHurkwqv4Z.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/PXNopPwCXl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/PXNopPwCXl.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/QArvYA1I5y.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/QArvYA1I5y.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/QKdvStkUZD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/QKdvStkUZD.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/QkWxbTjqEQ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/QkWxbTjqEQ.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/QoD4gdBKht.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/QoD4gdBKht.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/QxOTHR8Vr5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/QxOTHR8Vr5.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/R4BCKWzeKK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/R4BCKWzeKK.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/RBTWh9W2wN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/RBTWh9W2wN.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/RSdIxOjWTU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/RSdIxOjWTU.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/RVXzOJsITX.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/RVXzOJsITX.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/RVsXeoSc9F.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/RVsXeoSc9F.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/RWTGsJXzQz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/RWTGsJXzQz.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/RYuyMUd2gk.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/RYuyMUd2gk.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/RpX90PHiU0.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/RpX90PHiU0.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/RvpGNGwBDO.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/RvpGNGwBDO.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/RykGa318Dx.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/RykGa318Dx.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/S4670YUK50.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/S4670YUK50.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/S6gLS26ZJ4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/S6gLS26ZJ4.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/S9LbD4Pr4R.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/S9LbD4Pr4R.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/SAOrYUiv3f.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/SAOrYUiv3f.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/SCkYQvq0A9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/SCkYQvq0A9.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/SDPXeHAEsY.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/SDPXeHAEsY.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/SFVT3QJAYW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/SFVT3QJAYW.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/SNuFk4PnW2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/SNuFk4PnW2.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/ShzxZhno8O.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/ShzxZhno8O.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/SnDPKIXHDi.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/SnDPKIXHDi.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/SzCgZ3qNN5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/SzCgZ3qNN5.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/T520ZP6L8T.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/T520ZP6L8T.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/TJTFd5hAYj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/TJTFd5hAYj.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/TRuTR85WZK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/TRuTR85WZK.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/TgwFqiQRdp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/TgwFqiQRdp.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/Tj8JfMPQOP.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/Tj8JfMPQOP.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/TrSKsrbw64.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/TrSKsrbw64.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/TtsQu77nNc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/TtsQu77nNc.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/U5ugQslU2z.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/U5ugQslU2z.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/UP8fkuONg2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/UP8fkuONg2.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/UQd9WJKHHq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/UQd9WJKHHq.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/UdYGjLjpzk.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/UdYGjLjpzk.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/UeKNqkUYqr.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/UeKNqkUYqr.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/UfKa2OpfYT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/UfKa2OpfYT.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/UmSdXFQzs5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/UmSdXFQzs5.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/Uwk8g9mKl8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/Uwk8g9mKl8.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/V39a2Wfhny.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/V39a2Wfhny.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/V6Alb9zB67.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/V6Alb9zB67.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/VBCxRuQlyS.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/VBCxRuQlyS.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/VCeH9ZweWA.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/VCeH9ZweWA.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/VLXVn8J66H.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/VLXVn8J66H.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/VWVKSidnGZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/VWVKSidnGZ.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/VYon30GsHO.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/VYon30GsHO.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/Vdgc0ZvuWs.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/Vdgc0ZvuWs.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/VfmDAdXzKM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/VfmDAdXzKM.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/VhYMLsMLrL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/VhYMLsMLrL.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/VxqkIhG88M.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/VxqkIhG88M.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/W5bnoMpunF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/W5bnoMpunF.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/WOpGodfIa8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/WOpGodfIa8.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/WVz16ttXmN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/WVz16ttXmN.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/WZDWUF8ibK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/WZDWUF8ibK.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/X5FuWfVgX6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/X5FuWfVgX6.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/XLacQhFM5v.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/XLacQhFM5v.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/XOK5FCR5BV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/XOK5FCR5BV.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/XSCVXLUIBn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/XSCVXLUIBn.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/XpelL4dfYJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/XpelL4dfYJ.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/Y0nmeL8Mk6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/Y0nmeL8Mk6.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/Y3mvjkMqPV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/Y3mvjkMqPV.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/Y5EXqXazv8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/Y5EXqXazv8.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/YGlCkfra9u.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/YGlCkfra9u.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/YHnNk2wz6l.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/YHnNk2wz6l.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/YJDISUV0P9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/YJDISUV0P9.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/YNZk56sw8a.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/YNZk56sw8a.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/YSjosSoyxD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/YSjosSoyxD.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/YYPqiV1dMh.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/YYPqiV1dMh.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/YcFI3Qezx8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/YcFI3Qezx8.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/Z7wOsOEcI7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/Z7wOsOEcI7.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/ZEkMAMmFrT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/ZEkMAMmFrT.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/ZHV48dd3xb.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/ZHV48dd3xb.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/ZPpTfz3cuC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/ZPpTfz3cuC.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/ZSKbzDVpdh.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/ZSKbzDVpdh.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/ZV0dzO1N3D.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/ZV0dzO1N3D.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/ZfCQZQ3Yi4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/ZfCQZQ3Yi4.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/ZgH9SeepAW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/ZgH9SeepAW.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/Zzt021tkHA.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/Zzt021tkHA.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/a1DiihgGoN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/a1DiihgGoN.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/aAzECToODG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/aAzECToODG.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/acAvcgb9wR.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/acAvcgb9wR.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/al6GdI6HHq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/al6GdI6HHq.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/b6lOjv1QB9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/b6lOjv1QB9.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/bCdroQZubL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/bCdroQZubL.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/bGXLKzz8DB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/bGXLKzz8DB.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/bOJODCt4Nj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/bOJODCt4Nj.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/bZMWPiINDJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/bZMWPiINDJ.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/bcY4kDXEiL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/bcY4kDXEiL.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/c6ixLi9Yns.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/c6ixLi9Yns.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/cC1vOfH1YD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/cC1vOfH1YD.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/cKgcqJQFSi.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/cKgcqJQFSi.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/cM7YAi3zbW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/cM7YAi3zbW.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/cZb1hdO5AT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/cZb1hdO5AT.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/cjKn08z80L.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/cjKn08z80L.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/cnoFERqEX9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/cnoFERqEX9.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/dBQTDFizrM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/dBQTDFizrM.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/dBXjMyQ6v5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/dBXjMyQ6v5.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/dQcYTBwxmD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/dQcYTBwxmD.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/dVvABT62C9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/dVvABT62C9.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/e3r8e0DiFz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/e3r8e0DiFz.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/eFsp09gaZX.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/eFsp09gaZX.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/eKleS2KN9V.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/eKleS2KN9V.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/eSoalgVCBH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/eSoalgVCBH.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/eVz6pfc2Aq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/eVz6pfc2Aq.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/eYtwlKx3DL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/eYtwlKx3DL.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/ecmluorkUs.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/ecmluorkUs.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/encSaFhW3u.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/encSaFhW3u.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/fEVDUjY0o4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/fEVDUjY0o4.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/fNBZi3EAxz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/fNBZi3EAxz.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/fQ6iyzZG4E.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/fQ6iyzZG4E.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/fkSI356192.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/fkSI356192.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/fqaD1J6KEH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/fqaD1J6KEH.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/fsCqVRe2XV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/fsCqVRe2XV.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/g32LIqIkv7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/g32LIqIkv7.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/g7NcHJ0Dqm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/g7NcHJ0Dqm.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/gKDRuR0huT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/gKDRuR0huT.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/gjl4ArLhJm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/gjl4ArLhJm.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/gvU8LsfGOx.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/gvU8LsfGOx.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/h9Y4PiPY6w.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/h9Y4PiPY6w.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/hchuG3s1rY.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/hchuG3s1rY.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/hnhVAIsmxU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/hnhVAIsmxU.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/hqtR9072e5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/hqtR9072e5.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/i53vKZdcnE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/i53vKZdcnE.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/iBn3UOpKdu.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/iBn3UOpKdu.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/iI6pw0QLBV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/iI6pw0QLBV.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/iQAGO67miB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/iQAGO67miB.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/iTg6zX0H2i.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/iTg6zX0H2i.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/iq57t3NYGm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/iq57t3NYGm.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/ixUQwlLoQl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/ixUQwlLoQl.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/ixp5a4MCzH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/ixp5a4MCzH.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/izrpe1H39g.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/izrpe1H39g.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/j0gOb12WG7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/j0gOb12WG7.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/j41I8z5Dbm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/j41I8z5Dbm.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/j9KVlh9Elu.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/j9KVlh9Elu.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/jEPN6e30lK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/jEPN6e30lK.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/jHoO30hDWC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/jHoO30hDWC.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/jOEODojhaI.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/jOEODojhaI.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/jSdYYlxIPu.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/jSdYYlxIPu.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/kDrpkD1xK6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/kDrpkD1xK6.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/kODlOvWLVJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/kODlOvWLVJ.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/koWMEughuG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/koWMEughuG.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/kpmo31UbcA.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/kpmo31UbcA.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/kuu79cE7XV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/kuu79cE7XV.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/ky7lfFDW6q.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/ky7lfFDW6q.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/kyEHvPp7Gk.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/kyEHvPp7Gk.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/lOk975L1YB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/lOk975L1YB.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/lW11AhH3pd.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/lW11AhH3pd.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/llHMuoBQb8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/llHMuoBQb8.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/m8AHxnkobT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/m8AHxnkobT.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/mBub665Sw1.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/mBub665Sw1.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/mKU2FtqWwc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/mKU2FtqWwc.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/mN75YcjhNl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/mN75YcjhNl.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/mhhBA6GJJy.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/mhhBA6GJJy.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/nE3Qa1apaH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/nE3Qa1apaH.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/nT8J5haK6F.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/nT8J5haK6F.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/nUWnom5eaz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/nUWnom5eaz.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/nY4f0rBQfZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/nY4f0rBQfZ.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/nenm6c9K9H.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/nenm6c9K9H.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/nrmmmwvAB3.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/nrmmmwvAB3.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/nzdiNgzpBk.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/nzdiNgzpBk.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/oEmtybut45.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/oEmtybut45.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/oV4NuQJ94t.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/oV4NuQJ94t.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/oklahTMTmf.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/oklahTMTmf.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/ors0bDh2bc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/ors0bDh2bc.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/pc50J7VwEQ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/pc50J7VwEQ.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/pqukhkAth1.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/pqukhkAth1.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/q5p595DJ6Q.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/q5p595DJ6Q.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/qE0fojpqnw.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/qE0fojpqnw.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/qGpRbiQ2ae.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/qGpRbiQ2ae.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/qoLqfVeYjg.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/qoLqfVeYjg.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/qxfXnYfFUG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/qxfXnYfFUG.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/r8w1v3Z6lL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/r8w1v3Z6lL.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/rMw8A9V28h.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/rMw8A9V28h.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/rZI5VmbmH8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/rZI5VmbmH8.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/rdy3COwDJ8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/rdy3COwDJ8.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/rlmBhex75r.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/rlmBhex75r.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/rn7ZDhqfGn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/rn7ZDhqfGn.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/rse9BAjK8p.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/rse9BAjK8p.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/rxLnaPSdKY.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/rxLnaPSdKY.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/sDb6wxVAlp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/sDb6wxVAlp.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/sHN8Z0s7Zl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/sHN8Z0s7Zl.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/sIk16HKXOH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/sIk16HKXOH.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/sfXrv8XKuT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/sfXrv8XKuT.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/spAP90Xdxo.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/spAP90Xdxo.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/t2LfLuggKw.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/t2LfLuggKw.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/t6anM049gM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/t6anM049gM.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/t6b9ipJFco.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/t6b9ipJFco.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/t88runt2vt.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/t88runt2vt.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/t96N3ukmC2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/t96N3ukmC2.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/tFHSIUZTRU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/tFHSIUZTRU.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/tOBEeyrzR5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/tOBEeyrzR5.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/tqmxPtSV5e.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/tqmxPtSV5e.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/ttgDLEo0YY.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/ttgDLEo0YY.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/tyDsoFs45y.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/tyDsoFs45y.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/tyrqHRTjct.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/tyrqHRTjct.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/uMrfngv4qE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/uMrfngv4qE.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/ufp5xt5UlZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/ufp5xt5UlZ.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/ukDSDTeRKn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/ukDSDTeRKn.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/vAhi6T2iCs.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/vAhi6T2iCs.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/vDddl4MmlU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/vDddl4MmlU.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/vLwvkrUp8m.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/vLwvkrUp8m.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/vO7uWdob4g.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/vO7uWdob4g.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/vUjLCf2llh.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/vUjLCf2llh.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/vdOsQV2zZZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/vdOsQV2zZZ.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/vqoyQGzxwZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/vqoyQGzxwZ.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/vuum3mHSut.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/vuum3mHSut.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/wff7vOGYXM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/wff7vOGYXM.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/wkgn6vRUUp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/wkgn6vRUUp.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/wmDBp8f0Z2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/wmDBp8f0Z2.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/woqch6WNMH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/woqch6WNMH.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/x1AVtHbq4f.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/x1AVtHbq4f.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/xEOJNLq3je.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/xEOJNLq3je.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/xM6CnVshaE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/xM6CnVshaE.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/xOe1maF1HZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/xOe1maF1HZ.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/xVFVQAk3u3.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/xVFVQAk3u3.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/xWEhNnxjgn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/xWEhNnxjgn.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/xmhnIZPlm0.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/xmhnIZPlm0.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/xqXMSXBMl8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/xqXMSXBMl8.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/xqemv5BeQH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/xqemv5BeQH.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/y8Wf7aTXFb.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/y8Wf7aTXFb.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/yCWOaOd0DH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/yCWOaOd0DH.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/yI34mPjVtK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/yI34mPjVtK.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/yQu5xEnWkt.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/yQu5xEnWkt.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/yVvQYsdxaq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/yVvQYsdxaq.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/yaMxpb9T34.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/yaMxpb9T34.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/ygTzDOCr3r.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/ygTzDOCr3r.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/z4XWuGECC2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/z4XWuGECC2.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/z9nNYIgtFz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/z9nNYIgtFz.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/zFiwaVTd6p.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/zFiwaVTd6p.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/zI6QHiNniJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/zI6QHiNniJ.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/zVrQLGqXwe.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/zVrQLGqXwe.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/zYVWOnWkq4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/zYVWOnWkq4.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/zZ91YoJG9X.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/zZ91YoJG9X.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/zuxZ6Tg1Ha.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v3.1/zuxZ6Tg1Ha.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/06T2RNzfTz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/06T2RNzfTz.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/07aN2OB1qj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/07aN2OB1qj.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/0JTPBSFvcC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/0JTPBSFvcC.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/0McUuUDCYj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/0McUuUDCYj.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/0T3L0HU9F5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/0T3L0HU9F5.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/0UrWNfXMbn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/0UrWNfXMbn.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/0We2g9ZRI1.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/0We2g9ZRI1.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/0crDi3Beji.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/0crDi3Beji.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/0dN19RtMpy.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/0dN19RtMpy.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/0nyPk4lS5G.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/0nyPk4lS5G.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/0sV5NP6Raj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/0sV5NP6Raj.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/0tlxl8JzK2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/0tlxl8JzK2.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/13VaDTQa1F.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/13VaDTQa1F.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/177ObAyjaW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/177ObAyjaW.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/1SIwphdqPw.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/1SIwphdqPw.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/1Wku3If0yF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/1Wku3If0yF.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/1fkLnqEKq5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/1fkLnqEKq5.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/1guqW4QDJq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/1guqW4QDJq.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/1zvL3jc30s.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/1zvL3jc30s.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/2BK4YBngu6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/2BK4YBngu6.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/2DcJnHQ1Wc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/2DcJnHQ1Wc.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/2EmGTjbMHL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/2EmGTjbMHL.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/2bgBJIgdGy.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/2bgBJIgdGy.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/3DKPTxt9nK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/3DKPTxt9nK.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/3K5GXTKPrP.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/3K5GXTKPrP.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/3QFEobjwmC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/3QFEobjwmC.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/3RDZKRFFEV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/3RDZKRFFEV.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/3s0rgujAIg.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/3s0rgujAIg.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/4Ax5wLUa4c.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/4Ax5wLUa4c.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/4EsYZXHdpa.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/4EsYZXHdpa.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/4MA1GGxtB2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/4MA1GGxtB2.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/4TA0dltn8Z.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/4TA0dltn8Z.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/4XwovA4lrF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/4XwovA4lrF.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/4iwufNM5Y6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/4iwufNM5Y6.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/4kQSb8Mpxb.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/4kQSb8Mpxb.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/4knxgNV22P.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/4knxgNV22P.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/4prVlpN79q.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/4prVlpN79q.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/54K50WUaKI.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/54K50WUaKI.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/5E9QwsWPit.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/5E9QwsWPit.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/5JUr6L7hij.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/5JUr6L7hij.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/5WMn1FI8mr.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/5WMn1FI8mr.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/5ejPdcXoEW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/5ejPdcXoEW.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/5h6yFrKLct.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/5h6yFrKLct.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/6ezYN7Hv0Z.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/6ezYN7Hv0Z.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/6l2wTrG0a6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/6l2wTrG0a6.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/6oA6qi8Lpj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/6oA6qi8Lpj.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/6pwxM7x9RG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/6pwxM7x9RG.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/70gJ0d6ueN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/70gJ0d6ueN.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/7NBB4SlixM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/7NBB4SlixM.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/7PDb7B0Y2N.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/7PDb7B0Y2N.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/7Pcw6lts4T.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/7Pcw6lts4T.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/7Xcf56RyAr.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/7Xcf56RyAr.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/7n3s1BSMBo.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/7n3s1BSMBo.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/7s32eactiP.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/7s32eactiP.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/81lR1cSmfJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/81lR1cSmfJ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/8dnUV6Vg0Y.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/8dnUV6Vg0Y.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/8tTziwEdcI.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/8tTziwEdcI.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/8zROpBby2x.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/8zROpBby2x.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/90J1b35WV8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/90J1b35WV8.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/91wjEMiEX6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/91wjEMiEX6.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/9EdR9Yk7ca.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/9EdR9Yk7ca.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/9RZxZPNxIu.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/9RZxZPNxIu.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/9TOztQhkC4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/9TOztQhkC4.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/9jWBrTk7UB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/9jWBrTk7UB.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/9lMN6zFkKE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/9lMN6zFkKE.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/9s6IGHapL2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/9s6IGHapL2.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/A01FvWmA8l.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/A01FvWmA8l.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/A3USVyZwFP.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/A3USVyZwFP.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/AGJgFoElmB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/AGJgFoElmB.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/AKEOkMAk9E.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/AKEOkMAk9E.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/ALzR9tiyk8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/ALzR9tiyk8.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/AenL9akVZ7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/AenL9akVZ7.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/AutcanQMIS.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/AutcanQMIS.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/B19N6aMdz3.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/B19N6aMdz3.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/B1EGKnhW9e.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/B1EGKnhW9e.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/B1oQQ08HGH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/B1oQQ08HGH.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/B54wYu3oDA.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/B54wYu3oDA.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/BBTptRbtCv.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/BBTptRbtCv.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/BGGCRglxce.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/BGGCRglxce.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/BP8ChaEEsu.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/BP8ChaEEsu.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/BWk4SOKZaL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/BWk4SOKZaL.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/Bj2rdZWLh7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/Bj2rdZWLh7.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/C0qtj9qPDQ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/C0qtj9qPDQ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/C9re7IuLWT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/C9re7IuLWT.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/CNHSzPEwGH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/CNHSzPEwGH.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/CP3AlJWqrp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/CP3AlJWqrp.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/CWYcYC8app.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/CWYcYC8app.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/Cb3SuEIO21.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/Cb3SuEIO21.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/CoZ4zNyWGC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/CoZ4zNyWGC.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/D1CTthvE4P.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/D1CTthvE4P.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/DFn3iuttpy.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/DFn3iuttpy.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/Dc9KyR2b2p.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/Dc9KyR2b2p.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/Dph3kXOCic.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/Dph3kXOCic.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/Dvpv1gBrUQ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/Dvpv1gBrUQ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/E4qThSDcnD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/E4qThSDcnD.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/EC4qtMsceH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/EC4qtMsceH.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/ERsIqJPx5L.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/ERsIqJPx5L.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/EZXLjw31Dl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/EZXLjw31Dl.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/EsvI0BL049.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/EsvI0BL049.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/F2Pe3EMY8l.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/F2Pe3EMY8l.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/F5lnyEc8P7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/F5lnyEc8P7.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/FCqK7dSpWU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/FCqK7dSpWU.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/FNBWotecr1.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/FNBWotecr1.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/FV6eIbtnYG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/FV6eIbtnYG.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/FXHmkUJdzB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/FXHmkUJdzB.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/Fn00VgWg5Y.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/Fn00VgWg5Y.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/G2sYQwPkhJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/G2sYQwPkhJ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/G5mzA5SBhk.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/G5mzA5SBhk.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/GDxA5zEvt0.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/GDxA5zEvt0.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/GXsAoZzuGz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/GXsAoZzuGz.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/GgA3nIlfrr.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/GgA3nIlfrr.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/Gl9QSM0HL9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/Gl9QSM0HL9.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/HWdd0atzlF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/HWdd0atzlF.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/HjAQJGqXYX.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/HjAQJGqXYX.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/HzjTooszyT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/HzjTooszyT.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/I3R2n3iDwp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/I3R2n3iDwp.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/I5jP7AdXUO.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/I5jP7AdXUO.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/I8b2lta2dV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/I8b2lta2dV.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/IFfft0YbVF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/IFfft0YbVF.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/IcZKeRjvKW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/IcZKeRjvKW.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/IiI7gJ520W.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/IiI7gJ520W.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/Ij3DQuVRk7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/Ij3DQuVRk7.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/IuHoP54Wlc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/IuHoP54Wlc.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/IwYqIz3EHD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/IwYqIz3EHD.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/J0cKBlje4u.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/J0cKBlje4u.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/J1zbYLAkpc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/J1zbYLAkpc.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/J6HXfDOVhX.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/J6HXfDOVhX.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/JH4VhArCNR.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/JH4VhArCNR.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/JXkrGa9mJm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/JXkrGa9mJm.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/JjTVAGnAQr.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/JjTVAGnAQr.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/JptCVz4qEd.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/JptCVz4qEd.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/JtusM5o9mV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/JtusM5o9mV.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/K8foSEhEd6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/K8foSEhEd6.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/KCFf7gu3Y4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/KCFf7gu3Y4.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/KRrQYpA7NN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/KRrQYpA7NN.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/KkW0XInSXe.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/KkW0XInSXe.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/KmUJvvIFQM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/KmUJvvIFQM.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/KwZarRNYrG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/KwZarRNYrG.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/L2R0Fdeoqj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/L2R0Fdeoqj.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/L6Togn7pnd.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/L6Togn7pnd.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/LGFBsMx1Ue.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/LGFBsMx1Ue.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/LKPjaqZzne.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/LKPjaqZzne.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/LTwPCkotqR.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/LTwPCkotqR.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/LlojbpWjs9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/LlojbpWjs9.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/LnGkF3PV4B.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/LnGkF3PV4B.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/Lw6juAfLhZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/Lw6juAfLhZ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/M2wCQaSIkx.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/M2wCQaSIkx.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/M7p8sbE3VI.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/M7p8sbE3VI.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/MAaNEFkxNx.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/MAaNEFkxNx.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/MN57efcLju.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/MN57efcLju.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/MTonphGglM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/MTonphGglM.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/MWxYsdcQAm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/MWxYsdcQAm.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/MiEtLwCnzM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/MiEtLwCnzM.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/Mm2925bgtf.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/Mm2925bgtf.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/MnCQlmeEpx.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/MnCQlmeEpx.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/Mnn3wVQyPT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/Mnn3wVQyPT.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/MwWzEyFzMN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/MwWzEyFzMN.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/N3qbcpPajg.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/N3qbcpPajg.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/NBM2jrtjUt.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/NBM2jrtjUt.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/NDycAe2PMg.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/NDycAe2PMg.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/NVaQ8JUMmp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/NVaQ8JUMmp.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/NauzwofxwH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/NauzwofxwH.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/Ngx37kpASZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/Ngx37kpASZ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/NhzifMsgk2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/NhzifMsgk2.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/NpGzSptAcC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/NpGzSptAcC.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/NpRS0S6JWC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/NpRS0S6JWC.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/NqADIATboI.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/NqADIATboI.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/NwHv5RB2rz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/NwHv5RB2rz.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/O953QNNUI0.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/O953QNNUI0.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/OCchs83O6Y.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/OCchs83O6Y.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/OGxNUCIKC2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/OGxNUCIKC2.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/OJyyKz5GVv.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/OJyyKz5GVv.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/OMOINSyhgb.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/OMOINSyhgb.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/ON96VWl2eE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/ON96VWl2eE.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/OYhonKADC9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/OYhonKADC9.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/OZwHXjKDnl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/OZwHXjKDnl.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/OdEuAfadOv.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/OdEuAfadOv.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/OxyGJylIwW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/OxyGJylIwW.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/PHurkwqv4Z.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/PHurkwqv4Z.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/PXNopPwCXl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/PXNopPwCXl.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/QArvYA1I5y.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/QArvYA1I5y.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/QKdvStkUZD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/QKdvStkUZD.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/QkWxbTjqEQ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/QkWxbTjqEQ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/QoD4gdBKht.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/QoD4gdBKht.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/QxOTHR8Vr5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/QxOTHR8Vr5.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/R4BCKWzeKK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/R4BCKWzeKK.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/RBTWh9W2wN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/RBTWh9W2wN.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/RSdIxOjWTU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/RSdIxOjWTU.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/RVXzOJsITX.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/RVXzOJsITX.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/RVsXeoSc9F.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/RVsXeoSc9F.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/RWTGsJXzQz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/RWTGsJXzQz.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/RYuyMUd2gk.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/RYuyMUd2gk.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/RpX90PHiU0.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/RpX90PHiU0.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/RvpGNGwBDO.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/RvpGNGwBDO.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/RykGa318Dx.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/RykGa318Dx.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/S4670YUK50.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/S4670YUK50.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/S6gLS26ZJ4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/S6gLS26ZJ4.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/S9LbD4Pr4R.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/S9LbD4Pr4R.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/SAOrYUiv3f.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/SAOrYUiv3f.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/SCkYQvq0A9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/SCkYQvq0A9.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/SDPXeHAEsY.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/SDPXeHAEsY.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/SFVT3QJAYW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/SFVT3QJAYW.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/SNuFk4PnW2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/SNuFk4PnW2.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/ShzxZhno8O.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/ShzxZhno8O.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/SnDPKIXHDi.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/SnDPKIXHDi.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/SzCgZ3qNN5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/SzCgZ3qNN5.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/T520ZP6L8T.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/T520ZP6L8T.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/TJTFd5hAYj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/TJTFd5hAYj.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/TRuTR85WZK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/TRuTR85WZK.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/TgwFqiQRdp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/TgwFqiQRdp.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/Tj8JfMPQOP.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/Tj8JfMPQOP.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/TrSKsrbw64.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/TrSKsrbw64.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/TtsQu77nNc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/TtsQu77nNc.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/U5ugQslU2z.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/U5ugQslU2z.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/UP8fkuONg2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/UP8fkuONg2.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/UQd9WJKHHq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/UQd9WJKHHq.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/UdYGjLjpzk.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/UdYGjLjpzk.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/UeKNqkUYqr.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/UeKNqkUYqr.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/UfKa2OpfYT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/UfKa2OpfYT.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/UmSdXFQzs5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/UmSdXFQzs5.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/Uwk8g9mKl8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/Uwk8g9mKl8.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/V39a2Wfhny.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/V39a2Wfhny.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/V6Alb9zB67.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/V6Alb9zB67.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/VBCxRuQlyS.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/VBCxRuQlyS.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/VCeH9ZweWA.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/VCeH9ZweWA.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/VLXVn8J66H.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/VLXVn8J66H.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/VWVKSidnGZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/VWVKSidnGZ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/VYon30GsHO.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/VYon30GsHO.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/Vdgc0ZvuWs.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/Vdgc0ZvuWs.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/VfmDAdXzKM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/VfmDAdXzKM.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/VhYMLsMLrL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/VhYMLsMLrL.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/VxqkIhG88M.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/VxqkIhG88M.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/W5bnoMpunF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/W5bnoMpunF.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/WOpGodfIa8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/WOpGodfIa8.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/WVz16ttXmN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/WVz16ttXmN.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/WZDWUF8ibK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/WZDWUF8ibK.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/X5FuWfVgX6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/X5FuWfVgX6.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/XLacQhFM5v.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/XLacQhFM5v.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/XOK5FCR5BV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/XOK5FCR5BV.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/XSCVXLUIBn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/XSCVXLUIBn.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/XpelL4dfYJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/XpelL4dfYJ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/Y0nmeL8Mk6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/Y0nmeL8Mk6.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/Y3mvjkMqPV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/Y3mvjkMqPV.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/Y5EXqXazv8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/Y5EXqXazv8.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/YGlCkfra9u.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/YGlCkfra9u.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/YHnNk2wz6l.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/YHnNk2wz6l.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/YJDISUV0P9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/YJDISUV0P9.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/YNZk56sw8a.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/YNZk56sw8a.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/YSjosSoyxD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/YSjosSoyxD.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/YYPqiV1dMh.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/YYPqiV1dMh.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/YcFI3Qezx8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/YcFI3Qezx8.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/Z7wOsOEcI7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/Z7wOsOEcI7.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/ZEkMAMmFrT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/ZEkMAMmFrT.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/ZHV48dd3xb.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/ZHV48dd3xb.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/ZPpTfz3cuC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/ZPpTfz3cuC.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/ZSKbzDVpdh.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/ZSKbzDVpdh.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/ZV0dzO1N3D.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/ZV0dzO1N3D.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/ZfCQZQ3Yi4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/ZfCQZQ3Yi4.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/ZgH9SeepAW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/ZgH9SeepAW.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/Zzt021tkHA.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/Zzt021tkHA.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/a1DiihgGoN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/a1DiihgGoN.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/aAzECToODG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/aAzECToODG.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/acAvcgb9wR.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/acAvcgb9wR.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/al6GdI6HHq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/al6GdI6HHq.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/b6lOjv1QB9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/b6lOjv1QB9.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/bCdroQZubL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/bCdroQZubL.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/bGXLKzz8DB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/bGXLKzz8DB.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/bOJODCt4Nj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/bOJODCt4Nj.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/bZMWPiINDJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/bZMWPiINDJ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/bcY4kDXEiL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/bcY4kDXEiL.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/c6ixLi9Yns.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/c6ixLi9Yns.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/cC1vOfH1YD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/cC1vOfH1YD.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/cKgcqJQFSi.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/cKgcqJQFSi.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/cM7YAi3zbW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/cM7YAi3zbW.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/cZb1hdO5AT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/cZb1hdO5AT.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/cjKn08z80L.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/cjKn08z80L.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/cnoFERqEX9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/cnoFERqEX9.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/dBQTDFizrM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/dBQTDFizrM.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/dBXjMyQ6v5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/dBXjMyQ6v5.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/dQcYTBwxmD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/dQcYTBwxmD.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/dVvABT62C9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/dVvABT62C9.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/e3r8e0DiFz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/e3r8e0DiFz.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/eFsp09gaZX.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/eFsp09gaZX.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/eKleS2KN9V.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/eKleS2KN9V.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/eSoalgVCBH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/eSoalgVCBH.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/eVz6pfc2Aq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/eVz6pfc2Aq.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/eYtwlKx3DL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/eYtwlKx3DL.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/ecmluorkUs.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/ecmluorkUs.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/encSaFhW3u.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/encSaFhW3u.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/fEVDUjY0o4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/fEVDUjY0o4.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/fNBZi3EAxz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/fNBZi3EAxz.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/fQ6iyzZG4E.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/fQ6iyzZG4E.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/fkSI356192.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/fkSI356192.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/fqaD1J6KEH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/fqaD1J6KEH.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/fsCqVRe2XV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/fsCqVRe2XV.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/g32LIqIkv7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/g32LIqIkv7.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/g7NcHJ0Dqm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/g7NcHJ0Dqm.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/gKDRuR0huT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/gKDRuR0huT.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/gjl4ArLhJm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/gjl4ArLhJm.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/gvU8LsfGOx.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/gvU8LsfGOx.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/h9Y4PiPY6w.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/h9Y4PiPY6w.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/hchuG3s1rY.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/hchuG3s1rY.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/hnhVAIsmxU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/hnhVAIsmxU.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/hqtR9072e5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/hqtR9072e5.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/i53vKZdcnE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/i53vKZdcnE.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/iBn3UOpKdu.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/iBn3UOpKdu.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/iI6pw0QLBV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/iI6pw0QLBV.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/iQAGO67miB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/iQAGO67miB.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/iTg6zX0H2i.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/iTg6zX0H2i.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/iq57t3NYGm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/iq57t3NYGm.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/ixUQwlLoQl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/ixUQwlLoQl.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/ixp5a4MCzH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/ixp5a4MCzH.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/izrpe1H39g.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/izrpe1H39g.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/j0gOb12WG7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/j0gOb12WG7.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/j41I8z5Dbm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/j41I8z5Dbm.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/j9KVlh9Elu.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/j9KVlh9Elu.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/jEPN6e30lK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/jEPN6e30lK.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/jHoO30hDWC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/jHoO30hDWC.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/jOEODojhaI.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/jOEODojhaI.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/jSdYYlxIPu.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/jSdYYlxIPu.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/kDrpkD1xK6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/kDrpkD1xK6.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/kODlOvWLVJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/kODlOvWLVJ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/koWMEughuG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/koWMEughuG.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/kpmo31UbcA.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/kpmo31UbcA.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/kuu79cE7XV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/kuu79cE7XV.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/ky7lfFDW6q.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/ky7lfFDW6q.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/kyEHvPp7Gk.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/kyEHvPp7Gk.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/lOk975L1YB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/lOk975L1YB.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/lW11AhH3pd.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/lW11AhH3pd.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/llHMuoBQb8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/llHMuoBQb8.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/m8AHxnkobT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/m8AHxnkobT.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/mBub665Sw1.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/mBub665Sw1.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/mKU2FtqWwc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/mKU2FtqWwc.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/mN75YcjhNl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/mN75YcjhNl.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/mhhBA6GJJy.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/mhhBA6GJJy.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/nE3Qa1apaH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/nE3Qa1apaH.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/nT8J5haK6F.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/nT8J5haK6F.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/nUWnom5eaz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/nUWnom5eaz.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/nY4f0rBQfZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/nY4f0rBQfZ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/nenm6c9K9H.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/nenm6c9K9H.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/nrmmmwvAB3.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/nrmmmwvAB3.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/nzdiNgzpBk.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/nzdiNgzpBk.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/oEmtybut45.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/oEmtybut45.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/oV4NuQJ94t.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/oV4NuQJ94t.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/oklahTMTmf.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/oklahTMTmf.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/ors0bDh2bc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/ors0bDh2bc.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/pc50J7VwEQ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/pc50J7VwEQ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/pqukhkAth1.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/pqukhkAth1.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/q5p595DJ6Q.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/q5p595DJ6Q.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/qE0fojpqnw.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/qE0fojpqnw.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/qGpRbiQ2ae.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/qGpRbiQ2ae.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/qoLqfVeYjg.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/qoLqfVeYjg.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/qxfXnYfFUG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/qxfXnYfFUG.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/r8w1v3Z6lL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/r8w1v3Z6lL.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/rMw8A9V28h.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/rMw8A9V28h.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/rZI5VmbmH8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/rZI5VmbmH8.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/rdy3COwDJ8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/rdy3COwDJ8.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/rlmBhex75r.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/rlmBhex75r.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/rn7ZDhqfGn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/rn7ZDhqfGn.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/rse9BAjK8p.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/rse9BAjK8p.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/rxLnaPSdKY.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/rxLnaPSdKY.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/sDb6wxVAlp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/sDb6wxVAlp.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/sHN8Z0s7Zl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/sHN8Z0s7Zl.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/sIk16HKXOH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/sIk16HKXOH.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/sfXrv8XKuT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/sfXrv8XKuT.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/spAP90Xdxo.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/spAP90Xdxo.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/t2LfLuggKw.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/t2LfLuggKw.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/t6anM049gM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/t6anM049gM.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/t6b9ipJFco.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/t6b9ipJFco.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/t88runt2vt.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/t88runt2vt.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/t96N3ukmC2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/t96N3ukmC2.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/tFHSIUZTRU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/tFHSIUZTRU.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/tOBEeyrzR5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/tOBEeyrzR5.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/tqmxPtSV5e.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/tqmxPtSV5e.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/ttgDLEo0YY.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/ttgDLEo0YY.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/tyDsoFs45y.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/tyDsoFs45y.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/tyrqHRTjct.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/tyrqHRTjct.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/uMrfngv4qE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/uMrfngv4qE.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/ufp5xt5UlZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/ufp5xt5UlZ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/ukDSDTeRKn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/ukDSDTeRKn.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/vAhi6T2iCs.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/vAhi6T2iCs.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/vDddl4MmlU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/vDddl4MmlU.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/vLwvkrUp8m.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/vLwvkrUp8m.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/vO7uWdob4g.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/vO7uWdob4g.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/vUjLCf2llh.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/vUjLCf2llh.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/vdOsQV2zZZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/vdOsQV2zZZ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/vqoyQGzxwZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/vqoyQGzxwZ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/vuum3mHSut.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/vuum3mHSut.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/wff7vOGYXM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/wff7vOGYXM.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/wkgn6vRUUp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/wkgn6vRUUp.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/wmDBp8f0Z2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/wmDBp8f0Z2.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/woqch6WNMH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/woqch6WNMH.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/x1AVtHbq4f.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/x1AVtHbq4f.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/xEOJNLq3je.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/xEOJNLq3je.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/xM6CnVshaE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/xM6CnVshaE.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/xOe1maF1HZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/xOe1maF1HZ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/xVFVQAk3u3.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/xVFVQAk3u3.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/xWEhNnxjgn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/xWEhNnxjgn.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/xmhnIZPlm0.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/xmhnIZPlm0.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/xqXMSXBMl8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/xqXMSXBMl8.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/xqemv5BeQH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/xqemv5BeQH.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/y8Wf7aTXFb.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/y8Wf7aTXFb.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/yCWOaOd0DH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/yCWOaOd0DH.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/yI34mPjVtK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/yI34mPjVtK.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/yQu5xEnWkt.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/yQu5xEnWkt.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/yVvQYsdxaq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/yVvQYsdxaq.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/yaMxpb9T34.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/yaMxpb9T34.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/ygTzDOCr3r.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/ygTzDOCr3r.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/z4XWuGECC2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/z4XWuGECC2.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/z9nNYIgtFz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/z9nNYIgtFz.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/zFiwaVTd6p.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/zFiwaVTd6p.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/zI6QHiNniJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/zI6QHiNniJ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/zVrQLGqXwe.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/zVrQLGqXwe.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/zYVWOnWkq4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/zYVWOnWkq4.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/zZ91YoJG9X.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/zZ91YoJG9X.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/zuxZ6Tg1Ha.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-fr/zuxZ6Tg1Ha.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/06T2RNzfTz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/06T2RNzfTz.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/07aN2OB1qj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/07aN2OB1qj.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/0JTPBSFvcC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/0JTPBSFvcC.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/0McUuUDCYj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/0McUuUDCYj.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/0T3L0HU9F5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/0T3L0HU9F5.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/0UrWNfXMbn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/0UrWNfXMbn.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/0We2g9ZRI1.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/0We2g9ZRI1.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/0crDi3Beji.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/0crDi3Beji.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/0dN19RtMpy.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/0dN19RtMpy.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/0nyPk4lS5G.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/0nyPk4lS5G.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/0sV5NP6Raj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/0sV5NP6Raj.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/0tlxl8JzK2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/0tlxl8JzK2.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/13VaDTQa1F.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/13VaDTQa1F.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/177ObAyjaW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/177ObAyjaW.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/1SIwphdqPw.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/1SIwphdqPw.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/1Wku3If0yF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/1Wku3If0yF.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/1fkLnqEKq5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/1fkLnqEKq5.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/1guqW4QDJq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/1guqW4QDJq.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/1zvL3jc30s.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/1zvL3jc30s.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/2BK4YBngu6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/2BK4YBngu6.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/2DcJnHQ1Wc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/2DcJnHQ1Wc.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/2EmGTjbMHL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/2EmGTjbMHL.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/2bgBJIgdGy.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/2bgBJIgdGy.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/3DKPTxt9nK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/3DKPTxt9nK.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/3K5GXTKPrP.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/3K5GXTKPrP.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/3QFEobjwmC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/3QFEobjwmC.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/3RDZKRFFEV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/3RDZKRFFEV.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/3s0rgujAIg.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/3s0rgujAIg.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/4Ax5wLUa4c.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/4Ax5wLUa4c.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/4EsYZXHdpa.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/4EsYZXHdpa.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/4MA1GGxtB2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/4MA1GGxtB2.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/4TA0dltn8Z.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/4TA0dltn8Z.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/4XwovA4lrF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/4XwovA4lrF.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/4iwufNM5Y6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/4iwufNM5Y6.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/4kQSb8Mpxb.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/4kQSb8Mpxb.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/4knxgNV22P.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/4knxgNV22P.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/4prVlpN79q.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/4prVlpN79q.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/54K50WUaKI.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/54K50WUaKI.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/5E9QwsWPit.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/5E9QwsWPit.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/5JUr6L7hij.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/5JUr6L7hij.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/5WMn1FI8mr.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/5WMn1FI8mr.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/5ejPdcXoEW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/5ejPdcXoEW.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/5h6yFrKLct.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/5h6yFrKLct.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/6ezYN7Hv0Z.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/6ezYN7Hv0Z.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/6l2wTrG0a6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/6l2wTrG0a6.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/6oA6qi8Lpj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/6oA6qi8Lpj.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/6pwxM7x9RG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/6pwxM7x9RG.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/70gJ0d6ueN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/70gJ0d6ueN.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/7NBB4SlixM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/7NBB4SlixM.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/7PDb7B0Y2N.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/7PDb7B0Y2N.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/7Pcw6lts4T.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/7Pcw6lts4T.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/7Xcf56RyAr.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/7Xcf56RyAr.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/7n3s1BSMBo.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/7n3s1BSMBo.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/7s32eactiP.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/7s32eactiP.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/81lR1cSmfJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/81lR1cSmfJ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/8dnUV6Vg0Y.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/8dnUV6Vg0Y.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/8tTziwEdcI.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/8tTziwEdcI.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/8zROpBby2x.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/8zROpBby2x.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/90J1b35WV8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/90J1b35WV8.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/91wjEMiEX6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/91wjEMiEX6.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/9EdR9Yk7ca.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/9EdR9Yk7ca.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/9RZxZPNxIu.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/9RZxZPNxIu.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/9TOztQhkC4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/9TOztQhkC4.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/9jWBrTk7UB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/9jWBrTk7UB.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/9lMN6zFkKE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/9lMN6zFkKE.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/9s6IGHapL2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/9s6IGHapL2.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/A01FvWmA8l.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/A01FvWmA8l.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/A3USVyZwFP.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/A3USVyZwFP.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/AGJgFoElmB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/AGJgFoElmB.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/AKEOkMAk9E.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/AKEOkMAk9E.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/ALzR9tiyk8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/ALzR9tiyk8.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/AenL9akVZ7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/AenL9akVZ7.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/AutcanQMIS.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/AutcanQMIS.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/B19N6aMdz3.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/B19N6aMdz3.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/B1EGKnhW9e.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/B1EGKnhW9e.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/B1oQQ08HGH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/B1oQQ08HGH.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/B54wYu3oDA.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/B54wYu3oDA.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/BBTptRbtCv.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/BBTptRbtCv.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/BGGCRglxce.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/BGGCRglxce.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/BP8ChaEEsu.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/BP8ChaEEsu.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/BWk4SOKZaL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/BWk4SOKZaL.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/Bj2rdZWLh7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/Bj2rdZWLh7.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/C0qtj9qPDQ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/C0qtj9qPDQ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/C9re7IuLWT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/C9re7IuLWT.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/CNHSzPEwGH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/CNHSzPEwGH.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/CP3AlJWqrp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/CP3AlJWqrp.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/CWYcYC8app.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/CWYcYC8app.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/Cb3SuEIO21.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/Cb3SuEIO21.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/CoZ4zNyWGC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/CoZ4zNyWGC.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/D1CTthvE4P.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/D1CTthvE4P.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/DFn3iuttpy.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/DFn3iuttpy.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/Dc9KyR2b2p.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/Dc9KyR2b2p.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/Dph3kXOCic.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/Dph3kXOCic.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/Dvpv1gBrUQ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/Dvpv1gBrUQ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/E4qThSDcnD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/E4qThSDcnD.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/EC4qtMsceH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/EC4qtMsceH.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/ERsIqJPx5L.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/ERsIqJPx5L.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/EZXLjw31Dl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/EZXLjw31Dl.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/EsvI0BL049.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/EsvI0BL049.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/F2Pe3EMY8l.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/F2Pe3EMY8l.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/F5lnyEc8P7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/F5lnyEc8P7.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/FCqK7dSpWU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/FCqK7dSpWU.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/FNBWotecr1.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/FNBWotecr1.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/FV6eIbtnYG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/FV6eIbtnYG.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/FXHmkUJdzB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/FXHmkUJdzB.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/Fn00VgWg5Y.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/Fn00VgWg5Y.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/G2sYQwPkhJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/G2sYQwPkhJ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/G5mzA5SBhk.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/G5mzA5SBhk.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/GDxA5zEvt0.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/GDxA5zEvt0.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/GXsAoZzuGz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/GXsAoZzuGz.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/GgA3nIlfrr.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/GgA3nIlfrr.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/Gl9QSM0HL9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/Gl9QSM0HL9.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/HWdd0atzlF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/HWdd0atzlF.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/HjAQJGqXYX.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/HjAQJGqXYX.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/HzjTooszyT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/HzjTooszyT.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/I3R2n3iDwp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/I3R2n3iDwp.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/I5jP7AdXUO.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/I5jP7AdXUO.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/I8b2lta2dV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/I8b2lta2dV.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/IFfft0YbVF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/IFfft0YbVF.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/IcZKeRjvKW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/IcZKeRjvKW.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/IiI7gJ520W.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/IiI7gJ520W.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/Ij3DQuVRk7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/Ij3DQuVRk7.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/IuHoP54Wlc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/IuHoP54Wlc.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/IwYqIz3EHD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/IwYqIz3EHD.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/J0cKBlje4u.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/J0cKBlje4u.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/J1zbYLAkpc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/J1zbYLAkpc.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/J6HXfDOVhX.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/J6HXfDOVhX.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/JH4VhArCNR.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/JH4VhArCNR.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/JXkrGa9mJm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/JXkrGa9mJm.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/JjTVAGnAQr.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/JjTVAGnAQr.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/JptCVz4qEd.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/JptCVz4qEd.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/JtusM5o9mV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/JtusM5o9mV.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/K8foSEhEd6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/K8foSEhEd6.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/KCFf7gu3Y4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/KCFf7gu3Y4.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/KRrQYpA7NN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/KRrQYpA7NN.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/KkW0XInSXe.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/KkW0XInSXe.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/KmUJvvIFQM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/KmUJvvIFQM.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/KwZarRNYrG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/KwZarRNYrG.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/L2R0Fdeoqj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/L2R0Fdeoqj.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/L6Togn7pnd.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/L6Togn7pnd.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/LGFBsMx1Ue.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/LGFBsMx1Ue.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/LKPjaqZzne.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/LKPjaqZzne.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/LTwPCkotqR.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/LTwPCkotqR.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/LlojbpWjs9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/LlojbpWjs9.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/LnGkF3PV4B.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/LnGkF3PV4B.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/Lw6juAfLhZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/Lw6juAfLhZ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/M2wCQaSIkx.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/M2wCQaSIkx.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/M7p8sbE3VI.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/M7p8sbE3VI.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/MAaNEFkxNx.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/MAaNEFkxNx.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/MN57efcLju.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/MN57efcLju.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/MTonphGglM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/MTonphGglM.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/MWxYsdcQAm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/MWxYsdcQAm.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/MiEtLwCnzM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/MiEtLwCnzM.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/Mm2925bgtf.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/Mm2925bgtf.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/MnCQlmeEpx.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/MnCQlmeEpx.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/Mnn3wVQyPT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/Mnn3wVQyPT.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/MwWzEyFzMN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/MwWzEyFzMN.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/N3qbcpPajg.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/N3qbcpPajg.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/NBM2jrtjUt.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/NBM2jrtjUt.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/NDycAe2PMg.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/NDycAe2PMg.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/NVaQ8JUMmp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/NVaQ8JUMmp.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/NauzwofxwH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/NauzwofxwH.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/Ngx37kpASZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/Ngx37kpASZ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/NhzifMsgk2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/NhzifMsgk2.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/NpGzSptAcC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/NpGzSptAcC.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/NpRS0S6JWC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/NpRS0S6JWC.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/NqADIATboI.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/NqADIATboI.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/NwHv5RB2rz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/NwHv5RB2rz.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/O953QNNUI0.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/O953QNNUI0.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/OCchs83O6Y.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/OCchs83O6Y.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/OGxNUCIKC2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/OGxNUCIKC2.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/OJyyKz5GVv.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/OJyyKz5GVv.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/OMOINSyhgb.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/OMOINSyhgb.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/ON96VWl2eE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/ON96VWl2eE.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/OYhonKADC9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/OYhonKADC9.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/OZwHXjKDnl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/OZwHXjKDnl.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/OdEuAfadOv.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/OdEuAfadOv.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/OxyGJylIwW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/OxyGJylIwW.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/PHurkwqv4Z.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/PHurkwqv4Z.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/PXNopPwCXl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/PXNopPwCXl.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/QArvYA1I5y.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/QArvYA1I5y.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/QKdvStkUZD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/QKdvStkUZD.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/QkWxbTjqEQ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/QkWxbTjqEQ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/QoD4gdBKht.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/QoD4gdBKht.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/QxOTHR8Vr5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/QxOTHR8Vr5.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/R4BCKWzeKK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/R4BCKWzeKK.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/RBTWh9W2wN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/RBTWh9W2wN.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/RSdIxOjWTU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/RSdIxOjWTU.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/RVXzOJsITX.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/RVXzOJsITX.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/RVsXeoSc9F.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/RVsXeoSc9F.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/RWTGsJXzQz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/RWTGsJXzQz.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/RYuyMUd2gk.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/RYuyMUd2gk.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/RpX90PHiU0.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/RpX90PHiU0.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/RvpGNGwBDO.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/RvpGNGwBDO.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/RykGa318Dx.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/RykGa318Dx.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/S4670YUK50.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/S4670YUK50.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/S6gLS26ZJ4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/S6gLS26ZJ4.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/S9LbD4Pr4R.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/S9LbD4Pr4R.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/SAOrYUiv3f.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/SAOrYUiv3f.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/SCkYQvq0A9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/SCkYQvq0A9.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/SDPXeHAEsY.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/SDPXeHAEsY.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/SFVT3QJAYW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/SFVT3QJAYW.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/SNuFk4PnW2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/SNuFk4PnW2.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/ShzxZhno8O.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/ShzxZhno8O.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/SnDPKIXHDi.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/SnDPKIXHDi.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/SzCgZ3qNN5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/SzCgZ3qNN5.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/T520ZP6L8T.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/T520ZP6L8T.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/TJTFd5hAYj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/TJTFd5hAYj.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/TRuTR85WZK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/TRuTR85WZK.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/TgwFqiQRdp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/TgwFqiQRdp.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/Tj8JfMPQOP.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/Tj8JfMPQOP.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/TrSKsrbw64.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/TrSKsrbw64.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/TtsQu77nNc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/TtsQu77nNc.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/U5ugQslU2z.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/U5ugQslU2z.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/UP8fkuONg2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/UP8fkuONg2.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/UQd9WJKHHq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/UQd9WJKHHq.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/UdYGjLjpzk.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/UdYGjLjpzk.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/UeKNqkUYqr.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/UeKNqkUYqr.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/UfKa2OpfYT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/UfKa2OpfYT.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/UmSdXFQzs5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/UmSdXFQzs5.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/Uwk8g9mKl8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/Uwk8g9mKl8.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/V39a2Wfhny.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/V39a2Wfhny.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/V6Alb9zB67.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/V6Alb9zB67.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/VBCxRuQlyS.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/VBCxRuQlyS.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/VCeH9ZweWA.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/VCeH9ZweWA.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/VLXVn8J66H.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/VLXVn8J66H.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/VWVKSidnGZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/VWVKSidnGZ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/VYon30GsHO.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/VYon30GsHO.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/Vdgc0ZvuWs.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/Vdgc0ZvuWs.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/VfmDAdXzKM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/VfmDAdXzKM.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/VhYMLsMLrL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/VhYMLsMLrL.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/VxqkIhG88M.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/VxqkIhG88M.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/W5bnoMpunF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/W5bnoMpunF.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/WOpGodfIa8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/WOpGodfIa8.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/WVz16ttXmN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/WVz16ttXmN.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/WZDWUF8ibK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/WZDWUF8ibK.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/X5FuWfVgX6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/X5FuWfVgX6.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/XLacQhFM5v.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/XLacQhFM5v.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/XOK5FCR5BV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/XOK5FCR5BV.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/XSCVXLUIBn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/XSCVXLUIBn.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/XpelL4dfYJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/XpelL4dfYJ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/Y0nmeL8Mk6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/Y0nmeL8Mk6.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/Y3mvjkMqPV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/Y3mvjkMqPV.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/Y5EXqXazv8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/Y5EXqXazv8.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/YGlCkfra9u.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/YGlCkfra9u.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/YHnNk2wz6l.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/YHnNk2wz6l.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/YJDISUV0P9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/YJDISUV0P9.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/YNZk56sw8a.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/YNZk56sw8a.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/YSjosSoyxD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/YSjosSoyxD.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/YYPqiV1dMh.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/YYPqiV1dMh.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/YcFI3Qezx8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/YcFI3Qezx8.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/Z7wOsOEcI7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/Z7wOsOEcI7.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/ZEkMAMmFrT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/ZEkMAMmFrT.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/ZHV48dd3xb.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/ZHV48dd3xb.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/ZPpTfz3cuC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/ZPpTfz3cuC.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/ZSKbzDVpdh.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/ZSKbzDVpdh.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/ZV0dzO1N3D.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/ZV0dzO1N3D.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/ZfCQZQ3Yi4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/ZfCQZQ3Yi4.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/ZgH9SeepAW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/ZgH9SeepAW.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/Zzt021tkHA.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/Zzt021tkHA.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/a1DiihgGoN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/a1DiihgGoN.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/aAzECToODG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/aAzECToODG.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/acAvcgb9wR.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/acAvcgb9wR.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/al6GdI6HHq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/al6GdI6HHq.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/b6lOjv1QB9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/b6lOjv1QB9.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/bCdroQZubL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/bCdroQZubL.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/bGXLKzz8DB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/bGXLKzz8DB.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/bOJODCt4Nj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/bOJODCt4Nj.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/bZMWPiINDJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/bZMWPiINDJ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/bcY4kDXEiL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/bcY4kDXEiL.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/c6ixLi9Yns.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/c6ixLi9Yns.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/cC1vOfH1YD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/cC1vOfH1YD.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/cKgcqJQFSi.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/cKgcqJQFSi.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/cM7YAi3zbW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/cM7YAi3zbW.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/cZb1hdO5AT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/cZb1hdO5AT.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/cjKn08z80L.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/cjKn08z80L.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/cnoFERqEX9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/cnoFERqEX9.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/dBQTDFizrM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/dBQTDFizrM.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/dBXjMyQ6v5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/dBXjMyQ6v5.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/dQcYTBwxmD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/dQcYTBwxmD.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/dVvABT62C9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/dVvABT62C9.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/e3r8e0DiFz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/e3r8e0DiFz.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/eFsp09gaZX.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/eFsp09gaZX.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/eKleS2KN9V.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/eKleS2KN9V.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/eSoalgVCBH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/eSoalgVCBH.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/eVz6pfc2Aq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/eVz6pfc2Aq.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/eYtwlKx3DL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/eYtwlKx3DL.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/ecmluorkUs.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/ecmluorkUs.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/encSaFhW3u.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/encSaFhW3u.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/fEVDUjY0o4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/fEVDUjY0o4.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/fNBZi3EAxz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/fNBZi3EAxz.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/fQ6iyzZG4E.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/fQ6iyzZG4E.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/fkSI356192.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/fkSI356192.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/fqaD1J6KEH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/fqaD1J6KEH.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/fsCqVRe2XV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/fsCqVRe2XV.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/g32LIqIkv7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/g32LIqIkv7.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/g7NcHJ0Dqm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/g7NcHJ0Dqm.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/gKDRuR0huT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/gKDRuR0huT.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/gjl4ArLhJm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/gjl4ArLhJm.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/gvU8LsfGOx.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/gvU8LsfGOx.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/h9Y4PiPY6w.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/h9Y4PiPY6w.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/hchuG3s1rY.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/hchuG3s1rY.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/hnhVAIsmxU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/hnhVAIsmxU.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/hqtR9072e5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/hqtR9072e5.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/i53vKZdcnE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/i53vKZdcnE.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/iBn3UOpKdu.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/iBn3UOpKdu.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/iI6pw0QLBV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/iI6pw0QLBV.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/iQAGO67miB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/iQAGO67miB.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/iTg6zX0H2i.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/iTg6zX0H2i.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/iq57t3NYGm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/iq57t3NYGm.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/ixUQwlLoQl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/ixUQwlLoQl.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/ixp5a4MCzH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/ixp5a4MCzH.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/izrpe1H39g.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/izrpe1H39g.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/j0gOb12WG7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/j0gOb12WG7.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/j41I8z5Dbm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/j41I8z5Dbm.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/j9KVlh9Elu.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/j9KVlh9Elu.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/jEPN6e30lK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/jEPN6e30lK.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/jHoO30hDWC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/jHoO30hDWC.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/jOEODojhaI.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/jOEODojhaI.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/jSdYYlxIPu.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/jSdYYlxIPu.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/kDrpkD1xK6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/kDrpkD1xK6.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/kODlOvWLVJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/kODlOvWLVJ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/koWMEughuG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/koWMEughuG.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/kpmo31UbcA.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/kpmo31UbcA.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/kuu79cE7XV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/kuu79cE7XV.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/ky7lfFDW6q.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/ky7lfFDW6q.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/kyEHvPp7Gk.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/kyEHvPp7Gk.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/lOk975L1YB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/lOk975L1YB.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/lW11AhH3pd.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/lW11AhH3pd.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/llHMuoBQb8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/llHMuoBQb8.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/m8AHxnkobT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/m8AHxnkobT.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/mBub665Sw1.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/mBub665Sw1.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/mKU2FtqWwc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/mKU2FtqWwc.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/mN75YcjhNl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/mN75YcjhNl.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/mhhBA6GJJy.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/mhhBA6GJJy.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/nE3Qa1apaH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/nE3Qa1apaH.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/nT8J5haK6F.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/nT8J5haK6F.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/nUWnom5eaz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/nUWnom5eaz.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/nY4f0rBQfZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/nY4f0rBQfZ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/nenm6c9K9H.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/nenm6c9K9H.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/nrmmmwvAB3.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/nrmmmwvAB3.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/nzdiNgzpBk.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/nzdiNgzpBk.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/oEmtybut45.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/oEmtybut45.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/oV4NuQJ94t.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/oV4NuQJ94t.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/oklahTMTmf.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/oklahTMTmf.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/ors0bDh2bc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/ors0bDh2bc.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/pc50J7VwEQ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/pc50J7VwEQ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/pqukhkAth1.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/pqukhkAth1.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/q5p595DJ6Q.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/q5p595DJ6Q.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/qE0fojpqnw.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/qE0fojpqnw.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/qGpRbiQ2ae.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/qGpRbiQ2ae.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/qoLqfVeYjg.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/qoLqfVeYjg.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/qxfXnYfFUG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/qxfXnYfFUG.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/r8w1v3Z6lL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/r8w1v3Z6lL.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/rMw8A9V28h.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/rMw8A9V28h.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/rZI5VmbmH8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/rZI5VmbmH8.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/rdy3COwDJ8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/rdy3COwDJ8.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/rlmBhex75r.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/rlmBhex75r.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/rn7ZDhqfGn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/rn7ZDhqfGn.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/rse9BAjK8p.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/rse9BAjK8p.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/rxLnaPSdKY.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/rxLnaPSdKY.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/sDb6wxVAlp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/sDb6wxVAlp.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/sHN8Z0s7Zl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/sHN8Z0s7Zl.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/sIk16HKXOH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/sIk16HKXOH.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/sfXrv8XKuT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/sfXrv8XKuT.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/spAP90Xdxo.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/spAP90Xdxo.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/t2LfLuggKw.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/t2LfLuggKw.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/t6anM049gM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/t6anM049gM.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/t6b9ipJFco.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/t6b9ipJFco.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/t88runt2vt.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/t88runt2vt.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/t96N3ukmC2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/t96N3ukmC2.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/tFHSIUZTRU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/tFHSIUZTRU.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/tOBEeyrzR5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/tOBEeyrzR5.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/tqmxPtSV5e.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/tqmxPtSV5e.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/ttgDLEo0YY.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/ttgDLEo0YY.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/tyDsoFs45y.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/tyDsoFs45y.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/tyrqHRTjct.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/tyrqHRTjct.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/uMrfngv4qE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/uMrfngv4qE.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/ufp5xt5UlZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/ufp5xt5UlZ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/ukDSDTeRKn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/ukDSDTeRKn.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/vAhi6T2iCs.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/vAhi6T2iCs.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/vDddl4MmlU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/vDddl4MmlU.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/vLwvkrUp8m.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/vLwvkrUp8m.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/vO7uWdob4g.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/vO7uWdob4g.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/vUjLCf2llh.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/vUjLCf2llh.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/vdOsQV2zZZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/vdOsQV2zZZ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/vqoyQGzxwZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/vqoyQGzxwZ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/vuum3mHSut.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/vuum3mHSut.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/wff7vOGYXM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/wff7vOGYXM.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/wkgn6vRUUp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/wkgn6vRUUp.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/wmDBp8f0Z2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/wmDBp8f0Z2.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/woqch6WNMH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/woqch6WNMH.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/x1AVtHbq4f.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/x1AVtHbq4f.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/xEOJNLq3je.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/xEOJNLq3je.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/xM6CnVshaE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/xM6CnVshaE.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/xOe1maF1HZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/xOe1maF1HZ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/xVFVQAk3u3.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/xVFVQAk3u3.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/xWEhNnxjgn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/xWEhNnxjgn.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/xmhnIZPlm0.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/xmhnIZPlm0.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/xqXMSXBMl8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/xqXMSXBMl8.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/xqemv5BeQH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/xqemv5BeQH.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/y8Wf7aTXFb.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/y8Wf7aTXFb.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/yCWOaOd0DH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/yCWOaOd0DH.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/yI34mPjVtK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/yI34mPjVtK.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/yQu5xEnWkt.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/yQu5xEnWkt.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/yVvQYsdxaq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/yVvQYsdxaq.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/yaMxpb9T34.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/yaMxpb9T34.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/ygTzDOCr3r.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/ygTzDOCr3r.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/z4XWuGECC2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/z4XWuGECC2.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/z9nNYIgtFz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/z9nNYIgtFz.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/zFiwaVTd6p.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/zFiwaVTd6p.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/zI6QHiNniJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/zI6QHiNniJ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/zVrQLGqXwe.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/zVrQLGqXwe.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/zYVWOnWkq4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/zYVWOnWkq4.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/zZ91YoJG9X.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/zZ91YoJG9X.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/zuxZ6Tg1Ha.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1-us/zuxZ6Tg1Ha.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/06T2RNzfTz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/06T2RNzfTz.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/07aN2OB1qj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/07aN2OB1qj.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/0JTPBSFvcC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/0JTPBSFvcC.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/0McUuUDCYj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/0McUuUDCYj.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/0T3L0HU9F5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/0T3L0HU9F5.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/0UrWNfXMbn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/0UrWNfXMbn.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/0We2g9ZRI1.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/0We2g9ZRI1.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/0crDi3Beji.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/0crDi3Beji.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/0dN19RtMpy.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/0dN19RtMpy.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/0nyPk4lS5G.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/0nyPk4lS5G.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/0sV5NP6Raj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/0sV5NP6Raj.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/0tlxl8JzK2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/0tlxl8JzK2.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/13VaDTQa1F.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/13VaDTQa1F.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/177ObAyjaW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/177ObAyjaW.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/1SIwphdqPw.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/1SIwphdqPw.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/1Wku3If0yF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/1Wku3If0yF.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/1fkLnqEKq5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/1fkLnqEKq5.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/1guqW4QDJq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/1guqW4QDJq.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/1zvL3jc30s.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/1zvL3jc30s.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/2BK4YBngu6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/2BK4YBngu6.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/2DcJnHQ1Wc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/2DcJnHQ1Wc.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/2EmGTjbMHL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/2EmGTjbMHL.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/2bgBJIgdGy.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/2bgBJIgdGy.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/3DKPTxt9nK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/3DKPTxt9nK.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/3K5GXTKPrP.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/3K5GXTKPrP.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/3QFEobjwmC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/3QFEobjwmC.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/3RDZKRFFEV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/3RDZKRFFEV.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/3s0rgujAIg.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/3s0rgujAIg.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/4Ax5wLUa4c.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/4Ax5wLUa4c.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/4EsYZXHdpa.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/4EsYZXHdpa.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/4MA1GGxtB2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/4MA1GGxtB2.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/4TA0dltn8Z.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/4TA0dltn8Z.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/4XwovA4lrF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/4XwovA4lrF.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/4iwufNM5Y6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/4iwufNM5Y6.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/4kQSb8Mpxb.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/4kQSb8Mpxb.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/4knxgNV22P.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/4knxgNV22P.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/4prVlpN79q.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/4prVlpN79q.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/54K50WUaKI.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/54K50WUaKI.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/5E9QwsWPit.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/5E9QwsWPit.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/5JUr6L7hij.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/5JUr6L7hij.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/5WMn1FI8mr.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/5WMn1FI8mr.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/5ejPdcXoEW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/5ejPdcXoEW.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/5h6yFrKLct.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/5h6yFrKLct.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/6ezYN7Hv0Z.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/6ezYN7Hv0Z.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/6l2wTrG0a6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/6l2wTrG0a6.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/6oA6qi8Lpj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/6oA6qi8Lpj.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/6pwxM7x9RG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/6pwxM7x9RG.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/70gJ0d6ueN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/70gJ0d6ueN.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/7NBB4SlixM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/7NBB4SlixM.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/7PDb7B0Y2N.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/7PDb7B0Y2N.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/7Pcw6lts4T.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/7Pcw6lts4T.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/7Xcf56RyAr.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/7Xcf56RyAr.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/7n3s1BSMBo.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/7n3s1BSMBo.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/7s32eactiP.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/7s32eactiP.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/81lR1cSmfJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/81lR1cSmfJ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/8dnUV6Vg0Y.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/8dnUV6Vg0Y.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/8tTziwEdcI.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/8tTziwEdcI.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/8zROpBby2x.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/8zROpBby2x.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/90J1b35WV8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/90J1b35WV8.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/91wjEMiEX6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/91wjEMiEX6.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/9EdR9Yk7ca.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/9EdR9Yk7ca.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/9RZxZPNxIu.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/9RZxZPNxIu.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/9TOztQhkC4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/9TOztQhkC4.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/9jWBrTk7UB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/9jWBrTk7UB.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/9lMN6zFkKE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/9lMN6zFkKE.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/9s6IGHapL2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/9s6IGHapL2.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/A01FvWmA8l.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/A01FvWmA8l.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/A3USVyZwFP.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/A3USVyZwFP.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/AGJgFoElmB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/AGJgFoElmB.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/AKEOkMAk9E.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/AKEOkMAk9E.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/ALzR9tiyk8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/ALzR9tiyk8.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/AenL9akVZ7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/AenL9akVZ7.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/AutcanQMIS.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/AutcanQMIS.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/B19N6aMdz3.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/B19N6aMdz3.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/B1EGKnhW9e.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/B1EGKnhW9e.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/B1oQQ08HGH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/B1oQQ08HGH.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/B54wYu3oDA.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/B54wYu3oDA.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/BBTptRbtCv.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/BBTptRbtCv.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/BGGCRglxce.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/BGGCRglxce.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/BP8ChaEEsu.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/BP8ChaEEsu.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/BWk4SOKZaL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/BWk4SOKZaL.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/Bj2rdZWLh7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/Bj2rdZWLh7.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/C0qtj9qPDQ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/C0qtj9qPDQ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/C9re7IuLWT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/C9re7IuLWT.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/CNHSzPEwGH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/CNHSzPEwGH.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/CP3AlJWqrp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/CP3AlJWqrp.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/CWYcYC8app.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/CWYcYC8app.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/Cb3SuEIO21.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/Cb3SuEIO21.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/CoZ4zNyWGC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/CoZ4zNyWGC.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/D1CTthvE4P.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/D1CTthvE4P.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/DFn3iuttpy.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/DFn3iuttpy.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/Dc9KyR2b2p.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/Dc9KyR2b2p.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/Dph3kXOCic.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/Dph3kXOCic.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/Dvpv1gBrUQ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/Dvpv1gBrUQ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/E4qThSDcnD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/E4qThSDcnD.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/EC4qtMsceH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/EC4qtMsceH.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/ERsIqJPx5L.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/ERsIqJPx5L.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/EZXLjw31Dl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/EZXLjw31Dl.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/EsvI0BL049.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/EsvI0BL049.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/F2Pe3EMY8l.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/F2Pe3EMY8l.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/F5lnyEc8P7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/F5lnyEc8P7.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/FCqK7dSpWU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/FCqK7dSpWU.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/FNBWotecr1.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/FNBWotecr1.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/FV6eIbtnYG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/FV6eIbtnYG.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/FXHmkUJdzB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/FXHmkUJdzB.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/Fn00VgWg5Y.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/Fn00VgWg5Y.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/G2sYQwPkhJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/G2sYQwPkhJ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/G5mzA5SBhk.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/G5mzA5SBhk.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/GDxA5zEvt0.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/GDxA5zEvt0.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/GXsAoZzuGz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/GXsAoZzuGz.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/GgA3nIlfrr.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/GgA3nIlfrr.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/Gl9QSM0HL9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/Gl9QSM0HL9.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/HWdd0atzlF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/HWdd0atzlF.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/HjAQJGqXYX.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/HjAQJGqXYX.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/HzjTooszyT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/HzjTooszyT.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/I3R2n3iDwp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/I3R2n3iDwp.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/I5jP7AdXUO.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/I5jP7AdXUO.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/I8b2lta2dV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/I8b2lta2dV.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/IFfft0YbVF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/IFfft0YbVF.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/IcZKeRjvKW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/IcZKeRjvKW.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/IiI7gJ520W.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/IiI7gJ520W.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/Ij3DQuVRk7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/Ij3DQuVRk7.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/IuHoP54Wlc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/IuHoP54Wlc.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/IwYqIz3EHD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/IwYqIz3EHD.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/J0cKBlje4u.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/J0cKBlje4u.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/J1zbYLAkpc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/J1zbYLAkpc.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/J6HXfDOVhX.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/J6HXfDOVhX.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/JH4VhArCNR.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/JH4VhArCNR.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/JXkrGa9mJm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/JXkrGa9mJm.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/JjTVAGnAQr.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/JjTVAGnAQr.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/JptCVz4qEd.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/JptCVz4qEd.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/JtusM5o9mV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/JtusM5o9mV.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/K8foSEhEd6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/K8foSEhEd6.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/KCFf7gu3Y4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/KCFf7gu3Y4.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/KRrQYpA7NN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/KRrQYpA7NN.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/KkW0XInSXe.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/KkW0XInSXe.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/KmUJvvIFQM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/KmUJvvIFQM.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/KwZarRNYrG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/KwZarRNYrG.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/L2R0Fdeoqj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/L2R0Fdeoqj.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/L6Togn7pnd.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/L6Togn7pnd.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/LGFBsMx1Ue.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/LGFBsMx1Ue.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/LKPjaqZzne.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/LKPjaqZzne.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/LTwPCkotqR.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/LTwPCkotqR.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/LlojbpWjs9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/LlojbpWjs9.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/LnGkF3PV4B.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/LnGkF3PV4B.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/Lw6juAfLhZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/Lw6juAfLhZ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/M2wCQaSIkx.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/M2wCQaSIkx.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/M7p8sbE3VI.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/M7p8sbE3VI.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/MAaNEFkxNx.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/MAaNEFkxNx.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/MN57efcLju.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/MN57efcLju.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/MTonphGglM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/MTonphGglM.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/MWxYsdcQAm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/MWxYsdcQAm.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/MiEtLwCnzM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/MiEtLwCnzM.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/Mm2925bgtf.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/Mm2925bgtf.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/MnCQlmeEpx.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/MnCQlmeEpx.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/Mnn3wVQyPT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/Mnn3wVQyPT.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/MwWzEyFzMN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/MwWzEyFzMN.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/N3qbcpPajg.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/N3qbcpPajg.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/NBM2jrtjUt.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/NBM2jrtjUt.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/NDycAe2PMg.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/NDycAe2PMg.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/NVaQ8JUMmp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/NVaQ8JUMmp.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/NauzwofxwH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/NauzwofxwH.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/Ngx37kpASZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/Ngx37kpASZ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/NhzifMsgk2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/NhzifMsgk2.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/NpGzSptAcC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/NpGzSptAcC.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/NpRS0S6JWC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/NpRS0S6JWC.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/NqADIATboI.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/NqADIATboI.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/NwHv5RB2rz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/NwHv5RB2rz.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/O953QNNUI0.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/O953QNNUI0.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/OCchs83O6Y.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/OCchs83O6Y.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/OGxNUCIKC2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/OGxNUCIKC2.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/OJyyKz5GVv.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/OJyyKz5GVv.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/OMOINSyhgb.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/OMOINSyhgb.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/ON96VWl2eE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/ON96VWl2eE.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/OYhonKADC9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/OYhonKADC9.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/OZwHXjKDnl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/OZwHXjKDnl.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/OdEuAfadOv.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/OdEuAfadOv.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/OxyGJylIwW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/OxyGJylIwW.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/PHurkwqv4Z.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/PHurkwqv4Z.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/PXNopPwCXl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/PXNopPwCXl.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/QArvYA1I5y.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/QArvYA1I5y.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/QKdvStkUZD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/QKdvStkUZD.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/QkWxbTjqEQ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/QkWxbTjqEQ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/QoD4gdBKht.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/QoD4gdBKht.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/QxOTHR8Vr5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/QxOTHR8Vr5.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/R4BCKWzeKK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/R4BCKWzeKK.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/RBTWh9W2wN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/RBTWh9W2wN.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/RSdIxOjWTU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/RSdIxOjWTU.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/RVXzOJsITX.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/RVXzOJsITX.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/RVsXeoSc9F.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/RVsXeoSc9F.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/RWTGsJXzQz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/RWTGsJXzQz.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/RYuyMUd2gk.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/RYuyMUd2gk.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/RpX90PHiU0.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/RpX90PHiU0.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/RvpGNGwBDO.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/RvpGNGwBDO.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/RykGa318Dx.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/RykGa318Dx.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/S4670YUK50.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/S4670YUK50.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/S6gLS26ZJ4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/S6gLS26ZJ4.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/S9LbD4Pr4R.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/S9LbD4Pr4R.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/SAOrYUiv3f.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/SAOrYUiv3f.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/SCkYQvq0A9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/SCkYQvq0A9.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/SDPXeHAEsY.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/SDPXeHAEsY.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/SFVT3QJAYW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/SFVT3QJAYW.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/SNuFk4PnW2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/SNuFk4PnW2.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/ShzxZhno8O.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/ShzxZhno8O.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/SnDPKIXHDi.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/SnDPKIXHDi.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/SzCgZ3qNN5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/SzCgZ3qNN5.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/T520ZP6L8T.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/T520ZP6L8T.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/TJTFd5hAYj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/TJTFd5hAYj.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/TRuTR85WZK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/TRuTR85WZK.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/TgwFqiQRdp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/TgwFqiQRdp.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/Tj8JfMPQOP.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/Tj8JfMPQOP.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/TrSKsrbw64.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/TrSKsrbw64.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/TtsQu77nNc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/TtsQu77nNc.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/U5ugQslU2z.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/U5ugQslU2z.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/UP8fkuONg2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/UP8fkuONg2.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/UQd9WJKHHq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/UQd9WJKHHq.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/UdYGjLjpzk.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/UdYGjLjpzk.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/UeKNqkUYqr.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/UeKNqkUYqr.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/UfKa2OpfYT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/UfKa2OpfYT.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/UmSdXFQzs5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/UmSdXFQzs5.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/Uwk8g9mKl8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/Uwk8g9mKl8.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/V39a2Wfhny.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/V39a2Wfhny.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/V6Alb9zB67.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/V6Alb9zB67.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/VBCxRuQlyS.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/VBCxRuQlyS.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/VCeH9ZweWA.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/VCeH9ZweWA.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/VLXVn8J66H.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/VLXVn8J66H.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/VWVKSidnGZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/VWVKSidnGZ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/VYon30GsHO.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/VYon30GsHO.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/Vdgc0ZvuWs.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/Vdgc0ZvuWs.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/VfmDAdXzKM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/VfmDAdXzKM.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/VhYMLsMLrL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/VhYMLsMLrL.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/VxqkIhG88M.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/VxqkIhG88M.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/W5bnoMpunF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/W5bnoMpunF.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/WOpGodfIa8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/WOpGodfIa8.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/WVz16ttXmN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/WVz16ttXmN.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/WZDWUF8ibK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/WZDWUF8ibK.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/X5FuWfVgX6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/X5FuWfVgX6.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/XLacQhFM5v.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/XLacQhFM5v.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/XOK5FCR5BV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/XOK5FCR5BV.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/XSCVXLUIBn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/XSCVXLUIBn.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/XpelL4dfYJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/XpelL4dfYJ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/Y0nmeL8Mk6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/Y0nmeL8Mk6.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/Y3mvjkMqPV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/Y3mvjkMqPV.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/Y5EXqXazv8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/Y5EXqXazv8.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/YGlCkfra9u.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/YGlCkfra9u.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/YHnNk2wz6l.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/YHnNk2wz6l.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/YJDISUV0P9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/YJDISUV0P9.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/YNZk56sw8a.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/YNZk56sw8a.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/YSjosSoyxD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/YSjosSoyxD.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/YYPqiV1dMh.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/YYPqiV1dMh.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/YcFI3Qezx8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/YcFI3Qezx8.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/Z7wOsOEcI7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/Z7wOsOEcI7.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/ZEkMAMmFrT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/ZEkMAMmFrT.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/ZHV48dd3xb.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/ZHV48dd3xb.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/ZPpTfz3cuC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/ZPpTfz3cuC.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/ZSKbzDVpdh.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/ZSKbzDVpdh.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/ZV0dzO1N3D.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/ZV0dzO1N3D.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/ZfCQZQ3Yi4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/ZfCQZQ3Yi4.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/ZgH9SeepAW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/ZgH9SeepAW.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/Zzt021tkHA.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/Zzt021tkHA.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/a1DiihgGoN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/a1DiihgGoN.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/aAzECToODG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/aAzECToODG.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/acAvcgb9wR.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/acAvcgb9wR.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/al6GdI6HHq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/al6GdI6HHq.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/b6lOjv1QB9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/b6lOjv1QB9.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/bCdroQZubL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/bCdroQZubL.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/bGXLKzz8DB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/bGXLKzz8DB.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/bOJODCt4Nj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/bOJODCt4Nj.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/bZMWPiINDJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/bZMWPiINDJ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/bcY4kDXEiL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/bcY4kDXEiL.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/c6ixLi9Yns.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/c6ixLi9Yns.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/cC1vOfH1YD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/cC1vOfH1YD.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/cKgcqJQFSi.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/cKgcqJQFSi.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/cM7YAi3zbW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/cM7YAi3zbW.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/cZb1hdO5AT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/cZb1hdO5AT.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/cjKn08z80L.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/cjKn08z80L.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/cnoFERqEX9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/cnoFERqEX9.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/dBQTDFizrM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/dBQTDFizrM.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/dBXjMyQ6v5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/dBXjMyQ6v5.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/dQcYTBwxmD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/dQcYTBwxmD.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/dVvABT62C9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/dVvABT62C9.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/e3r8e0DiFz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/e3r8e0DiFz.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/eFsp09gaZX.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/eFsp09gaZX.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/eKleS2KN9V.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/eKleS2KN9V.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/eSoalgVCBH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/eSoalgVCBH.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/eVz6pfc2Aq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/eVz6pfc2Aq.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/eYtwlKx3DL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/eYtwlKx3DL.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/ecmluorkUs.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/ecmluorkUs.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/encSaFhW3u.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/encSaFhW3u.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/fEVDUjY0o4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/fEVDUjY0o4.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/fNBZi3EAxz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/fNBZi3EAxz.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/fQ6iyzZG4E.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/fQ6iyzZG4E.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/fkSI356192.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/fkSI356192.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/fqaD1J6KEH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/fqaD1J6KEH.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/fsCqVRe2XV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/fsCqVRe2XV.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/g32LIqIkv7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/g32LIqIkv7.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/g7NcHJ0Dqm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/g7NcHJ0Dqm.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/gKDRuR0huT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/gKDRuR0huT.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/gjl4ArLhJm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/gjl4ArLhJm.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/gvU8LsfGOx.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/gvU8LsfGOx.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/h9Y4PiPY6w.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/h9Y4PiPY6w.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/hchuG3s1rY.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/hchuG3s1rY.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/hnhVAIsmxU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/hnhVAIsmxU.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/hqtR9072e5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/hqtR9072e5.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/i53vKZdcnE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/i53vKZdcnE.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/iBn3UOpKdu.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/iBn3UOpKdu.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/iI6pw0QLBV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/iI6pw0QLBV.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/iQAGO67miB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/iQAGO67miB.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/iTg6zX0H2i.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/iTg6zX0H2i.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/iq57t3NYGm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/iq57t3NYGm.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/ixUQwlLoQl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/ixUQwlLoQl.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/ixp5a4MCzH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/ixp5a4MCzH.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/izrpe1H39g.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/izrpe1H39g.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/j0gOb12WG7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/j0gOb12WG7.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/j41I8z5Dbm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/j41I8z5Dbm.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/j9KVlh9Elu.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/j9KVlh9Elu.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/jEPN6e30lK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/jEPN6e30lK.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/jHoO30hDWC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/jHoO30hDWC.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/jOEODojhaI.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/jOEODojhaI.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/jSdYYlxIPu.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/jSdYYlxIPu.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/kDrpkD1xK6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/kDrpkD1xK6.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/kODlOvWLVJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/kODlOvWLVJ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/koWMEughuG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/koWMEughuG.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/kpmo31UbcA.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/kpmo31UbcA.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/kuu79cE7XV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/kuu79cE7XV.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/ky7lfFDW6q.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/ky7lfFDW6q.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/kyEHvPp7Gk.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/kyEHvPp7Gk.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/lOk975L1YB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/lOk975L1YB.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/lW11AhH3pd.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/lW11AhH3pd.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/llHMuoBQb8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/llHMuoBQb8.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/m8AHxnkobT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/m8AHxnkobT.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/mBub665Sw1.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/mBub665Sw1.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/mKU2FtqWwc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/mKU2FtqWwc.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/mN75YcjhNl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/mN75YcjhNl.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/mhhBA6GJJy.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/mhhBA6GJJy.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/nE3Qa1apaH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/nE3Qa1apaH.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/nT8J5haK6F.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/nT8J5haK6F.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/nUWnom5eaz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/nUWnom5eaz.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/nY4f0rBQfZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/nY4f0rBQfZ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/nenm6c9K9H.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/nenm6c9K9H.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/nrmmmwvAB3.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/nrmmmwvAB3.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/nzdiNgzpBk.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/nzdiNgzpBk.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/oEmtybut45.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/oEmtybut45.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/oV4NuQJ94t.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/oV4NuQJ94t.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/oklahTMTmf.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/oklahTMTmf.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/ors0bDh2bc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/ors0bDh2bc.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/pc50J7VwEQ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/pc50J7VwEQ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/pqukhkAth1.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/pqukhkAth1.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/q5p595DJ6Q.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/q5p595DJ6Q.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/qE0fojpqnw.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/qE0fojpqnw.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/qGpRbiQ2ae.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/qGpRbiQ2ae.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/qoLqfVeYjg.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/qoLqfVeYjg.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/qxfXnYfFUG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/qxfXnYfFUG.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/r8w1v3Z6lL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/r8w1v3Z6lL.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/rMw8A9V28h.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/rMw8A9V28h.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/rZI5VmbmH8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/rZI5VmbmH8.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/rdy3COwDJ8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/rdy3COwDJ8.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/rlmBhex75r.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/rlmBhex75r.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/rn7ZDhqfGn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/rn7ZDhqfGn.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/rse9BAjK8p.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/rse9BAjK8p.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/rxLnaPSdKY.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/rxLnaPSdKY.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/sDb6wxVAlp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/sDb6wxVAlp.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/sHN8Z0s7Zl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/sHN8Z0s7Zl.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/sIk16HKXOH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/sIk16HKXOH.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/sfXrv8XKuT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/sfXrv8XKuT.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/spAP90Xdxo.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/spAP90Xdxo.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/t2LfLuggKw.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/t2LfLuggKw.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/t6anM049gM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/t6anM049gM.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/t6b9ipJFco.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/t6b9ipJFco.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/t88runt2vt.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/t88runt2vt.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/t96N3ukmC2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/t96N3ukmC2.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/tFHSIUZTRU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/tFHSIUZTRU.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/tOBEeyrzR5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/tOBEeyrzR5.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/tqmxPtSV5e.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/tqmxPtSV5e.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/ttgDLEo0YY.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/ttgDLEo0YY.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/tyDsoFs45y.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/tyDsoFs45y.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/tyrqHRTjct.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/tyrqHRTjct.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/uMrfngv4qE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/uMrfngv4qE.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/ufp5xt5UlZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/ufp5xt5UlZ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/ukDSDTeRKn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/ukDSDTeRKn.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/vAhi6T2iCs.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/vAhi6T2iCs.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/vDddl4MmlU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/vDddl4MmlU.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/vLwvkrUp8m.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/vLwvkrUp8m.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/vO7uWdob4g.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/vO7uWdob4g.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/vUjLCf2llh.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/vUjLCf2llh.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/vdOsQV2zZZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/vdOsQV2zZZ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/vqoyQGzxwZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/vqoyQGzxwZ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/vuum3mHSut.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/vuum3mHSut.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/wff7vOGYXM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/wff7vOGYXM.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/wkgn6vRUUp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/wkgn6vRUUp.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/wmDBp8f0Z2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/wmDBp8f0Z2.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/woqch6WNMH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/woqch6WNMH.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/x1AVtHbq4f.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/x1AVtHbq4f.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/xEOJNLq3je.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/xEOJNLq3je.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/xM6CnVshaE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/xM6CnVshaE.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/xOe1maF1HZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/xOe1maF1HZ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/xVFVQAk3u3.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/xVFVQAk3u3.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/xWEhNnxjgn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/xWEhNnxjgn.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/xmhnIZPlm0.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/xmhnIZPlm0.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/xqXMSXBMl8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/xqXMSXBMl8.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/xqemv5BeQH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/xqemv5BeQH.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/y8Wf7aTXFb.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/y8Wf7aTXFb.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/yCWOaOd0DH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/yCWOaOd0DH.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/yI34mPjVtK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/yI34mPjVtK.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/yQu5xEnWkt.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/yQu5xEnWkt.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/yVvQYsdxaq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/yVvQYsdxaq.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/yaMxpb9T34.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/yaMxpb9T34.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/ygTzDOCr3r.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/ygTzDOCr3r.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/z4XWuGECC2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/z4XWuGECC2.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/z9nNYIgtFz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/z9nNYIgtFz.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/zFiwaVTd6p.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/zFiwaVTd6p.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/zI6QHiNniJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/zI6QHiNniJ.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/zVrQLGqXwe.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/zVrQLGqXwe.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/zYVWOnWkq4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/zYVWOnWkq4.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/zZ91YoJG9X.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/zZ91YoJG9X.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/zuxZ6Tg1Ha.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.6.1/zuxZ6Tg1Ha.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/06T2RNzfTz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/06T2RNzfTz.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/07aN2OB1qj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/07aN2OB1qj.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/0JTPBSFvcC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/0JTPBSFvcC.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/0McUuUDCYj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/0McUuUDCYj.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/0T3L0HU9F5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/0T3L0HU9F5.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/0UrWNfXMbn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/0UrWNfXMbn.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/0We2g9ZRI1.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/0We2g9ZRI1.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/0crDi3Beji.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/0crDi3Beji.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/0dN19RtMpy.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/0dN19RtMpy.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/0nyPk4lS5G.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/0nyPk4lS5G.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/0sV5NP6Raj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/0sV5NP6Raj.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/0tlxl8JzK2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/0tlxl8JzK2.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/13VaDTQa1F.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/13VaDTQa1F.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/177ObAyjaW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/177ObAyjaW.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/1SIwphdqPw.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/1SIwphdqPw.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/1Wku3If0yF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/1Wku3If0yF.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/1fkLnqEKq5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/1fkLnqEKq5.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/1guqW4QDJq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/1guqW4QDJq.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/1zvL3jc30s.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/1zvL3jc30s.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/2BK4YBngu6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/2BK4YBngu6.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/2DcJnHQ1Wc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/2DcJnHQ1Wc.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/2EmGTjbMHL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/2EmGTjbMHL.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/2bgBJIgdGy.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/2bgBJIgdGy.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/3DKPTxt9nK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/3DKPTxt9nK.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/3K5GXTKPrP.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/3K5GXTKPrP.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/3QFEobjwmC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/3QFEobjwmC.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/3RDZKRFFEV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/3RDZKRFFEV.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/3s0rgujAIg.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/3s0rgujAIg.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/4Ax5wLUa4c.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/4Ax5wLUa4c.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/4EsYZXHdpa.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/4EsYZXHdpa.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/4MA1GGxtB2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/4MA1GGxtB2.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/4TA0dltn8Z.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/4TA0dltn8Z.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/4XwovA4lrF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/4XwovA4lrF.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/4iwufNM5Y6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/4iwufNM5Y6.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/4kQSb8Mpxb.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/4kQSb8Mpxb.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/4knxgNV22P.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/4knxgNV22P.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/4prVlpN79q.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/4prVlpN79q.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/54K50WUaKI.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/54K50WUaKI.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/5E9QwsWPit.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/5E9QwsWPit.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/5JUr6L7hij.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/5JUr6L7hij.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/5WMn1FI8mr.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/5WMn1FI8mr.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/5ejPdcXoEW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/5ejPdcXoEW.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/5h6yFrKLct.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/5h6yFrKLct.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/6ezYN7Hv0Z.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/6ezYN7Hv0Z.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/6l2wTrG0a6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/6l2wTrG0a6.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/6oA6qi8Lpj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/6oA6qi8Lpj.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/6pwxM7x9RG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/6pwxM7x9RG.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/70gJ0d6ueN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/70gJ0d6ueN.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/7NBB4SlixM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/7NBB4SlixM.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/7PDb7B0Y2N.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/7PDb7B0Y2N.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/7Pcw6lts4T.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/7Pcw6lts4T.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/7Xcf56RyAr.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/7Xcf56RyAr.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/7n3s1BSMBo.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/7n3s1BSMBo.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/7s32eactiP.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/7s32eactiP.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/81lR1cSmfJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/81lR1cSmfJ.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/8dnUV6Vg0Y.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/8dnUV6Vg0Y.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/8tTziwEdcI.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/8tTziwEdcI.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/8zROpBby2x.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/8zROpBby2x.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/90J1b35WV8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/90J1b35WV8.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/91wjEMiEX6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/91wjEMiEX6.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/9EdR9Yk7ca.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/9EdR9Yk7ca.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/9RZxZPNxIu.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/9RZxZPNxIu.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/9TOztQhkC4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/9TOztQhkC4.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/9jWBrTk7UB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/9jWBrTk7UB.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/9lMN6zFkKE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/9lMN6zFkKE.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/9s6IGHapL2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/9s6IGHapL2.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/A01FvWmA8l.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/A01FvWmA8l.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/A3USVyZwFP.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/A3USVyZwFP.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/AGJgFoElmB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/AGJgFoElmB.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/AKEOkMAk9E.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/AKEOkMAk9E.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/ALzR9tiyk8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/ALzR9tiyk8.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/AenL9akVZ7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/AenL9akVZ7.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/AutcanQMIS.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/AutcanQMIS.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/B19N6aMdz3.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/B19N6aMdz3.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/B1EGKnhW9e.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/B1EGKnhW9e.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/B1oQQ08HGH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/B1oQQ08HGH.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/B54wYu3oDA.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/B54wYu3oDA.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/BBTptRbtCv.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/BBTptRbtCv.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/BGGCRglxce.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/BGGCRglxce.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/BP8ChaEEsu.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/BP8ChaEEsu.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/BWk4SOKZaL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/BWk4SOKZaL.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/Bj2rdZWLh7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/Bj2rdZWLh7.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/C0qtj9qPDQ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/C0qtj9qPDQ.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/C9re7IuLWT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/C9re7IuLWT.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/CNHSzPEwGH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/CNHSzPEwGH.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/CP3AlJWqrp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/CP3AlJWqrp.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/CWYcYC8app.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/CWYcYC8app.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/Cb3SuEIO21.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/Cb3SuEIO21.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/CoZ4zNyWGC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/CoZ4zNyWGC.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/D1CTthvE4P.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/D1CTthvE4P.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/DFn3iuttpy.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/DFn3iuttpy.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/Dc9KyR2b2p.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/Dc9KyR2b2p.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/Dph3kXOCic.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/Dph3kXOCic.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/Dvpv1gBrUQ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/Dvpv1gBrUQ.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/E4qThSDcnD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/E4qThSDcnD.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/EC4qtMsceH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/EC4qtMsceH.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/ERsIqJPx5L.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/ERsIqJPx5L.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/EZXLjw31Dl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/EZXLjw31Dl.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/EsvI0BL049.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/EsvI0BL049.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/F2Pe3EMY8l.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/F2Pe3EMY8l.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/F5lnyEc8P7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/F5lnyEc8P7.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/FCqK7dSpWU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/FCqK7dSpWU.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/FNBWotecr1.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/FNBWotecr1.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/FV6eIbtnYG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/FV6eIbtnYG.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/FXHmkUJdzB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/FXHmkUJdzB.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/Fn00VgWg5Y.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/Fn00VgWg5Y.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/G2sYQwPkhJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/G2sYQwPkhJ.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/G5mzA5SBhk.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/G5mzA5SBhk.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/GDxA5zEvt0.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/GDxA5zEvt0.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/GXsAoZzuGz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/GXsAoZzuGz.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/GgA3nIlfrr.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/GgA3nIlfrr.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/Gl9QSM0HL9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/Gl9QSM0HL9.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/HWdd0atzlF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/HWdd0atzlF.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/HjAQJGqXYX.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/HjAQJGqXYX.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/HzjTooszyT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/HzjTooszyT.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/I3R2n3iDwp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/I3R2n3iDwp.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/I5jP7AdXUO.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/I5jP7AdXUO.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/I8b2lta2dV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/I8b2lta2dV.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/IFfft0YbVF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/IFfft0YbVF.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/IcZKeRjvKW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/IcZKeRjvKW.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/IiI7gJ520W.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/IiI7gJ520W.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/Ij3DQuVRk7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/Ij3DQuVRk7.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/IuHoP54Wlc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/IuHoP54Wlc.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/IwYqIz3EHD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/IwYqIz3EHD.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/J0cKBlje4u.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/J0cKBlje4u.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/J1zbYLAkpc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/J1zbYLAkpc.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/J6HXfDOVhX.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/J6HXfDOVhX.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/JH4VhArCNR.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/JH4VhArCNR.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/JXkrGa9mJm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/JXkrGa9mJm.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/JjTVAGnAQr.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/JjTVAGnAQr.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/JptCVz4qEd.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/JptCVz4qEd.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/JtusM5o9mV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/JtusM5o9mV.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/K8foSEhEd6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/K8foSEhEd6.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/KCFf7gu3Y4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/KCFf7gu3Y4.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/KRrQYpA7NN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/KRrQYpA7NN.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/KkW0XInSXe.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/KkW0XInSXe.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/KmUJvvIFQM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/KmUJvvIFQM.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/KwZarRNYrG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/KwZarRNYrG.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/L2R0Fdeoqj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/L2R0Fdeoqj.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/L6Togn7pnd.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/L6Togn7pnd.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/LGFBsMx1Ue.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/LGFBsMx1Ue.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/LKPjaqZzne.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/LKPjaqZzne.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/LTwPCkotqR.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/LTwPCkotqR.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/LlojbpWjs9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/LlojbpWjs9.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/LnGkF3PV4B.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/LnGkF3PV4B.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/Lw6juAfLhZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/Lw6juAfLhZ.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/M2wCQaSIkx.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/M2wCQaSIkx.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/M7p8sbE3VI.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/M7p8sbE3VI.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/MAaNEFkxNx.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/MAaNEFkxNx.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/MN57efcLju.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/MN57efcLju.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/MTonphGglM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/MTonphGglM.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/MWxYsdcQAm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/MWxYsdcQAm.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/MiEtLwCnzM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/MiEtLwCnzM.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/Mm2925bgtf.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/Mm2925bgtf.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/MnCQlmeEpx.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/MnCQlmeEpx.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/Mnn3wVQyPT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/Mnn3wVQyPT.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/MwWzEyFzMN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/MwWzEyFzMN.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/N3qbcpPajg.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/N3qbcpPajg.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/NBM2jrtjUt.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/NBM2jrtjUt.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/NDycAe2PMg.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/NDycAe2PMg.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/NVaQ8JUMmp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/NVaQ8JUMmp.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/NauzwofxwH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/NauzwofxwH.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/Ngx37kpASZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/Ngx37kpASZ.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/NhzifMsgk2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/NhzifMsgk2.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/NpGzSptAcC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/NpGzSptAcC.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/NpRS0S6JWC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/NpRS0S6JWC.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/NqADIATboI.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/NqADIATboI.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/NwHv5RB2rz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/NwHv5RB2rz.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/O953QNNUI0.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/O953QNNUI0.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/OCchs83O6Y.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/OCchs83O6Y.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/OGxNUCIKC2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/OGxNUCIKC2.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/OJyyKz5GVv.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/OJyyKz5GVv.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/OMOINSyhgb.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/OMOINSyhgb.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/ON96VWl2eE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/ON96VWl2eE.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/OYhonKADC9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/OYhonKADC9.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/OZwHXjKDnl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/OZwHXjKDnl.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/OdEuAfadOv.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/OdEuAfadOv.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/OxyGJylIwW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/OxyGJylIwW.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/PHurkwqv4Z.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/PHurkwqv4Z.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/PXNopPwCXl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/PXNopPwCXl.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/QArvYA1I5y.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/QArvYA1I5y.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/QKdvStkUZD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/QKdvStkUZD.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/QkWxbTjqEQ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/QkWxbTjqEQ.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/QoD4gdBKht.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/QoD4gdBKht.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/QxOTHR8Vr5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/QxOTHR8Vr5.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/R4BCKWzeKK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/R4BCKWzeKK.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/RBTWh9W2wN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/RBTWh9W2wN.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/RSdIxOjWTU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/RSdIxOjWTU.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/RVXzOJsITX.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/RVXzOJsITX.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/RVsXeoSc9F.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/RVsXeoSc9F.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/RWTGsJXzQz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/RWTGsJXzQz.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/RYuyMUd2gk.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/RYuyMUd2gk.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/RpX90PHiU0.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/RpX90PHiU0.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/RvpGNGwBDO.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/RvpGNGwBDO.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/RykGa318Dx.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/RykGa318Dx.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/S4670YUK50.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/S4670YUK50.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/S6gLS26ZJ4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/S6gLS26ZJ4.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/S9LbD4Pr4R.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/S9LbD4Pr4R.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/SAOrYUiv3f.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/SAOrYUiv3f.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/SCkYQvq0A9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/SCkYQvq0A9.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/SDPXeHAEsY.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/SDPXeHAEsY.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/SFVT3QJAYW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/SFVT3QJAYW.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/SNuFk4PnW2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/SNuFk4PnW2.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/ShzxZhno8O.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/ShzxZhno8O.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/SnDPKIXHDi.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/SnDPKIXHDi.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/SzCgZ3qNN5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/SzCgZ3qNN5.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/T520ZP6L8T.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/T520ZP6L8T.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/TJTFd5hAYj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/TJTFd5hAYj.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/TRuTR85WZK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/TRuTR85WZK.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/TgwFqiQRdp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/TgwFqiQRdp.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/Tj8JfMPQOP.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/Tj8JfMPQOP.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/TrSKsrbw64.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/TrSKsrbw64.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/TtsQu77nNc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/TtsQu77nNc.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/U5ugQslU2z.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/U5ugQslU2z.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/UP8fkuONg2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/UP8fkuONg2.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/UQd9WJKHHq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/UQd9WJKHHq.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/UdYGjLjpzk.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/UdYGjLjpzk.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/UeKNqkUYqr.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/UeKNqkUYqr.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/UfKa2OpfYT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/UfKa2OpfYT.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/UmSdXFQzs5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/UmSdXFQzs5.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/Uwk8g9mKl8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/Uwk8g9mKl8.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/V39a2Wfhny.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/V39a2Wfhny.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/V6Alb9zB67.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/V6Alb9zB67.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/VBCxRuQlyS.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/VBCxRuQlyS.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/VCeH9ZweWA.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/VCeH9ZweWA.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/VLXVn8J66H.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/VLXVn8J66H.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/VWVKSidnGZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/VWVKSidnGZ.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/VYon30GsHO.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/VYon30GsHO.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/Vdgc0ZvuWs.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/Vdgc0ZvuWs.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/VfmDAdXzKM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/VfmDAdXzKM.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/VhYMLsMLrL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/VhYMLsMLrL.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/VxqkIhG88M.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/VxqkIhG88M.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/W5bnoMpunF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/W5bnoMpunF.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/WOpGodfIa8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/WOpGodfIa8.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/WVz16ttXmN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/WVz16ttXmN.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/WZDWUF8ibK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/WZDWUF8ibK.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/X5FuWfVgX6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/X5FuWfVgX6.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/XLacQhFM5v.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/XLacQhFM5v.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/XOK5FCR5BV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/XOK5FCR5BV.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/XSCVXLUIBn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/XSCVXLUIBn.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/XpelL4dfYJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/XpelL4dfYJ.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/Y0nmeL8Mk6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/Y0nmeL8Mk6.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/Y3mvjkMqPV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/Y3mvjkMqPV.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/Y5EXqXazv8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/Y5EXqXazv8.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/YGlCkfra9u.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/YGlCkfra9u.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/YHnNk2wz6l.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/YHnNk2wz6l.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/YJDISUV0P9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/YJDISUV0P9.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/YNZk56sw8a.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/YNZk56sw8a.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/YSjosSoyxD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/YSjosSoyxD.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/YYPqiV1dMh.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/YYPqiV1dMh.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/YcFI3Qezx8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/YcFI3Qezx8.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/Z7wOsOEcI7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/Z7wOsOEcI7.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/ZEkMAMmFrT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/ZEkMAMmFrT.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/ZHV48dd3xb.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/ZHV48dd3xb.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/ZPpTfz3cuC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/ZPpTfz3cuC.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/ZSKbzDVpdh.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/ZSKbzDVpdh.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/ZV0dzO1N3D.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/ZV0dzO1N3D.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/ZfCQZQ3Yi4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/ZfCQZQ3Yi4.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/ZgH9SeepAW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/ZgH9SeepAW.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/Zzt021tkHA.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/Zzt021tkHA.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/a1DiihgGoN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/a1DiihgGoN.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/aAzECToODG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/aAzECToODG.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/acAvcgb9wR.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/acAvcgb9wR.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/al6GdI6HHq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/al6GdI6HHq.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/b6lOjv1QB9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/b6lOjv1QB9.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/bCdroQZubL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/bCdroQZubL.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/bGXLKzz8DB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/bGXLKzz8DB.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/bOJODCt4Nj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/bOJODCt4Nj.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/bZMWPiINDJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/bZMWPiINDJ.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/bcY4kDXEiL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/bcY4kDXEiL.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/c6ixLi9Yns.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/c6ixLi9Yns.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/cC1vOfH1YD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/cC1vOfH1YD.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/cKgcqJQFSi.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/cKgcqJQFSi.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/cM7YAi3zbW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/cM7YAi3zbW.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/cZb1hdO5AT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/cZb1hdO5AT.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/cjKn08z80L.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/cjKn08z80L.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/cnoFERqEX9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/cnoFERqEX9.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/dBQTDFizrM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/dBQTDFizrM.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/dBXjMyQ6v5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/dBXjMyQ6v5.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/dQcYTBwxmD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/dQcYTBwxmD.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/dVvABT62C9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/dVvABT62C9.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/e3r8e0DiFz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/e3r8e0DiFz.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/eFsp09gaZX.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/eFsp09gaZX.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/eKleS2KN9V.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/eKleS2KN9V.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/eSoalgVCBH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/eSoalgVCBH.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/eVz6pfc2Aq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/eVz6pfc2Aq.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/eYtwlKx3DL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/eYtwlKx3DL.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/ecmluorkUs.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/ecmluorkUs.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/encSaFhW3u.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/encSaFhW3u.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/fEVDUjY0o4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/fEVDUjY0o4.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/fNBZi3EAxz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/fNBZi3EAxz.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/fQ6iyzZG4E.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/fQ6iyzZG4E.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/fkSI356192.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/fkSI356192.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/fqaD1J6KEH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/fqaD1J6KEH.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/fsCqVRe2XV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/fsCqVRe2XV.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/g32LIqIkv7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/g32LIqIkv7.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/g7NcHJ0Dqm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/g7NcHJ0Dqm.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/gKDRuR0huT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/gKDRuR0huT.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/gjl4ArLhJm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/gjl4ArLhJm.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/gvU8LsfGOx.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/gvU8LsfGOx.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/h9Y4PiPY6w.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/h9Y4PiPY6w.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/hchuG3s1rY.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/hchuG3s1rY.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/hnhVAIsmxU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/hnhVAIsmxU.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/hqtR9072e5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/hqtR9072e5.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/i53vKZdcnE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/i53vKZdcnE.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/iBn3UOpKdu.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/iBn3UOpKdu.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/iI6pw0QLBV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/iI6pw0QLBV.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/iQAGO67miB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/iQAGO67miB.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/iTg6zX0H2i.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/iTg6zX0H2i.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/iq57t3NYGm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/iq57t3NYGm.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/ixUQwlLoQl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/ixUQwlLoQl.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/ixp5a4MCzH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/ixp5a4MCzH.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/izrpe1H39g.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/izrpe1H39g.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/j0gOb12WG7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/j0gOb12WG7.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/j41I8z5Dbm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/j41I8z5Dbm.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/j9KVlh9Elu.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/j9KVlh9Elu.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/jEPN6e30lK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/jEPN6e30lK.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/jHoO30hDWC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/jHoO30hDWC.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/jOEODojhaI.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/jOEODojhaI.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/jSdYYlxIPu.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/jSdYYlxIPu.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/kDrpkD1xK6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/kDrpkD1xK6.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/kODlOvWLVJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/kODlOvWLVJ.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/koWMEughuG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/koWMEughuG.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/kpmo31UbcA.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/kpmo31UbcA.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/kuu79cE7XV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/kuu79cE7XV.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/ky7lfFDW6q.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/ky7lfFDW6q.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/kyEHvPp7Gk.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/kyEHvPp7Gk.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/lOk975L1YB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/lOk975L1YB.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/lW11AhH3pd.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/lW11AhH3pd.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/llHMuoBQb8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/llHMuoBQb8.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/m8AHxnkobT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/m8AHxnkobT.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/mBub665Sw1.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/mBub665Sw1.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/mKU2FtqWwc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/mKU2FtqWwc.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/mN75YcjhNl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/mN75YcjhNl.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/mhhBA6GJJy.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/mhhBA6GJJy.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/nE3Qa1apaH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/nE3Qa1apaH.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/nT8J5haK6F.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/nT8J5haK6F.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/nUWnom5eaz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/nUWnom5eaz.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/nY4f0rBQfZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/nY4f0rBQfZ.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/nenm6c9K9H.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/nenm6c9K9H.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/nrmmmwvAB3.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/nrmmmwvAB3.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/nzdiNgzpBk.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/nzdiNgzpBk.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/oEmtybut45.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/oEmtybut45.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/oV4NuQJ94t.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/oV4NuQJ94t.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/oklahTMTmf.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/oklahTMTmf.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/ors0bDh2bc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/ors0bDh2bc.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/pc50J7VwEQ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/pc50J7VwEQ.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/pqukhkAth1.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/pqukhkAth1.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/q5p595DJ6Q.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/q5p595DJ6Q.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/qE0fojpqnw.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/qE0fojpqnw.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/qGpRbiQ2ae.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/qGpRbiQ2ae.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/qoLqfVeYjg.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/qoLqfVeYjg.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/qxfXnYfFUG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/qxfXnYfFUG.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/r8w1v3Z6lL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/r8w1v3Z6lL.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/rMw8A9V28h.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/rMw8A9V28h.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/rZI5VmbmH8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/rZI5VmbmH8.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/rdy3COwDJ8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/rdy3COwDJ8.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/rlmBhex75r.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/rlmBhex75r.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/rn7ZDhqfGn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/rn7ZDhqfGn.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/rse9BAjK8p.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/rse9BAjK8p.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/rxLnaPSdKY.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/rxLnaPSdKY.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/sDb6wxVAlp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/sDb6wxVAlp.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/sHN8Z0s7Zl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/sHN8Z0s7Zl.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/sIk16HKXOH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/sIk16HKXOH.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/sfXrv8XKuT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/sfXrv8XKuT.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/spAP90Xdxo.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/spAP90Xdxo.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/t2LfLuggKw.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/t2LfLuggKw.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/t6anM049gM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/t6anM049gM.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/t6b9ipJFco.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/t6b9ipJFco.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/t88runt2vt.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/t88runt2vt.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/t96N3ukmC2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/t96N3ukmC2.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/tFHSIUZTRU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/tFHSIUZTRU.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/tOBEeyrzR5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/tOBEeyrzR5.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/tqmxPtSV5e.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/tqmxPtSV5e.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/ttgDLEo0YY.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/ttgDLEo0YY.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/tyDsoFs45y.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/tyDsoFs45y.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/tyrqHRTjct.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/tyrqHRTjct.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/uMrfngv4qE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/uMrfngv4qE.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/ufp5xt5UlZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/ufp5xt5UlZ.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/ukDSDTeRKn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/ukDSDTeRKn.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/vAhi6T2iCs.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/vAhi6T2iCs.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/vDddl4MmlU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/vDddl4MmlU.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/vLwvkrUp8m.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/vLwvkrUp8m.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/vO7uWdob4g.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/vO7uWdob4g.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/vUjLCf2llh.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/vUjLCf2llh.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/vdOsQV2zZZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/vdOsQV2zZZ.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/vqoyQGzxwZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/vqoyQGzxwZ.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/vuum3mHSut.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/vuum3mHSut.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/wff7vOGYXM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/wff7vOGYXM.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/wkgn6vRUUp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/wkgn6vRUUp.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/wmDBp8f0Z2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/wmDBp8f0Z2.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/woqch6WNMH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/woqch6WNMH.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/x1AVtHbq4f.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/x1AVtHbq4f.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/xEOJNLq3je.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/xEOJNLq3je.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/xM6CnVshaE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/xM6CnVshaE.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/xOe1maF1HZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/xOe1maF1HZ.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/xVFVQAk3u3.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/xVFVQAk3u3.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/xWEhNnxjgn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/xWEhNnxjgn.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/xmhnIZPlm0.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/xmhnIZPlm0.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/xqXMSXBMl8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/xqXMSXBMl8.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/xqemv5BeQH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/xqemv5BeQH.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/y8Wf7aTXFb.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/y8Wf7aTXFb.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/yCWOaOd0DH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/yCWOaOd0DH.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/yI34mPjVtK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/yI34mPjVtK.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/yQu5xEnWkt.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/yQu5xEnWkt.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/yVvQYsdxaq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/yVvQYsdxaq.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/yaMxpb9T34.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/yaMxpb9T34.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/ygTzDOCr3r.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/ygTzDOCr3r.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/z4XWuGECC2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/z4XWuGECC2.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/z9nNYIgtFz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/z9nNYIgtFz.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/zFiwaVTd6p.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/zFiwaVTd6p.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/zI6QHiNniJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/zI6QHiNniJ.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/zVrQLGqXwe.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/zVrQLGqXwe.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/zYVWOnWkq4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/zYVWOnWkq4.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/zZ91YoJG9X.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/zZ91YoJG9X.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/zuxZ6Tg1Ha.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-fr/zuxZ6Tg1Ha.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/06T2RNzfTz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/06T2RNzfTz.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/07aN2OB1qj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/07aN2OB1qj.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/0JTPBSFvcC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/0JTPBSFvcC.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/0McUuUDCYj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/0McUuUDCYj.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/0T3L0HU9F5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/0T3L0HU9F5.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/0UrWNfXMbn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/0UrWNfXMbn.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/0We2g9ZRI1.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/0We2g9ZRI1.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/0crDi3Beji.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/0crDi3Beji.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/0dN19RtMpy.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/0dN19RtMpy.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/0nyPk4lS5G.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/0nyPk4lS5G.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/0sV5NP6Raj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/0sV5NP6Raj.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/0tlxl8JzK2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/0tlxl8JzK2.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/13VaDTQa1F.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/13VaDTQa1F.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/177ObAyjaW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/177ObAyjaW.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/1SIwphdqPw.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/1SIwphdqPw.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/1Wku3If0yF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/1Wku3If0yF.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/1fkLnqEKq5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/1fkLnqEKq5.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/1guqW4QDJq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/1guqW4QDJq.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/1zvL3jc30s.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/1zvL3jc30s.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/2BK4YBngu6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/2BK4YBngu6.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/2DcJnHQ1Wc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/2DcJnHQ1Wc.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/2EmGTjbMHL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/2EmGTjbMHL.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/2bgBJIgdGy.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/2bgBJIgdGy.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/3DKPTxt9nK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/3DKPTxt9nK.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/3K5GXTKPrP.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/3K5GXTKPrP.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/3QFEobjwmC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/3QFEobjwmC.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/3RDZKRFFEV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/3RDZKRFFEV.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/3s0rgujAIg.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/3s0rgujAIg.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/4Ax5wLUa4c.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/4Ax5wLUa4c.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/4EsYZXHdpa.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/4EsYZXHdpa.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/4MA1GGxtB2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/4MA1GGxtB2.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/4TA0dltn8Z.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/4TA0dltn8Z.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/4XwovA4lrF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/4XwovA4lrF.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/4iwufNM5Y6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/4iwufNM5Y6.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/4kQSb8Mpxb.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/4kQSb8Mpxb.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/4knxgNV22P.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/4knxgNV22P.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/4prVlpN79q.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/4prVlpN79q.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/54K50WUaKI.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/54K50WUaKI.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/5E9QwsWPit.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/5E9QwsWPit.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/5JUr6L7hij.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/5JUr6L7hij.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/5WMn1FI8mr.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/5WMn1FI8mr.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/5ejPdcXoEW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/5ejPdcXoEW.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/5h6yFrKLct.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/5h6yFrKLct.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/6ezYN7Hv0Z.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/6ezYN7Hv0Z.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/6l2wTrG0a6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/6l2wTrG0a6.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/6oA6qi8Lpj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/6oA6qi8Lpj.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/6pwxM7x9RG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/6pwxM7x9RG.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/70gJ0d6ueN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/70gJ0d6ueN.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/7NBB4SlixM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/7NBB4SlixM.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/7PDb7B0Y2N.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/7PDb7B0Y2N.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/7Pcw6lts4T.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/7Pcw6lts4T.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/7Xcf56RyAr.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/7Xcf56RyAr.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/7n3s1BSMBo.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/7n3s1BSMBo.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/7s32eactiP.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/7s32eactiP.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/81lR1cSmfJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/81lR1cSmfJ.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/8dnUV6Vg0Y.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/8dnUV6Vg0Y.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/8tTziwEdcI.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/8tTziwEdcI.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/8zROpBby2x.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/8zROpBby2x.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/90J1b35WV8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/90J1b35WV8.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/91wjEMiEX6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/91wjEMiEX6.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/9EdR9Yk7ca.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/9EdR9Yk7ca.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/9RZxZPNxIu.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/9RZxZPNxIu.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/9TOztQhkC4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/9TOztQhkC4.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/9jWBrTk7UB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/9jWBrTk7UB.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/9lMN6zFkKE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/9lMN6zFkKE.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/9s6IGHapL2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/9s6IGHapL2.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/A01FvWmA8l.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/A01FvWmA8l.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/A3USVyZwFP.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/A3USVyZwFP.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/AGJgFoElmB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/AGJgFoElmB.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/AKEOkMAk9E.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/AKEOkMAk9E.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/ALzR9tiyk8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/ALzR9tiyk8.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/AenL9akVZ7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/AenL9akVZ7.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/AutcanQMIS.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/AutcanQMIS.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/B19N6aMdz3.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/B19N6aMdz3.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/B1EGKnhW9e.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/B1EGKnhW9e.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/B1oQQ08HGH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/B1oQQ08HGH.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/B54wYu3oDA.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/B54wYu3oDA.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/BBTptRbtCv.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/BBTptRbtCv.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/BGGCRglxce.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/BGGCRglxce.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/BP8ChaEEsu.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/BP8ChaEEsu.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/BWk4SOKZaL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/BWk4SOKZaL.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/Bj2rdZWLh7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/Bj2rdZWLh7.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/C0qtj9qPDQ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/C0qtj9qPDQ.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/C9re7IuLWT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/C9re7IuLWT.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/CNHSzPEwGH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/CNHSzPEwGH.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/CP3AlJWqrp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/CP3AlJWqrp.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/CWYcYC8app.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/CWYcYC8app.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/Cb3SuEIO21.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/Cb3SuEIO21.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/CoZ4zNyWGC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/CoZ4zNyWGC.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/D1CTthvE4P.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/D1CTthvE4P.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/DFn3iuttpy.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/DFn3iuttpy.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/Dc9KyR2b2p.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/Dc9KyR2b2p.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/Dph3kXOCic.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/Dph3kXOCic.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/Dvpv1gBrUQ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/Dvpv1gBrUQ.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/E4qThSDcnD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/E4qThSDcnD.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/EC4qtMsceH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/EC4qtMsceH.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/ERsIqJPx5L.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/ERsIqJPx5L.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/EZXLjw31Dl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/EZXLjw31Dl.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/EsvI0BL049.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/EsvI0BL049.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/F2Pe3EMY8l.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/F2Pe3EMY8l.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/F5lnyEc8P7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/F5lnyEc8P7.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/FCqK7dSpWU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/FCqK7dSpWU.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/FNBWotecr1.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/FNBWotecr1.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/FV6eIbtnYG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/FV6eIbtnYG.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/FXHmkUJdzB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/FXHmkUJdzB.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/Fn00VgWg5Y.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/Fn00VgWg5Y.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/G2sYQwPkhJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/G2sYQwPkhJ.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/G5mzA5SBhk.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/G5mzA5SBhk.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/GDxA5zEvt0.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/GDxA5zEvt0.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/GXsAoZzuGz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/GXsAoZzuGz.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/GgA3nIlfrr.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/GgA3nIlfrr.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/Gl9QSM0HL9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/Gl9QSM0HL9.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/HWdd0atzlF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/HWdd0atzlF.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/HjAQJGqXYX.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/HjAQJGqXYX.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/HzjTooszyT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/HzjTooszyT.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/I3R2n3iDwp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/I3R2n3iDwp.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/I5jP7AdXUO.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/I5jP7AdXUO.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/I8b2lta2dV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/I8b2lta2dV.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/IFfft0YbVF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/IFfft0YbVF.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/IcZKeRjvKW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/IcZKeRjvKW.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/IiI7gJ520W.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/IiI7gJ520W.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/Ij3DQuVRk7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/Ij3DQuVRk7.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/IuHoP54Wlc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/IuHoP54Wlc.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/IwYqIz3EHD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/IwYqIz3EHD.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/J0cKBlje4u.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/J0cKBlje4u.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/J1zbYLAkpc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/J1zbYLAkpc.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/J6HXfDOVhX.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/J6HXfDOVhX.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/JH4VhArCNR.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/JH4VhArCNR.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/JXkrGa9mJm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/JXkrGa9mJm.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/JjTVAGnAQr.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/JjTVAGnAQr.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/JptCVz4qEd.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/JptCVz4qEd.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/JtusM5o9mV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/JtusM5o9mV.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/K8foSEhEd6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/K8foSEhEd6.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/KCFf7gu3Y4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/KCFf7gu3Y4.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/KRrQYpA7NN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/KRrQYpA7NN.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/KkW0XInSXe.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/KkW0XInSXe.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/KmUJvvIFQM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/KmUJvvIFQM.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/KwZarRNYrG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/KwZarRNYrG.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/L2R0Fdeoqj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/L2R0Fdeoqj.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/L6Togn7pnd.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/L6Togn7pnd.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/LGFBsMx1Ue.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/LGFBsMx1Ue.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/LKPjaqZzne.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/LKPjaqZzne.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/LTwPCkotqR.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/LTwPCkotqR.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/LlojbpWjs9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/LlojbpWjs9.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/LnGkF3PV4B.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/LnGkF3PV4B.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/Lw6juAfLhZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/Lw6juAfLhZ.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/M2wCQaSIkx.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/M2wCQaSIkx.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/M7p8sbE3VI.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/M7p8sbE3VI.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/MAaNEFkxNx.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/MAaNEFkxNx.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/MN57efcLju.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/MN57efcLju.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/MTonphGglM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/MTonphGglM.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/MWxYsdcQAm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/MWxYsdcQAm.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/MiEtLwCnzM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/MiEtLwCnzM.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/Mm2925bgtf.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/Mm2925bgtf.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/MnCQlmeEpx.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/MnCQlmeEpx.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/Mnn3wVQyPT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/Mnn3wVQyPT.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/MwWzEyFzMN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/MwWzEyFzMN.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/N3qbcpPajg.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/N3qbcpPajg.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/NBM2jrtjUt.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/NBM2jrtjUt.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/NDycAe2PMg.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/NDycAe2PMg.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/NVaQ8JUMmp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/NVaQ8JUMmp.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/NauzwofxwH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/NauzwofxwH.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/Ngx37kpASZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/Ngx37kpASZ.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/NhzifMsgk2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/NhzifMsgk2.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/NpGzSptAcC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/NpGzSptAcC.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/NpRS0S6JWC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/NpRS0S6JWC.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/NqADIATboI.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/NqADIATboI.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/NwHv5RB2rz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/NwHv5RB2rz.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/O953QNNUI0.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/O953QNNUI0.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/OCchs83O6Y.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/OCchs83O6Y.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/OGxNUCIKC2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/OGxNUCIKC2.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/OJyyKz5GVv.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/OJyyKz5GVv.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/OMOINSyhgb.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/OMOINSyhgb.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/ON96VWl2eE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/ON96VWl2eE.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/OYhonKADC9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/OYhonKADC9.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/OZwHXjKDnl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/OZwHXjKDnl.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/OdEuAfadOv.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/OdEuAfadOv.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/OxyGJylIwW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/OxyGJylIwW.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/PHurkwqv4Z.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/PHurkwqv4Z.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/PXNopPwCXl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/PXNopPwCXl.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/QArvYA1I5y.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/QArvYA1I5y.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/QKdvStkUZD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/QKdvStkUZD.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/QkWxbTjqEQ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/QkWxbTjqEQ.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/QoD4gdBKht.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/QoD4gdBKht.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/QxOTHR8Vr5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/QxOTHR8Vr5.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/R4BCKWzeKK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/R4BCKWzeKK.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/RBTWh9W2wN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/RBTWh9W2wN.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/RSdIxOjWTU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/RSdIxOjWTU.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/RVXzOJsITX.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/RVXzOJsITX.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/RVsXeoSc9F.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/RVsXeoSc9F.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/RWTGsJXzQz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/RWTGsJXzQz.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/RYuyMUd2gk.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/RYuyMUd2gk.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/RpX90PHiU0.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/RpX90PHiU0.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/RvpGNGwBDO.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/RvpGNGwBDO.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/RykGa318Dx.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/RykGa318Dx.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/S4670YUK50.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/S4670YUK50.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/S6gLS26ZJ4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/S6gLS26ZJ4.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/S9LbD4Pr4R.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/S9LbD4Pr4R.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/SAOrYUiv3f.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/SAOrYUiv3f.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/SCkYQvq0A9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/SCkYQvq0A9.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/SDPXeHAEsY.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/SDPXeHAEsY.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/SFVT3QJAYW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/SFVT3QJAYW.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/SNuFk4PnW2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/SNuFk4PnW2.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/ShzxZhno8O.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/ShzxZhno8O.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/SnDPKIXHDi.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/SnDPKIXHDi.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/SzCgZ3qNN5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/SzCgZ3qNN5.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/T520ZP6L8T.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/T520ZP6L8T.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/TJTFd5hAYj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/TJTFd5hAYj.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/TRuTR85WZK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/TRuTR85WZK.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/TgwFqiQRdp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/TgwFqiQRdp.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/Tj8JfMPQOP.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/Tj8JfMPQOP.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/TrSKsrbw64.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/TrSKsrbw64.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/TtsQu77nNc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/TtsQu77nNc.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/U5ugQslU2z.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/U5ugQslU2z.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/UP8fkuONg2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/UP8fkuONg2.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/UQd9WJKHHq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/UQd9WJKHHq.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/UdYGjLjpzk.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/UdYGjLjpzk.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/UeKNqkUYqr.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/UeKNqkUYqr.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/UfKa2OpfYT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/UfKa2OpfYT.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/UmSdXFQzs5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/UmSdXFQzs5.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/Uwk8g9mKl8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/Uwk8g9mKl8.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/V39a2Wfhny.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/V39a2Wfhny.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/V6Alb9zB67.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/V6Alb9zB67.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/VBCxRuQlyS.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/VBCxRuQlyS.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/VCeH9ZweWA.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/VCeH9ZweWA.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/VLXVn8J66H.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/VLXVn8J66H.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/VWVKSidnGZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/VWVKSidnGZ.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/VYon30GsHO.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/VYon30GsHO.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/Vdgc0ZvuWs.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/Vdgc0ZvuWs.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/VfmDAdXzKM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/VfmDAdXzKM.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/VhYMLsMLrL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/VhYMLsMLrL.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/VxqkIhG88M.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/VxqkIhG88M.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/W5bnoMpunF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/W5bnoMpunF.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/WOpGodfIa8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/WOpGodfIa8.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/WVz16ttXmN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/WVz16ttXmN.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/WZDWUF8ibK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/WZDWUF8ibK.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/X5FuWfVgX6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/X5FuWfVgX6.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/XLacQhFM5v.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/XLacQhFM5v.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/XOK5FCR5BV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/XOK5FCR5BV.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/XSCVXLUIBn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/XSCVXLUIBn.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/XpelL4dfYJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/XpelL4dfYJ.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/Y0nmeL8Mk6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/Y0nmeL8Mk6.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/Y3mvjkMqPV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/Y3mvjkMqPV.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/Y5EXqXazv8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/Y5EXqXazv8.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/YGlCkfra9u.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/YGlCkfra9u.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/YHnNk2wz6l.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/YHnNk2wz6l.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/YJDISUV0P9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/YJDISUV0P9.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/YNZk56sw8a.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/YNZk56sw8a.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/YSjosSoyxD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/YSjosSoyxD.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/YYPqiV1dMh.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/YYPqiV1dMh.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/YcFI3Qezx8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/YcFI3Qezx8.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/Z7wOsOEcI7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/Z7wOsOEcI7.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/ZEkMAMmFrT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/ZEkMAMmFrT.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/ZHV48dd3xb.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/ZHV48dd3xb.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/ZPpTfz3cuC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/ZPpTfz3cuC.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/ZSKbzDVpdh.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/ZSKbzDVpdh.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/ZV0dzO1N3D.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/ZV0dzO1N3D.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/ZfCQZQ3Yi4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/ZfCQZQ3Yi4.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/ZgH9SeepAW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/ZgH9SeepAW.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/Zzt021tkHA.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/Zzt021tkHA.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/a1DiihgGoN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/a1DiihgGoN.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/aAzECToODG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/aAzECToODG.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/acAvcgb9wR.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/acAvcgb9wR.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/al6GdI6HHq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/al6GdI6HHq.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/b6lOjv1QB9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/b6lOjv1QB9.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/bCdroQZubL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/bCdroQZubL.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/bGXLKzz8DB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/bGXLKzz8DB.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/bOJODCt4Nj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/bOJODCt4Nj.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/bZMWPiINDJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/bZMWPiINDJ.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/bcY4kDXEiL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/bcY4kDXEiL.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/c6ixLi9Yns.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/c6ixLi9Yns.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/cC1vOfH1YD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/cC1vOfH1YD.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/cKgcqJQFSi.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/cKgcqJQFSi.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/cM7YAi3zbW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/cM7YAi3zbW.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/cZb1hdO5AT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/cZb1hdO5AT.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/cjKn08z80L.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/cjKn08z80L.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/cnoFERqEX9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/cnoFERqEX9.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/dBQTDFizrM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/dBQTDFizrM.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/dBXjMyQ6v5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/dBXjMyQ6v5.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/dQcYTBwxmD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/dQcYTBwxmD.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/dVvABT62C9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/dVvABT62C9.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/e3r8e0DiFz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/e3r8e0DiFz.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/eFsp09gaZX.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/eFsp09gaZX.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/eKleS2KN9V.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/eKleS2KN9V.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/eSoalgVCBH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/eSoalgVCBH.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/eVz6pfc2Aq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/eVz6pfc2Aq.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/eYtwlKx3DL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/eYtwlKx3DL.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/ecmluorkUs.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/ecmluorkUs.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/encSaFhW3u.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/encSaFhW3u.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/fEVDUjY0o4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/fEVDUjY0o4.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/fNBZi3EAxz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/fNBZi3EAxz.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/fQ6iyzZG4E.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/fQ6iyzZG4E.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/fkSI356192.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/fkSI356192.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/fqaD1J6KEH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/fqaD1J6KEH.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/fsCqVRe2XV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/fsCqVRe2XV.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/g32LIqIkv7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/g32LIqIkv7.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/g7NcHJ0Dqm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/g7NcHJ0Dqm.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/gKDRuR0huT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/gKDRuR0huT.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/gjl4ArLhJm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/gjl4ArLhJm.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/gvU8LsfGOx.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/gvU8LsfGOx.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/h9Y4PiPY6w.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/h9Y4PiPY6w.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/hchuG3s1rY.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/hchuG3s1rY.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/hnhVAIsmxU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/hnhVAIsmxU.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/hqtR9072e5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/hqtR9072e5.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/i53vKZdcnE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/i53vKZdcnE.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/iBn3UOpKdu.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/iBn3UOpKdu.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/iI6pw0QLBV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/iI6pw0QLBV.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/iQAGO67miB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/iQAGO67miB.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/iTg6zX0H2i.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/iTg6zX0H2i.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/iq57t3NYGm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/iq57t3NYGm.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/ixUQwlLoQl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/ixUQwlLoQl.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/ixp5a4MCzH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/ixp5a4MCzH.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/izrpe1H39g.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/izrpe1H39g.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/j0gOb12WG7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/j0gOb12WG7.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/j41I8z5Dbm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/j41I8z5Dbm.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/j9KVlh9Elu.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/j9KVlh9Elu.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/jEPN6e30lK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/jEPN6e30lK.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/jHoO30hDWC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/jHoO30hDWC.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/jOEODojhaI.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/jOEODojhaI.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/jSdYYlxIPu.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/jSdYYlxIPu.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/kDrpkD1xK6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/kDrpkD1xK6.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/kODlOvWLVJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/kODlOvWLVJ.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/koWMEughuG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/koWMEughuG.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/kpmo31UbcA.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/kpmo31UbcA.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/kuu79cE7XV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/kuu79cE7XV.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/ky7lfFDW6q.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/ky7lfFDW6q.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/kyEHvPp7Gk.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/kyEHvPp7Gk.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/lOk975L1YB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/lOk975L1YB.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/lW11AhH3pd.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/lW11AhH3pd.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/llHMuoBQb8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/llHMuoBQb8.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/m8AHxnkobT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/m8AHxnkobT.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/mBub665Sw1.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/mBub665Sw1.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/mKU2FtqWwc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/mKU2FtqWwc.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/mN75YcjhNl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/mN75YcjhNl.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/mhhBA6GJJy.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/mhhBA6GJJy.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/nE3Qa1apaH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/nE3Qa1apaH.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/nT8J5haK6F.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/nT8J5haK6F.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/nUWnom5eaz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/nUWnom5eaz.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/nY4f0rBQfZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/nY4f0rBQfZ.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/nenm6c9K9H.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/nenm6c9K9H.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/nrmmmwvAB3.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/nrmmmwvAB3.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/nzdiNgzpBk.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/nzdiNgzpBk.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/oEmtybut45.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/oEmtybut45.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/oV4NuQJ94t.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/oV4NuQJ94t.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/oklahTMTmf.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/oklahTMTmf.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/ors0bDh2bc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/ors0bDh2bc.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/pc50J7VwEQ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/pc50J7VwEQ.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/pqukhkAth1.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/pqukhkAth1.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/q5p595DJ6Q.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/q5p595DJ6Q.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/qE0fojpqnw.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/qE0fojpqnw.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/qGpRbiQ2ae.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/qGpRbiQ2ae.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/qoLqfVeYjg.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/qoLqfVeYjg.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/qxfXnYfFUG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/qxfXnYfFUG.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/r8w1v3Z6lL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/r8w1v3Z6lL.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/rMw8A9V28h.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/rMw8A9V28h.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/rZI5VmbmH8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/rZI5VmbmH8.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/rdy3COwDJ8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/rdy3COwDJ8.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/rlmBhex75r.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/rlmBhex75r.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/rn7ZDhqfGn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/rn7ZDhqfGn.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/rse9BAjK8p.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/rse9BAjK8p.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/rxLnaPSdKY.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/rxLnaPSdKY.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/sDb6wxVAlp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/sDb6wxVAlp.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/sHN8Z0s7Zl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/sHN8Z0s7Zl.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/sIk16HKXOH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/sIk16HKXOH.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/sfXrv8XKuT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/sfXrv8XKuT.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/spAP90Xdxo.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/spAP90Xdxo.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/t2LfLuggKw.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/t2LfLuggKw.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/t6anM049gM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/t6anM049gM.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/t6b9ipJFco.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/t6b9ipJFco.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/t88runt2vt.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/t88runt2vt.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/t96N3ukmC2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/t96N3ukmC2.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/tFHSIUZTRU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/tFHSIUZTRU.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/tOBEeyrzR5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/tOBEeyrzR5.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/tqmxPtSV5e.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/tqmxPtSV5e.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/ttgDLEo0YY.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/ttgDLEo0YY.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/tyDsoFs45y.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/tyDsoFs45y.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/tyrqHRTjct.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/tyrqHRTjct.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/uMrfngv4qE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/uMrfngv4qE.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/ufp5xt5UlZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/ufp5xt5UlZ.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/ukDSDTeRKn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/ukDSDTeRKn.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/vAhi6T2iCs.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/vAhi6T2iCs.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/vDddl4MmlU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/vDddl4MmlU.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/vLwvkrUp8m.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/vLwvkrUp8m.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/vO7uWdob4g.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/vO7uWdob4g.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/vUjLCf2llh.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/vUjLCf2llh.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/vdOsQV2zZZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/vdOsQV2zZZ.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/vqoyQGzxwZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/vqoyQGzxwZ.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/vuum3mHSut.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/vuum3mHSut.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/wff7vOGYXM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/wff7vOGYXM.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/wkgn6vRUUp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/wkgn6vRUUp.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/wmDBp8f0Z2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/wmDBp8f0Z2.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/woqch6WNMH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/woqch6WNMH.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/x1AVtHbq4f.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/x1AVtHbq4f.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/xEOJNLq3je.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/xEOJNLq3je.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/xM6CnVshaE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/xM6CnVshaE.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/xOe1maF1HZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/xOe1maF1HZ.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/xVFVQAk3u3.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/xVFVQAk3u3.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/xWEhNnxjgn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/xWEhNnxjgn.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/xmhnIZPlm0.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/xmhnIZPlm0.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/xqXMSXBMl8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/xqXMSXBMl8.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/xqemv5BeQH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/xqemv5BeQH.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/y8Wf7aTXFb.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/y8Wf7aTXFb.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/yCWOaOd0DH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/yCWOaOd0DH.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/yI34mPjVtK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/yI34mPjVtK.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/yQu5xEnWkt.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/yQu5xEnWkt.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/yVvQYsdxaq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/yVvQYsdxaq.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/yaMxpb9T34.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/yaMxpb9T34.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/ygTzDOCr3r.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/ygTzDOCr3r.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/z4XWuGECC2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/z4XWuGECC2.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/z9nNYIgtFz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/z9nNYIgtFz.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/zFiwaVTd6p.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/zFiwaVTd6p.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/zI6QHiNniJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/zI6QHiNniJ.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/zVrQLGqXwe.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/zVrQLGqXwe.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/zYVWOnWkq4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/zYVWOnWkq4.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/zZ91YoJG9X.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/zZ91YoJG9X.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/zuxZ6Tg1Ha.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8-us/zuxZ6Tg1Ha.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/06T2RNzfTz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/06T2RNzfTz.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/07aN2OB1qj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/07aN2OB1qj.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/0JTPBSFvcC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/0JTPBSFvcC.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/0McUuUDCYj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/0McUuUDCYj.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/0T3L0HU9F5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/0T3L0HU9F5.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/0UrWNfXMbn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/0UrWNfXMbn.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/0We2g9ZRI1.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/0We2g9ZRI1.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/0crDi3Beji.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/0crDi3Beji.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/0dN19RtMpy.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/0dN19RtMpy.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/0nyPk4lS5G.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/0nyPk4lS5G.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/0sV5NP6Raj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/0sV5NP6Raj.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/0tlxl8JzK2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/0tlxl8JzK2.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/13VaDTQa1F.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/13VaDTQa1F.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/177ObAyjaW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/177ObAyjaW.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/1SIwphdqPw.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/1SIwphdqPw.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/1Wku3If0yF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/1Wku3If0yF.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/1fkLnqEKq5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/1fkLnqEKq5.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/1guqW4QDJq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/1guqW4QDJq.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/1zvL3jc30s.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/1zvL3jc30s.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/2BK4YBngu6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/2BK4YBngu6.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/2DcJnHQ1Wc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/2DcJnHQ1Wc.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/2EmGTjbMHL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/2EmGTjbMHL.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/2bgBJIgdGy.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/2bgBJIgdGy.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/3DKPTxt9nK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/3DKPTxt9nK.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/3K5GXTKPrP.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/3K5GXTKPrP.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/3QFEobjwmC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/3QFEobjwmC.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/3RDZKRFFEV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/3RDZKRFFEV.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/3s0rgujAIg.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/3s0rgujAIg.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/4Ax5wLUa4c.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/4Ax5wLUa4c.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/4EsYZXHdpa.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/4EsYZXHdpa.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/4MA1GGxtB2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/4MA1GGxtB2.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/4TA0dltn8Z.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/4TA0dltn8Z.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/4XwovA4lrF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/4XwovA4lrF.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/4iwufNM5Y6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/4iwufNM5Y6.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/4kQSb8Mpxb.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/4kQSb8Mpxb.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/4knxgNV22P.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/4knxgNV22P.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/4prVlpN79q.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/4prVlpN79q.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/54K50WUaKI.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/54K50WUaKI.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/5E9QwsWPit.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/5E9QwsWPit.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/5JUr6L7hij.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/5JUr6L7hij.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/5WMn1FI8mr.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/5WMn1FI8mr.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/5ejPdcXoEW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/5ejPdcXoEW.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/5h6yFrKLct.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/5h6yFrKLct.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/6ezYN7Hv0Z.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/6ezYN7Hv0Z.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/6l2wTrG0a6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/6l2wTrG0a6.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/6oA6qi8Lpj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/6oA6qi8Lpj.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/6pwxM7x9RG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/6pwxM7x9RG.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/70gJ0d6ueN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/70gJ0d6ueN.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/7NBB4SlixM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/7NBB4SlixM.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/7PDb7B0Y2N.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/7PDb7B0Y2N.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/7Pcw6lts4T.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/7Pcw6lts4T.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/7Xcf56RyAr.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/7Xcf56RyAr.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/7n3s1BSMBo.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/7n3s1BSMBo.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/7s32eactiP.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/7s32eactiP.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/81lR1cSmfJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/81lR1cSmfJ.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/8dnUV6Vg0Y.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/8dnUV6Vg0Y.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/8tTziwEdcI.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/8tTziwEdcI.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/8zROpBby2x.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/8zROpBby2x.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/90J1b35WV8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/90J1b35WV8.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/91wjEMiEX6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/91wjEMiEX6.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/9EdR9Yk7ca.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/9EdR9Yk7ca.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/9RZxZPNxIu.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/9RZxZPNxIu.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/9TOztQhkC4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/9TOztQhkC4.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/9jWBrTk7UB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/9jWBrTk7UB.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/9lMN6zFkKE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/9lMN6zFkKE.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/9s6IGHapL2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/9s6IGHapL2.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/A01FvWmA8l.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/A01FvWmA8l.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/A3USVyZwFP.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/A3USVyZwFP.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/AGJgFoElmB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/AGJgFoElmB.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/AKEOkMAk9E.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/AKEOkMAk9E.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/ALzR9tiyk8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/ALzR9tiyk8.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/AenL9akVZ7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/AenL9akVZ7.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/AutcanQMIS.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/AutcanQMIS.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/B19N6aMdz3.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/B19N6aMdz3.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/B1EGKnhW9e.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/B1EGKnhW9e.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/B1oQQ08HGH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/B1oQQ08HGH.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/B54wYu3oDA.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/B54wYu3oDA.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/BBTptRbtCv.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/BBTptRbtCv.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/BGGCRglxce.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/BGGCRglxce.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/BP8ChaEEsu.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/BP8ChaEEsu.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/BWk4SOKZaL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/BWk4SOKZaL.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/Bj2rdZWLh7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/Bj2rdZWLh7.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/C0qtj9qPDQ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/C0qtj9qPDQ.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/C9re7IuLWT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/C9re7IuLWT.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/CNHSzPEwGH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/CNHSzPEwGH.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/CP3AlJWqrp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/CP3AlJWqrp.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/CWYcYC8app.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/CWYcYC8app.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/Cb3SuEIO21.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/Cb3SuEIO21.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/CoZ4zNyWGC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/CoZ4zNyWGC.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/D1CTthvE4P.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/D1CTthvE4P.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/DFn3iuttpy.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/DFn3iuttpy.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/Dc9KyR2b2p.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/Dc9KyR2b2p.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/Dph3kXOCic.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/Dph3kXOCic.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/Dvpv1gBrUQ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/Dvpv1gBrUQ.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/E4qThSDcnD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/E4qThSDcnD.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/EC4qtMsceH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/EC4qtMsceH.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/ERsIqJPx5L.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/ERsIqJPx5L.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/EZXLjw31Dl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/EZXLjw31Dl.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/EsvI0BL049.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/EsvI0BL049.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/F2Pe3EMY8l.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/F2Pe3EMY8l.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/F5lnyEc8P7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/F5lnyEc8P7.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/FCqK7dSpWU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/FCqK7dSpWU.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/FNBWotecr1.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/FNBWotecr1.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/FV6eIbtnYG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/FV6eIbtnYG.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/FXHmkUJdzB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/FXHmkUJdzB.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/Fn00VgWg5Y.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/Fn00VgWg5Y.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/G2sYQwPkhJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/G2sYQwPkhJ.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/G5mzA5SBhk.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/G5mzA5SBhk.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/GDxA5zEvt0.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/GDxA5zEvt0.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/GXsAoZzuGz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/GXsAoZzuGz.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/GgA3nIlfrr.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/GgA3nIlfrr.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/Gl9QSM0HL9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/Gl9QSM0HL9.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/HWdd0atzlF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/HWdd0atzlF.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/HjAQJGqXYX.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/HjAQJGqXYX.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/HzjTooszyT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/HzjTooszyT.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/I3R2n3iDwp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/I3R2n3iDwp.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/I5jP7AdXUO.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/I5jP7AdXUO.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/I8b2lta2dV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/I8b2lta2dV.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/IFfft0YbVF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/IFfft0YbVF.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/IcZKeRjvKW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/IcZKeRjvKW.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/IiI7gJ520W.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/IiI7gJ520W.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/Ij3DQuVRk7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/Ij3DQuVRk7.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/IuHoP54Wlc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/IuHoP54Wlc.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/IwYqIz3EHD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/IwYqIz3EHD.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/J0cKBlje4u.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/J0cKBlje4u.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/J1zbYLAkpc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/J1zbYLAkpc.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/J6HXfDOVhX.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/J6HXfDOVhX.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/JH4VhArCNR.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/JH4VhArCNR.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/JXkrGa9mJm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/JXkrGa9mJm.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/JjTVAGnAQr.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/JjTVAGnAQr.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/JptCVz4qEd.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/JptCVz4qEd.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/JtusM5o9mV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/JtusM5o9mV.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/K8foSEhEd6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/K8foSEhEd6.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/KCFf7gu3Y4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/KCFf7gu3Y4.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/KRrQYpA7NN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/KRrQYpA7NN.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/KkW0XInSXe.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/KkW0XInSXe.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/KmUJvvIFQM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/KmUJvvIFQM.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/KwZarRNYrG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/KwZarRNYrG.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/L2R0Fdeoqj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/L2R0Fdeoqj.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/L6Togn7pnd.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/L6Togn7pnd.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/LGFBsMx1Ue.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/LGFBsMx1Ue.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/LKPjaqZzne.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/LKPjaqZzne.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/LTwPCkotqR.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/LTwPCkotqR.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/LlojbpWjs9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/LlojbpWjs9.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/LnGkF3PV4B.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/LnGkF3PV4B.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/Lw6juAfLhZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/Lw6juAfLhZ.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/M2wCQaSIkx.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/M2wCQaSIkx.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/M7p8sbE3VI.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/M7p8sbE3VI.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/MAaNEFkxNx.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/MAaNEFkxNx.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/MN57efcLju.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/MN57efcLju.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/MTonphGglM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/MTonphGglM.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/MWxYsdcQAm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/MWxYsdcQAm.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/MiEtLwCnzM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/MiEtLwCnzM.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/Mm2925bgtf.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/Mm2925bgtf.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/MnCQlmeEpx.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/MnCQlmeEpx.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/Mnn3wVQyPT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/Mnn3wVQyPT.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/MwWzEyFzMN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/MwWzEyFzMN.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/N3qbcpPajg.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/N3qbcpPajg.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/NBM2jrtjUt.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/NBM2jrtjUt.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/NDycAe2PMg.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/NDycAe2PMg.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/NVaQ8JUMmp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/NVaQ8JUMmp.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/NauzwofxwH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/NauzwofxwH.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/Ngx37kpASZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/Ngx37kpASZ.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/NhzifMsgk2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/NhzifMsgk2.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/NpGzSptAcC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/NpGzSptAcC.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/NpRS0S6JWC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/NpRS0S6JWC.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/NqADIATboI.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/NqADIATboI.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/NwHv5RB2rz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/NwHv5RB2rz.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/O953QNNUI0.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/O953QNNUI0.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/OCchs83O6Y.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/OCchs83O6Y.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/OGxNUCIKC2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/OGxNUCIKC2.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/OJyyKz5GVv.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/OJyyKz5GVv.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/OMOINSyhgb.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/OMOINSyhgb.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/ON96VWl2eE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/ON96VWl2eE.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/OYhonKADC9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/OYhonKADC9.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/OZwHXjKDnl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/OZwHXjKDnl.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/OdEuAfadOv.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/OdEuAfadOv.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/OxyGJylIwW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/OxyGJylIwW.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/PHurkwqv4Z.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/PHurkwqv4Z.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/PXNopPwCXl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/PXNopPwCXl.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/QArvYA1I5y.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/QArvYA1I5y.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/QKdvStkUZD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/QKdvStkUZD.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/QkWxbTjqEQ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/QkWxbTjqEQ.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/QoD4gdBKht.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/QoD4gdBKht.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/QxOTHR8Vr5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/QxOTHR8Vr5.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/R4BCKWzeKK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/R4BCKWzeKK.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/RBTWh9W2wN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/RBTWh9W2wN.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/RSdIxOjWTU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/RSdIxOjWTU.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/RVXzOJsITX.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/RVXzOJsITX.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/RVsXeoSc9F.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/RVsXeoSc9F.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/RWTGsJXzQz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/RWTGsJXzQz.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/RYuyMUd2gk.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/RYuyMUd2gk.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/RpX90PHiU0.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/RpX90PHiU0.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/RvpGNGwBDO.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/RvpGNGwBDO.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/RykGa318Dx.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/RykGa318Dx.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/S4670YUK50.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/S4670YUK50.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/S6gLS26ZJ4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/S6gLS26ZJ4.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/S9LbD4Pr4R.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/S9LbD4Pr4R.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/SAOrYUiv3f.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/SAOrYUiv3f.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/SCkYQvq0A9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/SCkYQvq0A9.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/SDPXeHAEsY.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/SDPXeHAEsY.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/SFVT3QJAYW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/SFVT3QJAYW.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/SNuFk4PnW2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/SNuFk4PnW2.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/ShzxZhno8O.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/ShzxZhno8O.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/SnDPKIXHDi.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/SnDPKIXHDi.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/SzCgZ3qNN5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/SzCgZ3qNN5.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/T520ZP6L8T.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/T520ZP6L8T.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/TJTFd5hAYj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/TJTFd5hAYj.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/TRuTR85WZK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/TRuTR85WZK.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/TgwFqiQRdp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/TgwFqiQRdp.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/Tj8JfMPQOP.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/Tj8JfMPQOP.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/TrSKsrbw64.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/TrSKsrbw64.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/TtsQu77nNc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/TtsQu77nNc.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/U5ugQslU2z.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/U5ugQslU2z.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/UP8fkuONg2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/UP8fkuONg2.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/UQd9WJKHHq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/UQd9WJKHHq.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/UdYGjLjpzk.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/UdYGjLjpzk.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/UeKNqkUYqr.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/UeKNqkUYqr.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/UfKa2OpfYT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/UfKa2OpfYT.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/UmSdXFQzs5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/UmSdXFQzs5.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/Uwk8g9mKl8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/Uwk8g9mKl8.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/V39a2Wfhny.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/V39a2Wfhny.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/V6Alb9zB67.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/V6Alb9zB67.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/VBCxRuQlyS.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/VBCxRuQlyS.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/VCeH9ZweWA.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/VCeH9ZweWA.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/VLXVn8J66H.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/VLXVn8J66H.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/VWVKSidnGZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/VWVKSidnGZ.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/VYon30GsHO.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/VYon30GsHO.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/Vdgc0ZvuWs.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/Vdgc0ZvuWs.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/VfmDAdXzKM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/VfmDAdXzKM.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/VhYMLsMLrL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/VhYMLsMLrL.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/VxqkIhG88M.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/VxqkIhG88M.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/W5bnoMpunF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/W5bnoMpunF.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/WOpGodfIa8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/WOpGodfIa8.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/WVz16ttXmN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/WVz16ttXmN.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/WZDWUF8ibK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/WZDWUF8ibK.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/X5FuWfVgX6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/X5FuWfVgX6.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/XLacQhFM5v.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/XLacQhFM5v.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/XOK5FCR5BV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/XOK5FCR5BV.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/XSCVXLUIBn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/XSCVXLUIBn.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/XpelL4dfYJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/XpelL4dfYJ.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/Y0nmeL8Mk6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/Y0nmeL8Mk6.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/Y3mvjkMqPV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/Y3mvjkMqPV.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/Y5EXqXazv8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/Y5EXqXazv8.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/YGlCkfra9u.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/YGlCkfra9u.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/YHnNk2wz6l.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/YHnNk2wz6l.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/YJDISUV0P9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/YJDISUV0P9.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/YNZk56sw8a.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/YNZk56sw8a.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/YSjosSoyxD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/YSjosSoyxD.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/YYPqiV1dMh.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/YYPqiV1dMh.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/YcFI3Qezx8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/YcFI3Qezx8.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/Z7wOsOEcI7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/Z7wOsOEcI7.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/ZEkMAMmFrT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/ZEkMAMmFrT.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/ZHV48dd3xb.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/ZHV48dd3xb.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/ZPpTfz3cuC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/ZPpTfz3cuC.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/ZSKbzDVpdh.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/ZSKbzDVpdh.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/ZV0dzO1N3D.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/ZV0dzO1N3D.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/ZfCQZQ3Yi4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/ZfCQZQ3Yi4.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/ZgH9SeepAW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/ZgH9SeepAW.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/Zzt021tkHA.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/Zzt021tkHA.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/a1DiihgGoN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/a1DiihgGoN.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/aAzECToODG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/aAzECToODG.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/acAvcgb9wR.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/acAvcgb9wR.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/al6GdI6HHq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/al6GdI6HHq.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/b6lOjv1QB9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/b6lOjv1QB9.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/bCdroQZubL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/bCdroQZubL.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/bGXLKzz8DB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/bGXLKzz8DB.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/bOJODCt4Nj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/bOJODCt4Nj.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/bZMWPiINDJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/bZMWPiINDJ.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/bcY4kDXEiL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/bcY4kDXEiL.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/c6ixLi9Yns.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/c6ixLi9Yns.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/cC1vOfH1YD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/cC1vOfH1YD.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/cKgcqJQFSi.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/cKgcqJQFSi.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/cM7YAi3zbW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/cM7YAi3zbW.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/cZb1hdO5AT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/cZb1hdO5AT.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/cjKn08z80L.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/cjKn08z80L.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/cnoFERqEX9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/cnoFERqEX9.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/dBQTDFizrM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/dBQTDFizrM.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/dBXjMyQ6v5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/dBXjMyQ6v5.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/dQcYTBwxmD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/dQcYTBwxmD.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/dVvABT62C9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/dVvABT62C9.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/e3r8e0DiFz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/e3r8e0DiFz.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/eFsp09gaZX.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/eFsp09gaZX.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/eKleS2KN9V.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/eKleS2KN9V.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/eSoalgVCBH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/eSoalgVCBH.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/eVz6pfc2Aq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/eVz6pfc2Aq.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/eYtwlKx3DL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/eYtwlKx3DL.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/ecmluorkUs.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/ecmluorkUs.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/encSaFhW3u.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/encSaFhW3u.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/fEVDUjY0o4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/fEVDUjY0o4.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/fNBZi3EAxz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/fNBZi3EAxz.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/fQ6iyzZG4E.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/fQ6iyzZG4E.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/fkSI356192.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/fkSI356192.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/fqaD1J6KEH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/fqaD1J6KEH.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/fsCqVRe2XV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/fsCqVRe2XV.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/g32LIqIkv7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/g32LIqIkv7.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/g7NcHJ0Dqm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/g7NcHJ0Dqm.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/gKDRuR0huT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/gKDRuR0huT.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/gjl4ArLhJm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/gjl4ArLhJm.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/gvU8LsfGOx.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/gvU8LsfGOx.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/h9Y4PiPY6w.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/h9Y4PiPY6w.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/hchuG3s1rY.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/hchuG3s1rY.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/hnhVAIsmxU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/hnhVAIsmxU.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/hqtR9072e5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/hqtR9072e5.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/i53vKZdcnE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/i53vKZdcnE.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/iBn3UOpKdu.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/iBn3UOpKdu.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/iI6pw0QLBV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/iI6pw0QLBV.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/iQAGO67miB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/iQAGO67miB.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/iTg6zX0H2i.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/iTg6zX0H2i.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/iq57t3NYGm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/iq57t3NYGm.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/ixUQwlLoQl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/ixUQwlLoQl.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/ixp5a4MCzH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/ixp5a4MCzH.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/izrpe1H39g.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/izrpe1H39g.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/j0gOb12WG7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/j0gOb12WG7.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/j41I8z5Dbm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/j41I8z5Dbm.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/j9KVlh9Elu.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/j9KVlh9Elu.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/jEPN6e30lK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/jEPN6e30lK.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/jHoO30hDWC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/jHoO30hDWC.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/jOEODojhaI.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/jOEODojhaI.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/jSdYYlxIPu.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/jSdYYlxIPu.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/kDrpkD1xK6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/kDrpkD1xK6.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/kODlOvWLVJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/kODlOvWLVJ.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/koWMEughuG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/koWMEughuG.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/kpmo31UbcA.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/kpmo31UbcA.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/kuu79cE7XV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/kuu79cE7XV.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/ky7lfFDW6q.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/ky7lfFDW6q.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/kyEHvPp7Gk.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/kyEHvPp7Gk.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/lOk975L1YB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/lOk975L1YB.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/lW11AhH3pd.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/lW11AhH3pd.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/llHMuoBQb8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/llHMuoBQb8.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/m8AHxnkobT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/m8AHxnkobT.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/mBub665Sw1.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/mBub665Sw1.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/mKU2FtqWwc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/mKU2FtqWwc.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/mN75YcjhNl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/mN75YcjhNl.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/mhhBA6GJJy.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/mhhBA6GJJy.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/nE3Qa1apaH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/nE3Qa1apaH.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/nT8J5haK6F.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/nT8J5haK6F.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/nUWnom5eaz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/nUWnom5eaz.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/nY4f0rBQfZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/nY4f0rBQfZ.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/nenm6c9K9H.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/nenm6c9K9H.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/nrmmmwvAB3.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/nrmmmwvAB3.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/nzdiNgzpBk.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/nzdiNgzpBk.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/oEmtybut45.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/oEmtybut45.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/oV4NuQJ94t.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/oV4NuQJ94t.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/oklahTMTmf.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/oklahTMTmf.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/ors0bDh2bc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/ors0bDh2bc.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/pc50J7VwEQ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/pc50J7VwEQ.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/pqukhkAth1.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/pqukhkAth1.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/q5p595DJ6Q.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/q5p595DJ6Q.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/qE0fojpqnw.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/qE0fojpqnw.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/qGpRbiQ2ae.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/qGpRbiQ2ae.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/qoLqfVeYjg.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/qoLqfVeYjg.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/qxfXnYfFUG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/qxfXnYfFUG.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/r8w1v3Z6lL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/r8w1v3Z6lL.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/rMw8A9V28h.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/rMw8A9V28h.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/rZI5VmbmH8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/rZI5VmbmH8.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/rdy3COwDJ8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/rdy3COwDJ8.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/rlmBhex75r.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/rlmBhex75r.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/rn7ZDhqfGn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/rn7ZDhqfGn.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/rse9BAjK8p.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/rse9BAjK8p.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/rxLnaPSdKY.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/rxLnaPSdKY.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/sDb6wxVAlp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/sDb6wxVAlp.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/sHN8Z0s7Zl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/sHN8Z0s7Zl.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/sIk16HKXOH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/sIk16HKXOH.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/sfXrv8XKuT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/sfXrv8XKuT.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/spAP90Xdxo.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/spAP90Xdxo.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/t2LfLuggKw.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/t2LfLuggKw.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/t6anM049gM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/t6anM049gM.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/t6b9ipJFco.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/t6b9ipJFco.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/t88runt2vt.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/t88runt2vt.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/t96N3ukmC2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/t96N3ukmC2.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/tFHSIUZTRU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/tFHSIUZTRU.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/tOBEeyrzR5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/tOBEeyrzR5.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/tqmxPtSV5e.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/tqmxPtSV5e.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/ttgDLEo0YY.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/ttgDLEo0YY.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/tyDsoFs45y.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/tyDsoFs45y.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/tyrqHRTjct.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/tyrqHRTjct.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/uMrfngv4qE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/uMrfngv4qE.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/ufp5xt5UlZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/ufp5xt5UlZ.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/ukDSDTeRKn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/ukDSDTeRKn.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/vAhi6T2iCs.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/vAhi6T2iCs.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/vDddl4MmlU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/vDddl4MmlU.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/vLwvkrUp8m.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/vLwvkrUp8m.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/vO7uWdob4g.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/vO7uWdob4g.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/vUjLCf2llh.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/vUjLCf2llh.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/vdOsQV2zZZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/vdOsQV2zZZ.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/vqoyQGzxwZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/vqoyQGzxwZ.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/vuum3mHSut.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/vuum3mHSut.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/wff7vOGYXM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/wff7vOGYXM.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/wkgn6vRUUp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/wkgn6vRUUp.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/wmDBp8f0Z2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/wmDBp8f0Z2.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/woqch6WNMH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/woqch6WNMH.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/x1AVtHbq4f.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/x1AVtHbq4f.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/xEOJNLq3je.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/xEOJNLq3je.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/xM6CnVshaE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/xM6CnVshaE.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/xOe1maF1HZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/xOe1maF1HZ.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/xVFVQAk3u3.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/xVFVQAk3u3.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/xWEhNnxjgn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/xWEhNnxjgn.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/xmhnIZPlm0.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/xmhnIZPlm0.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/xqXMSXBMl8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/xqXMSXBMl8.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/xqemv5BeQH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/xqemv5BeQH.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/y8Wf7aTXFb.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/y8Wf7aTXFb.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/yCWOaOd0DH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/yCWOaOd0DH.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/yI34mPjVtK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/yI34mPjVtK.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/yQu5xEnWkt.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/yQu5xEnWkt.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/yVvQYsdxaq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/yVvQYsdxaq.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/yaMxpb9T34.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/yaMxpb9T34.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/ygTzDOCr3r.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/ygTzDOCr3r.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/z4XWuGECC2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/z4XWuGECC2.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/z9nNYIgtFz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/z9nNYIgtFz.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/zFiwaVTd6p.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/zFiwaVTd6p.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/zI6QHiNniJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/zI6QHiNniJ.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/zVrQLGqXwe.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/zVrQLGqXwe.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/zYVWOnWkq4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/zYVWOnWkq4.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/zZ91YoJG9X.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/zZ91YoJG9X.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/zuxZ6Tg1Ha.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v4.8/zuxZ6Tg1Ha.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/06T2RNzfTz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/06T2RNzfTz.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/07aN2OB1qj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/07aN2OB1qj.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/0JTPBSFvcC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/0JTPBSFvcC.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/0McUuUDCYj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/0McUuUDCYj.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/0T3L0HU9F5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/0T3L0HU9F5.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/0UrWNfXMbn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/0UrWNfXMbn.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/0We2g9ZRI1.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/0We2g9ZRI1.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/0crDi3Beji.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/0crDi3Beji.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/0dN19RtMpy.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/0dN19RtMpy.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/0nyPk4lS5G.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/0nyPk4lS5G.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/0sV5NP6Raj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/0sV5NP6Raj.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/0tlxl8JzK2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/0tlxl8JzK2.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/13VaDTQa1F.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/13VaDTQa1F.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/177ObAyjaW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/177ObAyjaW.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/1SIwphdqPw.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/1SIwphdqPw.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/1Wku3If0yF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/1Wku3If0yF.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/1fkLnqEKq5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/1fkLnqEKq5.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/1guqW4QDJq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/1guqW4QDJq.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/1zvL3jc30s.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/1zvL3jc30s.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/2BK4YBngu6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/2BK4YBngu6.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/2DcJnHQ1Wc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/2DcJnHQ1Wc.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/2EmGTjbMHL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/2EmGTjbMHL.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/2bgBJIgdGy.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/2bgBJIgdGy.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/3DKPTxt9nK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/3DKPTxt9nK.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/3K5GXTKPrP.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/3K5GXTKPrP.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/3QFEobjwmC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/3QFEobjwmC.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/3RDZKRFFEV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/3RDZKRFFEV.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/3s0rgujAIg.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/3s0rgujAIg.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/4Ax5wLUa4c.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/4Ax5wLUa4c.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/4EsYZXHdpa.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/4EsYZXHdpa.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/4MA1GGxtB2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/4MA1GGxtB2.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/4TA0dltn8Z.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/4TA0dltn8Z.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/4XwovA4lrF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/4XwovA4lrF.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/4iwufNM5Y6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/4iwufNM5Y6.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/4kQSb8Mpxb.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/4kQSb8Mpxb.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/4knxgNV22P.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/4knxgNV22P.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/4prVlpN79q.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/4prVlpN79q.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/54K50WUaKI.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/54K50WUaKI.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/5E9QwsWPit.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/5E9QwsWPit.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/5JUr6L7hij.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/5JUr6L7hij.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/5WMn1FI8mr.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/5WMn1FI8mr.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/5ejPdcXoEW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/5ejPdcXoEW.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/5h6yFrKLct.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/5h6yFrKLct.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/6ezYN7Hv0Z.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/6ezYN7Hv0Z.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/6l2wTrG0a6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/6l2wTrG0a6.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/6oA6qi8Lpj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/6oA6qi8Lpj.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/6pwxM7x9RG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/6pwxM7x9RG.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/70gJ0d6ueN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/70gJ0d6ueN.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/7NBB4SlixM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/7NBB4SlixM.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/7PDb7B0Y2N.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/7PDb7B0Y2N.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/7Pcw6lts4T.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/7Pcw6lts4T.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/7Xcf56RyAr.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/7Xcf56RyAr.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/7n3s1BSMBo.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/7n3s1BSMBo.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/7s32eactiP.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/7s32eactiP.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/81lR1cSmfJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/81lR1cSmfJ.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/8dnUV6Vg0Y.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/8dnUV6Vg0Y.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/8tTziwEdcI.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/8tTziwEdcI.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/8zROpBby2x.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/8zROpBby2x.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/90J1b35WV8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/90J1b35WV8.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/91wjEMiEX6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/91wjEMiEX6.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/9EdR9Yk7ca.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/9EdR9Yk7ca.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/9RZxZPNxIu.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/9RZxZPNxIu.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/9TOztQhkC4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/9TOztQhkC4.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/9jWBrTk7UB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/9jWBrTk7UB.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/9lMN6zFkKE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/9lMN6zFkKE.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/9s6IGHapL2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/9s6IGHapL2.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/A01FvWmA8l.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/A01FvWmA8l.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/A3USVyZwFP.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/A3USVyZwFP.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/AGJgFoElmB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/AGJgFoElmB.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/AKEOkMAk9E.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/AKEOkMAk9E.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/ALzR9tiyk8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/ALzR9tiyk8.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/AenL9akVZ7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/AenL9akVZ7.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/AutcanQMIS.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/AutcanQMIS.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/B19N6aMdz3.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/B19N6aMdz3.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/B1EGKnhW9e.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/B1EGKnhW9e.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/B1oQQ08HGH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/B1oQQ08HGH.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/B54wYu3oDA.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/B54wYu3oDA.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/BBTptRbtCv.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/BBTptRbtCv.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/BGGCRglxce.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/BGGCRglxce.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/BP8ChaEEsu.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/BP8ChaEEsu.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/BWk4SOKZaL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/BWk4SOKZaL.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/Bj2rdZWLh7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/Bj2rdZWLh7.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/C0qtj9qPDQ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/C0qtj9qPDQ.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/C9re7IuLWT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/C9re7IuLWT.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/CNHSzPEwGH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/CNHSzPEwGH.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/CP3AlJWqrp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/CP3AlJWqrp.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/CWYcYC8app.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/CWYcYC8app.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/Cb3SuEIO21.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/Cb3SuEIO21.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/CoZ4zNyWGC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/CoZ4zNyWGC.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/D1CTthvE4P.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/D1CTthvE4P.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/DFn3iuttpy.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/DFn3iuttpy.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/Dc9KyR2b2p.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/Dc9KyR2b2p.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/Dph3kXOCic.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/Dph3kXOCic.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/Dvpv1gBrUQ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/Dvpv1gBrUQ.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/E4qThSDcnD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/E4qThSDcnD.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/EC4qtMsceH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/EC4qtMsceH.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/ERsIqJPx5L.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/ERsIqJPx5L.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/EZXLjw31Dl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/EZXLjw31Dl.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/EsvI0BL049.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/EsvI0BL049.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/F2Pe3EMY8l.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/F2Pe3EMY8l.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/F5lnyEc8P7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/F5lnyEc8P7.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/FCqK7dSpWU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/FCqK7dSpWU.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/FNBWotecr1.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/FNBWotecr1.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/FV6eIbtnYG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/FV6eIbtnYG.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/FXHmkUJdzB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/FXHmkUJdzB.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/Fn00VgWg5Y.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/Fn00VgWg5Y.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/G2sYQwPkhJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/G2sYQwPkhJ.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/G5mzA5SBhk.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/G5mzA5SBhk.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/GDxA5zEvt0.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/GDxA5zEvt0.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/GXsAoZzuGz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/GXsAoZzuGz.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/GgA3nIlfrr.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/GgA3nIlfrr.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/Gl9QSM0HL9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/Gl9QSM0HL9.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/HWdd0atzlF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/HWdd0atzlF.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/HjAQJGqXYX.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/HjAQJGqXYX.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/HzjTooszyT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/HzjTooszyT.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/I3R2n3iDwp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/I3R2n3iDwp.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/I5jP7AdXUO.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/I5jP7AdXUO.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/I8b2lta2dV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/I8b2lta2dV.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/IFfft0YbVF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/IFfft0YbVF.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/IcZKeRjvKW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/IcZKeRjvKW.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/IiI7gJ520W.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/IiI7gJ520W.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/Ij3DQuVRk7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/Ij3DQuVRk7.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/IuHoP54Wlc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/IuHoP54Wlc.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/IwYqIz3EHD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/IwYqIz3EHD.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/J0cKBlje4u.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/J0cKBlje4u.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/J1zbYLAkpc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/J1zbYLAkpc.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/J6HXfDOVhX.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/J6HXfDOVhX.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/JH4VhArCNR.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/JH4VhArCNR.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/JXkrGa9mJm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/JXkrGa9mJm.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/JjTVAGnAQr.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/JjTVAGnAQr.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/JptCVz4qEd.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/JptCVz4qEd.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/JtusM5o9mV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/JtusM5o9mV.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/K8foSEhEd6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/K8foSEhEd6.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/KCFf7gu3Y4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/KCFf7gu3Y4.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/KRrQYpA7NN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/KRrQYpA7NN.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/KkW0XInSXe.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/KkW0XInSXe.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/KmUJvvIFQM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/KmUJvvIFQM.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/KwZarRNYrG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/KwZarRNYrG.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/L2R0Fdeoqj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/L2R0Fdeoqj.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/L6Togn7pnd.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/L6Togn7pnd.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/LGFBsMx1Ue.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/LGFBsMx1Ue.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/LKPjaqZzne.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/LKPjaqZzne.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/LTwPCkotqR.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/LTwPCkotqR.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/LlojbpWjs9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/LlojbpWjs9.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/LnGkF3PV4B.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/LnGkF3PV4B.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/Lw6juAfLhZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/Lw6juAfLhZ.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/M2wCQaSIkx.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/M2wCQaSIkx.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/M7p8sbE3VI.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/M7p8sbE3VI.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/MAaNEFkxNx.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/MAaNEFkxNx.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/MN57efcLju.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/MN57efcLju.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/MTonphGglM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/MTonphGglM.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/MWxYsdcQAm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/MWxYsdcQAm.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/MiEtLwCnzM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/MiEtLwCnzM.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/Mm2925bgtf.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/Mm2925bgtf.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/MnCQlmeEpx.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/MnCQlmeEpx.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/Mnn3wVQyPT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/Mnn3wVQyPT.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/MwWzEyFzMN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/MwWzEyFzMN.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/N3qbcpPajg.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/N3qbcpPajg.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/NBM2jrtjUt.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/NBM2jrtjUt.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/NDycAe2PMg.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/NDycAe2PMg.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/NVaQ8JUMmp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/NVaQ8JUMmp.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/NauzwofxwH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/NauzwofxwH.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/Ngx37kpASZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/Ngx37kpASZ.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/NhzifMsgk2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/NhzifMsgk2.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/NpGzSptAcC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/NpGzSptAcC.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/NpRS0S6JWC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/NpRS0S6JWC.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/NqADIATboI.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/NqADIATboI.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/NwHv5RB2rz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/NwHv5RB2rz.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/O953QNNUI0.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/O953QNNUI0.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/OCchs83O6Y.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/OCchs83O6Y.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/OGxNUCIKC2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/OGxNUCIKC2.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/OJyyKz5GVv.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/OJyyKz5GVv.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/OMOINSyhgb.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/OMOINSyhgb.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/ON96VWl2eE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/ON96VWl2eE.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/OYhonKADC9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/OYhonKADC9.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/OZwHXjKDnl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/OZwHXjKDnl.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/OdEuAfadOv.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/OdEuAfadOv.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/OxyGJylIwW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/OxyGJylIwW.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/PHurkwqv4Z.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/PHurkwqv4Z.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/PXNopPwCXl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/PXNopPwCXl.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/QArvYA1I5y.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/QArvYA1I5y.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/QKdvStkUZD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/QKdvStkUZD.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/QkWxbTjqEQ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/QkWxbTjqEQ.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/QoD4gdBKht.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/QoD4gdBKht.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/QxOTHR8Vr5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/QxOTHR8Vr5.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/R4BCKWzeKK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/R4BCKWzeKK.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/RBTWh9W2wN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/RBTWh9W2wN.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/RSdIxOjWTU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/RSdIxOjWTU.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/RVXzOJsITX.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/RVXzOJsITX.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/RVsXeoSc9F.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/RVsXeoSc9F.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/RWTGsJXzQz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/RWTGsJXzQz.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/RYuyMUd2gk.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/RYuyMUd2gk.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/RpX90PHiU0.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/RpX90PHiU0.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/RvpGNGwBDO.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/RvpGNGwBDO.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/RykGa318Dx.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/RykGa318Dx.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/S4670YUK50.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/S4670YUK50.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/S6gLS26ZJ4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/S6gLS26ZJ4.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/S9LbD4Pr4R.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/S9LbD4Pr4R.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/SAOrYUiv3f.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/SAOrYUiv3f.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/SCkYQvq0A9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/SCkYQvq0A9.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/SDPXeHAEsY.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/SDPXeHAEsY.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/SFVT3QJAYW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/SFVT3QJAYW.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/SNuFk4PnW2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/SNuFk4PnW2.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/ShzxZhno8O.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/ShzxZhno8O.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/SnDPKIXHDi.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/SnDPKIXHDi.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/SzCgZ3qNN5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/SzCgZ3qNN5.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/T520ZP6L8T.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/T520ZP6L8T.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/TJTFd5hAYj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/TJTFd5hAYj.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/TRuTR85WZK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/TRuTR85WZK.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/TgwFqiQRdp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/TgwFqiQRdp.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/Tj8JfMPQOP.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/Tj8JfMPQOP.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/TrSKsrbw64.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/TrSKsrbw64.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/TtsQu77nNc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/TtsQu77nNc.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/U5ugQslU2z.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/U5ugQslU2z.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/UP8fkuONg2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/UP8fkuONg2.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/UQd9WJKHHq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/UQd9WJKHHq.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/UdYGjLjpzk.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/UdYGjLjpzk.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/UeKNqkUYqr.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/UeKNqkUYqr.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/UfKa2OpfYT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/UfKa2OpfYT.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/UmSdXFQzs5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/UmSdXFQzs5.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/Uwk8g9mKl8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/Uwk8g9mKl8.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/V39a2Wfhny.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/V39a2Wfhny.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/V6Alb9zB67.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/V6Alb9zB67.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/VBCxRuQlyS.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/VBCxRuQlyS.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/VCeH9ZweWA.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/VCeH9ZweWA.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/VLXVn8J66H.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/VLXVn8J66H.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/VWVKSidnGZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/VWVKSidnGZ.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/VYon30GsHO.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/VYon30GsHO.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/Vdgc0ZvuWs.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/Vdgc0ZvuWs.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/VfmDAdXzKM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/VfmDAdXzKM.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/VhYMLsMLrL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/VhYMLsMLrL.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/VxqkIhG88M.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/VxqkIhG88M.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/W5bnoMpunF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/W5bnoMpunF.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/WOpGodfIa8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/WOpGodfIa8.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/WVz16ttXmN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/WVz16ttXmN.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/WZDWUF8ibK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/WZDWUF8ibK.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/X5FuWfVgX6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/X5FuWfVgX6.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/XLacQhFM5v.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/XLacQhFM5v.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/XOK5FCR5BV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/XOK5FCR5BV.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/XSCVXLUIBn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/XSCVXLUIBn.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/XpelL4dfYJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/XpelL4dfYJ.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/Y0nmeL8Mk6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/Y0nmeL8Mk6.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/Y3mvjkMqPV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/Y3mvjkMqPV.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/Y5EXqXazv8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/Y5EXqXazv8.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/YGlCkfra9u.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/YGlCkfra9u.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/YHnNk2wz6l.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/YHnNk2wz6l.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/YJDISUV0P9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/YJDISUV0P9.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/YNZk56sw8a.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/YNZk56sw8a.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/YSjosSoyxD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/YSjosSoyxD.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/YYPqiV1dMh.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/YYPqiV1dMh.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/YcFI3Qezx8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/YcFI3Qezx8.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/Z7wOsOEcI7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/Z7wOsOEcI7.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/ZEkMAMmFrT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/ZEkMAMmFrT.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/ZHV48dd3xb.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/ZHV48dd3xb.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/ZPpTfz3cuC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/ZPpTfz3cuC.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/ZSKbzDVpdh.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/ZSKbzDVpdh.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/ZV0dzO1N3D.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/ZV0dzO1N3D.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/ZfCQZQ3Yi4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/ZfCQZQ3Yi4.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/ZgH9SeepAW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/ZgH9SeepAW.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/Zzt021tkHA.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/Zzt021tkHA.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/a1DiihgGoN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/a1DiihgGoN.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/aAzECToODG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/aAzECToODG.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/acAvcgb9wR.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/acAvcgb9wR.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/al6GdI6HHq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/al6GdI6HHq.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/b6lOjv1QB9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/b6lOjv1QB9.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/bCdroQZubL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/bCdroQZubL.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/bGXLKzz8DB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/bGXLKzz8DB.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/bOJODCt4Nj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/bOJODCt4Nj.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/bZMWPiINDJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/bZMWPiINDJ.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/bcY4kDXEiL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/bcY4kDXEiL.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/c6ixLi9Yns.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/c6ixLi9Yns.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/cC1vOfH1YD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/cC1vOfH1YD.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/cKgcqJQFSi.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/cKgcqJQFSi.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/cM7YAi3zbW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/cM7YAi3zbW.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/cZb1hdO5AT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/cZb1hdO5AT.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/cjKn08z80L.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/cjKn08z80L.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/cnoFERqEX9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/cnoFERqEX9.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/dBQTDFizrM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/dBQTDFizrM.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/dBXjMyQ6v5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/dBXjMyQ6v5.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/dQcYTBwxmD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/dQcYTBwxmD.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/dVvABT62C9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/dVvABT62C9.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/e3r8e0DiFz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/e3r8e0DiFz.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/eFsp09gaZX.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/eFsp09gaZX.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/eKleS2KN9V.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/eKleS2KN9V.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/eSoalgVCBH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/eSoalgVCBH.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/eVz6pfc2Aq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/eVz6pfc2Aq.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/eYtwlKx3DL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/eYtwlKx3DL.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/ecmluorkUs.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/ecmluorkUs.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/encSaFhW3u.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/encSaFhW3u.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/fEVDUjY0o4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/fEVDUjY0o4.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/fNBZi3EAxz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/fNBZi3EAxz.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/fQ6iyzZG4E.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/fQ6iyzZG4E.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/fkSI356192.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/fkSI356192.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/fqaD1J6KEH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/fqaD1J6KEH.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/fsCqVRe2XV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/fsCqVRe2XV.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/g32LIqIkv7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/g32LIqIkv7.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/g7NcHJ0Dqm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/g7NcHJ0Dqm.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/gKDRuR0huT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/gKDRuR0huT.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/gjl4ArLhJm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/gjl4ArLhJm.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/gvU8LsfGOx.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/gvU8LsfGOx.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/h9Y4PiPY6w.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/h9Y4PiPY6w.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/hchuG3s1rY.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/hchuG3s1rY.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/hnhVAIsmxU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/hnhVAIsmxU.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/hqtR9072e5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/hqtR9072e5.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/i53vKZdcnE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/i53vKZdcnE.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/iBn3UOpKdu.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/iBn3UOpKdu.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/iI6pw0QLBV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/iI6pw0QLBV.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/iQAGO67miB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/iQAGO67miB.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/iTg6zX0H2i.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/iTg6zX0H2i.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/iq57t3NYGm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/iq57t3NYGm.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/ixUQwlLoQl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/ixUQwlLoQl.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/ixp5a4MCzH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/ixp5a4MCzH.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/izrpe1H39g.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/izrpe1H39g.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/j0gOb12WG7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/j0gOb12WG7.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/j41I8z5Dbm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/j41I8z5Dbm.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/j9KVlh9Elu.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/j9KVlh9Elu.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/jEPN6e30lK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/jEPN6e30lK.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/jHoO30hDWC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/jHoO30hDWC.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/jOEODojhaI.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/jOEODojhaI.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/jSdYYlxIPu.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/jSdYYlxIPu.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/kDrpkD1xK6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/kDrpkD1xK6.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/kODlOvWLVJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/kODlOvWLVJ.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/koWMEughuG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/koWMEughuG.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/kpmo31UbcA.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/kpmo31UbcA.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/kuu79cE7XV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/kuu79cE7XV.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/ky7lfFDW6q.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/ky7lfFDW6q.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/kyEHvPp7Gk.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/kyEHvPp7Gk.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/lOk975L1YB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/lOk975L1YB.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/lW11AhH3pd.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/lW11AhH3pd.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/llHMuoBQb8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/llHMuoBQb8.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/m8AHxnkobT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/m8AHxnkobT.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/mBub665Sw1.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/mBub665Sw1.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/mKU2FtqWwc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/mKU2FtqWwc.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/mN75YcjhNl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/mN75YcjhNl.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/mhhBA6GJJy.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/mhhBA6GJJy.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/nE3Qa1apaH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/nE3Qa1apaH.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/nT8J5haK6F.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/nT8J5haK6F.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/nUWnom5eaz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/nUWnom5eaz.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/nY4f0rBQfZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/nY4f0rBQfZ.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/nenm6c9K9H.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/nenm6c9K9H.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/nrmmmwvAB3.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/nrmmmwvAB3.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/nzdiNgzpBk.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/nzdiNgzpBk.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/oEmtybut45.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/oEmtybut45.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/oV4NuQJ94t.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/oV4NuQJ94t.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/oklahTMTmf.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/oklahTMTmf.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/ors0bDh2bc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/ors0bDh2bc.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/pc50J7VwEQ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/pc50J7VwEQ.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/pqukhkAth1.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/pqukhkAth1.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/q5p595DJ6Q.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/q5p595DJ6Q.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/qE0fojpqnw.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/qE0fojpqnw.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/qGpRbiQ2ae.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/qGpRbiQ2ae.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/qoLqfVeYjg.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/qoLqfVeYjg.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/qxfXnYfFUG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/qxfXnYfFUG.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/r8w1v3Z6lL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/r8w1v3Z6lL.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/rMw8A9V28h.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/rMw8A9V28h.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/rZI5VmbmH8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/rZI5VmbmH8.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/rdy3COwDJ8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/rdy3COwDJ8.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/rlmBhex75r.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/rlmBhex75r.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/rn7ZDhqfGn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/rn7ZDhqfGn.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/rse9BAjK8p.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/rse9BAjK8p.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/rxLnaPSdKY.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/rxLnaPSdKY.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/sDb6wxVAlp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/sDb6wxVAlp.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/sHN8Z0s7Zl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/sHN8Z0s7Zl.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/sIk16HKXOH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/sIk16HKXOH.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/sfXrv8XKuT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/sfXrv8XKuT.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/spAP90Xdxo.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/spAP90Xdxo.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/t2LfLuggKw.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/t2LfLuggKw.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/t6anM049gM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/t6anM049gM.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/t6b9ipJFco.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/t6b9ipJFco.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/t88runt2vt.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/t88runt2vt.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/t96N3ukmC2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/t96N3ukmC2.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/tFHSIUZTRU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/tFHSIUZTRU.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/tOBEeyrzR5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/tOBEeyrzR5.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/tqmxPtSV5e.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/tqmxPtSV5e.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/ttgDLEo0YY.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/ttgDLEo0YY.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/tyDsoFs45y.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/tyDsoFs45y.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/tyrqHRTjct.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/tyrqHRTjct.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/uMrfngv4qE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/uMrfngv4qE.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/ufp5xt5UlZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/ufp5xt5UlZ.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/ukDSDTeRKn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/ukDSDTeRKn.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/vAhi6T2iCs.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/vAhi6T2iCs.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/vDddl4MmlU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/vDddl4MmlU.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/vLwvkrUp8m.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/vLwvkrUp8m.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/vO7uWdob4g.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/vO7uWdob4g.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/vUjLCf2llh.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/vUjLCf2llh.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/vdOsQV2zZZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/vdOsQV2zZZ.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/vqoyQGzxwZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/vqoyQGzxwZ.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/vuum3mHSut.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/vuum3mHSut.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/wff7vOGYXM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/wff7vOGYXM.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/wkgn6vRUUp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/wkgn6vRUUp.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/wmDBp8f0Z2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/wmDBp8f0Z2.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/woqch6WNMH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/woqch6WNMH.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/x1AVtHbq4f.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/x1AVtHbq4f.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/xEOJNLq3je.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/xEOJNLq3je.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/xM6CnVshaE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/xM6CnVshaE.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/xOe1maF1HZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/xOe1maF1HZ.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/xVFVQAk3u3.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/xVFVQAk3u3.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/xWEhNnxjgn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/xWEhNnxjgn.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/xmhnIZPlm0.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/xmhnIZPlm0.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/xqXMSXBMl8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/xqXMSXBMl8.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/xqemv5BeQH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/xqemv5BeQH.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/y8Wf7aTXFb.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/y8Wf7aTXFb.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/yCWOaOd0DH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/yCWOaOd0DH.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/yI34mPjVtK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/yI34mPjVtK.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/yQu5xEnWkt.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/yQu5xEnWkt.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/yVvQYsdxaq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/yVvQYsdxaq.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/yaMxpb9T34.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/yaMxpb9T34.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/ygTzDOCr3r.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/ygTzDOCr3r.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/z4XWuGECC2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/z4XWuGECC2.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/z9nNYIgtFz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/z9nNYIgtFz.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/zFiwaVTd6p.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/zFiwaVTd6p.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/zI6QHiNniJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/zI6QHiNniJ.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/zVrQLGqXwe.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/zVrQLGqXwe.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/zYVWOnWkq4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/zYVWOnWkq4.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/zZ91YoJG9X.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/zZ91YoJG9X.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/zuxZ6Tg1Ha.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-fr/zuxZ6Tg1Ha.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/06T2RNzfTz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/06T2RNzfTz.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/07aN2OB1qj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/07aN2OB1qj.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/0JTPBSFvcC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/0JTPBSFvcC.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/0McUuUDCYj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/0McUuUDCYj.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/0T3L0HU9F5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/0T3L0HU9F5.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/0UrWNfXMbn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/0UrWNfXMbn.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/0We2g9ZRI1.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/0We2g9ZRI1.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/0crDi3Beji.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/0crDi3Beji.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/0dN19RtMpy.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/0dN19RtMpy.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/0nyPk4lS5G.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/0nyPk4lS5G.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/0sV5NP6Raj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/0sV5NP6Raj.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/0tlxl8JzK2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/0tlxl8JzK2.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/13VaDTQa1F.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/13VaDTQa1F.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/177ObAyjaW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/177ObAyjaW.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/1SIwphdqPw.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/1SIwphdqPw.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/1Wku3If0yF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/1Wku3If0yF.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/1fkLnqEKq5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/1fkLnqEKq5.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/1guqW4QDJq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/1guqW4QDJq.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/1zvL3jc30s.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/1zvL3jc30s.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/2BK4YBngu6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/2BK4YBngu6.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/2DcJnHQ1Wc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/2DcJnHQ1Wc.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/2EmGTjbMHL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/2EmGTjbMHL.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/2bgBJIgdGy.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/2bgBJIgdGy.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/3DKPTxt9nK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/3DKPTxt9nK.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/3K5GXTKPrP.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/3K5GXTKPrP.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/3QFEobjwmC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/3QFEobjwmC.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/3RDZKRFFEV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/3RDZKRFFEV.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/3s0rgujAIg.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/3s0rgujAIg.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/4Ax5wLUa4c.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/4Ax5wLUa4c.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/4EsYZXHdpa.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/4EsYZXHdpa.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/4MA1GGxtB2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/4MA1GGxtB2.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/4TA0dltn8Z.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/4TA0dltn8Z.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/4XwovA4lrF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/4XwovA4lrF.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/4iwufNM5Y6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/4iwufNM5Y6.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/4kQSb8Mpxb.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/4kQSb8Mpxb.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/4knxgNV22P.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/4knxgNV22P.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/4prVlpN79q.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/4prVlpN79q.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/54K50WUaKI.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/54K50WUaKI.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/5E9QwsWPit.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/5E9QwsWPit.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/5JUr6L7hij.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/5JUr6L7hij.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/5WMn1FI8mr.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/5WMn1FI8mr.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/5ejPdcXoEW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/5ejPdcXoEW.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/5h6yFrKLct.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/5h6yFrKLct.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/6ezYN7Hv0Z.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/6ezYN7Hv0Z.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/6l2wTrG0a6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/6l2wTrG0a6.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/6oA6qi8Lpj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/6oA6qi8Lpj.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/6pwxM7x9RG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/6pwxM7x9RG.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/70gJ0d6ueN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/70gJ0d6ueN.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/7NBB4SlixM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/7NBB4SlixM.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/7PDb7B0Y2N.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/7PDb7B0Y2N.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/7Pcw6lts4T.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/7Pcw6lts4T.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/7Xcf56RyAr.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/7Xcf56RyAr.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/7n3s1BSMBo.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/7n3s1BSMBo.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/7s32eactiP.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/7s32eactiP.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/81lR1cSmfJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/81lR1cSmfJ.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/8dnUV6Vg0Y.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/8dnUV6Vg0Y.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/8tTziwEdcI.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/8tTziwEdcI.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/8zROpBby2x.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/8zROpBby2x.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/90J1b35WV8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/90J1b35WV8.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/91wjEMiEX6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/91wjEMiEX6.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/9EdR9Yk7ca.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/9EdR9Yk7ca.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/9RZxZPNxIu.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/9RZxZPNxIu.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/9TOztQhkC4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/9TOztQhkC4.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/9jWBrTk7UB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/9jWBrTk7UB.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/9lMN6zFkKE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/9lMN6zFkKE.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/9s6IGHapL2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/9s6IGHapL2.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/A01FvWmA8l.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/A01FvWmA8l.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/A3USVyZwFP.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/A3USVyZwFP.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/AGJgFoElmB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/AGJgFoElmB.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/AKEOkMAk9E.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/AKEOkMAk9E.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/ALzR9tiyk8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/ALzR9tiyk8.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/AenL9akVZ7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/AenL9akVZ7.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/AutcanQMIS.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/AutcanQMIS.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/B19N6aMdz3.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/B19N6aMdz3.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/B1EGKnhW9e.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/B1EGKnhW9e.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/B1oQQ08HGH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/B1oQQ08HGH.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/B54wYu3oDA.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/B54wYu3oDA.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/BBTptRbtCv.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/BBTptRbtCv.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/BGGCRglxce.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/BGGCRglxce.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/BP8ChaEEsu.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/BP8ChaEEsu.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/BWk4SOKZaL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/BWk4SOKZaL.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/Bj2rdZWLh7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/Bj2rdZWLh7.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/C0qtj9qPDQ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/C0qtj9qPDQ.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/C9re7IuLWT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/C9re7IuLWT.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/CNHSzPEwGH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/CNHSzPEwGH.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/CP3AlJWqrp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/CP3AlJWqrp.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/CWYcYC8app.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/CWYcYC8app.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/Cb3SuEIO21.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/Cb3SuEIO21.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/CoZ4zNyWGC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/CoZ4zNyWGC.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/D1CTthvE4P.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/D1CTthvE4P.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/DFn3iuttpy.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/DFn3iuttpy.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/Dc9KyR2b2p.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/Dc9KyR2b2p.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/Dph3kXOCic.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/Dph3kXOCic.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/Dvpv1gBrUQ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/Dvpv1gBrUQ.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/E4qThSDcnD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/E4qThSDcnD.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/EC4qtMsceH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/EC4qtMsceH.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/ERsIqJPx5L.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/ERsIqJPx5L.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/EZXLjw31Dl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/EZXLjw31Dl.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/EsvI0BL049.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/EsvI0BL049.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/F2Pe3EMY8l.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/F2Pe3EMY8l.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/F5lnyEc8P7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/F5lnyEc8P7.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/FCqK7dSpWU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/FCqK7dSpWU.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/FNBWotecr1.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/FNBWotecr1.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/FV6eIbtnYG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/FV6eIbtnYG.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/FXHmkUJdzB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/FXHmkUJdzB.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/Fn00VgWg5Y.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/Fn00VgWg5Y.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/G2sYQwPkhJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/G2sYQwPkhJ.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/G5mzA5SBhk.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/G5mzA5SBhk.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/GDxA5zEvt0.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/GDxA5zEvt0.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/GXsAoZzuGz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/GXsAoZzuGz.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/GgA3nIlfrr.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/GgA3nIlfrr.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/Gl9QSM0HL9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/Gl9QSM0HL9.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/HWdd0atzlF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/HWdd0atzlF.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/HjAQJGqXYX.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/HjAQJGqXYX.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/HzjTooszyT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/HzjTooszyT.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/I3R2n3iDwp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/I3R2n3iDwp.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/I5jP7AdXUO.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/I5jP7AdXUO.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/I8b2lta2dV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/I8b2lta2dV.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/IFfft0YbVF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/IFfft0YbVF.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/IcZKeRjvKW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/IcZKeRjvKW.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/IiI7gJ520W.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/IiI7gJ520W.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/Ij3DQuVRk7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/Ij3DQuVRk7.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/IuHoP54Wlc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/IuHoP54Wlc.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/IwYqIz3EHD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/IwYqIz3EHD.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/J0cKBlje4u.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/J0cKBlje4u.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/J1zbYLAkpc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/J1zbYLAkpc.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/J6HXfDOVhX.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/J6HXfDOVhX.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/JH4VhArCNR.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/JH4VhArCNR.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/JXkrGa9mJm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/JXkrGa9mJm.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/JjTVAGnAQr.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/JjTVAGnAQr.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/JptCVz4qEd.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/JptCVz4qEd.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/JtusM5o9mV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/JtusM5o9mV.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/K8foSEhEd6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/K8foSEhEd6.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/KCFf7gu3Y4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/KCFf7gu3Y4.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/KRrQYpA7NN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/KRrQYpA7NN.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/KkW0XInSXe.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/KkW0XInSXe.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/KmUJvvIFQM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/KmUJvvIFQM.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/KwZarRNYrG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/KwZarRNYrG.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/L2R0Fdeoqj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/L2R0Fdeoqj.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/L6Togn7pnd.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/L6Togn7pnd.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/LGFBsMx1Ue.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/LGFBsMx1Ue.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/LKPjaqZzne.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/LKPjaqZzne.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/LTwPCkotqR.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/LTwPCkotqR.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/LlojbpWjs9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/LlojbpWjs9.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/LnGkF3PV4B.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/LnGkF3PV4B.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/Lw6juAfLhZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/Lw6juAfLhZ.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/M2wCQaSIkx.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/M2wCQaSIkx.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/M7p8sbE3VI.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/M7p8sbE3VI.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/MAaNEFkxNx.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/MAaNEFkxNx.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/MN57efcLju.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/MN57efcLju.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/MTonphGglM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/MTonphGglM.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/MWxYsdcQAm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/MWxYsdcQAm.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/MiEtLwCnzM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/MiEtLwCnzM.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/Mm2925bgtf.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/Mm2925bgtf.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/MnCQlmeEpx.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/MnCQlmeEpx.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/Mnn3wVQyPT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/Mnn3wVQyPT.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/MwWzEyFzMN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/MwWzEyFzMN.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/N3qbcpPajg.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/N3qbcpPajg.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/NBM2jrtjUt.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/NBM2jrtjUt.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/NDycAe2PMg.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/NDycAe2PMg.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/NVaQ8JUMmp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/NVaQ8JUMmp.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/NauzwofxwH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/NauzwofxwH.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/Ngx37kpASZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/Ngx37kpASZ.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/NhzifMsgk2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/NhzifMsgk2.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/NpGzSptAcC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/NpGzSptAcC.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/NpRS0S6JWC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/NpRS0S6JWC.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/NqADIATboI.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/NqADIATboI.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/NwHv5RB2rz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/NwHv5RB2rz.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/O953QNNUI0.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/O953QNNUI0.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/OCchs83O6Y.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/OCchs83O6Y.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/OGxNUCIKC2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/OGxNUCIKC2.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/OJyyKz5GVv.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/OJyyKz5GVv.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/OMOINSyhgb.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/OMOINSyhgb.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/ON96VWl2eE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/ON96VWl2eE.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/OYhonKADC9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/OYhonKADC9.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/OZwHXjKDnl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/OZwHXjKDnl.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/OdEuAfadOv.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/OdEuAfadOv.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/OxyGJylIwW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/OxyGJylIwW.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/PHurkwqv4Z.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/PHurkwqv4Z.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/PXNopPwCXl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/PXNopPwCXl.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/QArvYA1I5y.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/QArvYA1I5y.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/QKdvStkUZD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/QKdvStkUZD.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/QkWxbTjqEQ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/QkWxbTjqEQ.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/QoD4gdBKht.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/QoD4gdBKht.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/QxOTHR8Vr5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/QxOTHR8Vr5.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/R4BCKWzeKK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/R4BCKWzeKK.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/RBTWh9W2wN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/RBTWh9W2wN.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/RSdIxOjWTU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/RSdIxOjWTU.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/RVXzOJsITX.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/RVXzOJsITX.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/RVsXeoSc9F.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/RVsXeoSc9F.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/RWTGsJXzQz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/RWTGsJXzQz.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/RYuyMUd2gk.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/RYuyMUd2gk.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/RpX90PHiU0.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/RpX90PHiU0.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/RvpGNGwBDO.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/RvpGNGwBDO.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/RykGa318Dx.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/RykGa318Dx.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/S4670YUK50.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/S4670YUK50.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/S6gLS26ZJ4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/S6gLS26ZJ4.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/S9LbD4Pr4R.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/S9LbD4Pr4R.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/SAOrYUiv3f.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/SAOrYUiv3f.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/SCkYQvq0A9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/SCkYQvq0A9.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/SDPXeHAEsY.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/SDPXeHAEsY.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/SFVT3QJAYW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/SFVT3QJAYW.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/SNuFk4PnW2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/SNuFk4PnW2.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/ShzxZhno8O.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/ShzxZhno8O.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/SnDPKIXHDi.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/SnDPKIXHDi.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/SzCgZ3qNN5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/SzCgZ3qNN5.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/T520ZP6L8T.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/T520ZP6L8T.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/TJTFd5hAYj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/TJTFd5hAYj.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/TRuTR85WZK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/TRuTR85WZK.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/TgwFqiQRdp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/TgwFqiQRdp.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/Tj8JfMPQOP.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/Tj8JfMPQOP.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/TrSKsrbw64.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/TrSKsrbw64.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/TtsQu77nNc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/TtsQu77nNc.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/U5ugQslU2z.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/U5ugQslU2z.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/UP8fkuONg2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/UP8fkuONg2.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/UQd9WJKHHq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/UQd9WJKHHq.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/UdYGjLjpzk.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/UdYGjLjpzk.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/UeKNqkUYqr.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/UeKNqkUYqr.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/UfKa2OpfYT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/UfKa2OpfYT.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/UmSdXFQzs5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/UmSdXFQzs5.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/Uwk8g9mKl8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/Uwk8g9mKl8.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/V39a2Wfhny.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/V39a2Wfhny.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/V6Alb9zB67.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/V6Alb9zB67.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/VBCxRuQlyS.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/VBCxRuQlyS.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/VCeH9ZweWA.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/VCeH9ZweWA.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/VLXVn8J66H.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/VLXVn8J66H.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/VWVKSidnGZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/VWVKSidnGZ.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/VYon30GsHO.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/VYon30GsHO.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/Vdgc0ZvuWs.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/Vdgc0ZvuWs.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/VfmDAdXzKM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/VfmDAdXzKM.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/VhYMLsMLrL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/VhYMLsMLrL.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/VxqkIhG88M.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/VxqkIhG88M.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/W5bnoMpunF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/W5bnoMpunF.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/WOpGodfIa8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/WOpGodfIa8.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/WVz16ttXmN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/WVz16ttXmN.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/WZDWUF8ibK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/WZDWUF8ibK.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/X5FuWfVgX6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/X5FuWfVgX6.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/XLacQhFM5v.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/XLacQhFM5v.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/XOK5FCR5BV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/XOK5FCR5BV.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/XSCVXLUIBn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/XSCVXLUIBn.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/XpelL4dfYJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/XpelL4dfYJ.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/Y0nmeL8Mk6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/Y0nmeL8Mk6.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/Y3mvjkMqPV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/Y3mvjkMqPV.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/Y5EXqXazv8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/Y5EXqXazv8.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/YGlCkfra9u.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/YGlCkfra9u.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/YHnNk2wz6l.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/YHnNk2wz6l.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/YJDISUV0P9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/YJDISUV0P9.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/YNZk56sw8a.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/YNZk56sw8a.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/YSjosSoyxD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/YSjosSoyxD.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/YYPqiV1dMh.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/YYPqiV1dMh.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/YcFI3Qezx8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/YcFI3Qezx8.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/Z7wOsOEcI7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/Z7wOsOEcI7.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/ZEkMAMmFrT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/ZEkMAMmFrT.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/ZHV48dd3xb.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/ZHV48dd3xb.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/ZPpTfz3cuC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/ZPpTfz3cuC.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/ZSKbzDVpdh.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/ZSKbzDVpdh.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/ZV0dzO1N3D.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/ZV0dzO1N3D.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/ZfCQZQ3Yi4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/ZfCQZQ3Yi4.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/ZgH9SeepAW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/ZgH9SeepAW.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/Zzt021tkHA.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/Zzt021tkHA.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/a1DiihgGoN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/a1DiihgGoN.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/aAzECToODG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/aAzECToODG.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/acAvcgb9wR.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/acAvcgb9wR.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/al6GdI6HHq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/al6GdI6HHq.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/b6lOjv1QB9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/b6lOjv1QB9.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/bCdroQZubL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/bCdroQZubL.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/bGXLKzz8DB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/bGXLKzz8DB.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/bOJODCt4Nj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/bOJODCt4Nj.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/bZMWPiINDJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/bZMWPiINDJ.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/bcY4kDXEiL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/bcY4kDXEiL.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/c6ixLi9Yns.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/c6ixLi9Yns.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/cC1vOfH1YD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/cC1vOfH1YD.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/cKgcqJQFSi.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/cKgcqJQFSi.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/cM7YAi3zbW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/cM7YAi3zbW.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/cZb1hdO5AT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/cZb1hdO5AT.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/cjKn08z80L.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/cjKn08z80L.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/cnoFERqEX9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/cnoFERqEX9.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/dBQTDFizrM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/dBQTDFizrM.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/dBXjMyQ6v5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/dBXjMyQ6v5.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/dQcYTBwxmD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/dQcYTBwxmD.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/dVvABT62C9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/dVvABT62C9.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/e3r8e0DiFz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/e3r8e0DiFz.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/eFsp09gaZX.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/eFsp09gaZX.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/eKleS2KN9V.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/eKleS2KN9V.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/eSoalgVCBH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/eSoalgVCBH.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/eVz6pfc2Aq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/eVz6pfc2Aq.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/eYtwlKx3DL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/eYtwlKx3DL.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/ecmluorkUs.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/ecmluorkUs.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/encSaFhW3u.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/encSaFhW3u.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/fEVDUjY0o4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/fEVDUjY0o4.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/fNBZi3EAxz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/fNBZi3EAxz.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/fQ6iyzZG4E.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/fQ6iyzZG4E.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/fkSI356192.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/fkSI356192.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/fqaD1J6KEH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/fqaD1J6KEH.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/fsCqVRe2XV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/fsCqVRe2XV.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/g32LIqIkv7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/g32LIqIkv7.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/g7NcHJ0Dqm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/g7NcHJ0Dqm.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/gKDRuR0huT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/gKDRuR0huT.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/gjl4ArLhJm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/gjl4ArLhJm.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/gvU8LsfGOx.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/gvU8LsfGOx.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/h9Y4PiPY6w.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/h9Y4PiPY6w.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/hchuG3s1rY.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/hchuG3s1rY.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/hnhVAIsmxU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/hnhVAIsmxU.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/hqtR9072e5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/hqtR9072e5.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/i53vKZdcnE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/i53vKZdcnE.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/iBn3UOpKdu.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/iBn3UOpKdu.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/iI6pw0QLBV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/iI6pw0QLBV.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/iQAGO67miB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/iQAGO67miB.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/iTg6zX0H2i.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/iTg6zX0H2i.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/iq57t3NYGm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/iq57t3NYGm.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/ixUQwlLoQl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/ixUQwlLoQl.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/ixp5a4MCzH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/ixp5a4MCzH.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/izrpe1H39g.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/izrpe1H39g.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/j0gOb12WG7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/j0gOb12WG7.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/j41I8z5Dbm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/j41I8z5Dbm.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/j9KVlh9Elu.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/j9KVlh9Elu.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/jEPN6e30lK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/jEPN6e30lK.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/jHoO30hDWC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/jHoO30hDWC.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/jOEODojhaI.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/jOEODojhaI.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/jSdYYlxIPu.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/jSdYYlxIPu.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/kDrpkD1xK6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/kDrpkD1xK6.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/kODlOvWLVJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/kODlOvWLVJ.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/koWMEughuG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/koWMEughuG.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/kpmo31UbcA.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/kpmo31UbcA.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/kuu79cE7XV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/kuu79cE7XV.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/ky7lfFDW6q.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/ky7lfFDW6q.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/kyEHvPp7Gk.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/kyEHvPp7Gk.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/lOk975L1YB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/lOk975L1YB.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/lW11AhH3pd.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/lW11AhH3pd.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/llHMuoBQb8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/llHMuoBQb8.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/m8AHxnkobT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/m8AHxnkobT.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/mBub665Sw1.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/mBub665Sw1.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/mKU2FtqWwc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/mKU2FtqWwc.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/mN75YcjhNl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/mN75YcjhNl.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/mhhBA6GJJy.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/mhhBA6GJJy.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/nE3Qa1apaH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/nE3Qa1apaH.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/nT8J5haK6F.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/nT8J5haK6F.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/nUWnom5eaz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/nUWnom5eaz.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/nY4f0rBQfZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/nY4f0rBQfZ.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/nenm6c9K9H.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/nenm6c9K9H.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/nrmmmwvAB3.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/nrmmmwvAB3.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/nzdiNgzpBk.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/nzdiNgzpBk.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/oEmtybut45.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/oEmtybut45.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/oV4NuQJ94t.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/oV4NuQJ94t.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/oklahTMTmf.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/oklahTMTmf.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/ors0bDh2bc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/ors0bDh2bc.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/pc50J7VwEQ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/pc50J7VwEQ.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/pqukhkAth1.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/pqukhkAth1.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/q5p595DJ6Q.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/q5p595DJ6Q.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/qE0fojpqnw.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/qE0fojpqnw.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/qGpRbiQ2ae.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/qGpRbiQ2ae.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/qoLqfVeYjg.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/qoLqfVeYjg.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/qxfXnYfFUG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/qxfXnYfFUG.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/r8w1v3Z6lL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/r8w1v3Z6lL.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/rMw8A9V28h.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/rMw8A9V28h.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/rZI5VmbmH8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/rZI5VmbmH8.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/rdy3COwDJ8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/rdy3COwDJ8.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/rlmBhex75r.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/rlmBhex75r.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/rn7ZDhqfGn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/rn7ZDhqfGn.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/rse9BAjK8p.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/rse9BAjK8p.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/rxLnaPSdKY.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/rxLnaPSdKY.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/sDb6wxVAlp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/sDb6wxVAlp.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/sHN8Z0s7Zl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/sHN8Z0s7Zl.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/sIk16HKXOH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/sIk16HKXOH.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/sfXrv8XKuT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/sfXrv8XKuT.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/spAP90Xdxo.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/spAP90Xdxo.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/t2LfLuggKw.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/t2LfLuggKw.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/t6anM049gM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/t6anM049gM.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/t6b9ipJFco.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/t6b9ipJFco.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/t88runt2vt.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/t88runt2vt.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/t96N3ukmC2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/t96N3ukmC2.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/tFHSIUZTRU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/tFHSIUZTRU.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/tOBEeyrzR5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/tOBEeyrzR5.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/tqmxPtSV5e.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/tqmxPtSV5e.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/ttgDLEo0YY.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/ttgDLEo0YY.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/tyDsoFs45y.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/tyDsoFs45y.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/tyrqHRTjct.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/tyrqHRTjct.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/uMrfngv4qE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/uMrfngv4qE.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/ufp5xt5UlZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/ufp5xt5UlZ.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/ukDSDTeRKn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/ukDSDTeRKn.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/vAhi6T2iCs.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/vAhi6T2iCs.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/vDddl4MmlU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/vDddl4MmlU.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/vLwvkrUp8m.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/vLwvkrUp8m.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/vO7uWdob4g.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/vO7uWdob4g.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/vUjLCf2llh.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/vUjLCf2llh.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/vdOsQV2zZZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/vdOsQV2zZZ.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/vqoyQGzxwZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/vqoyQGzxwZ.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/vuum3mHSut.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/vuum3mHSut.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/wff7vOGYXM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/wff7vOGYXM.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/wkgn6vRUUp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/wkgn6vRUUp.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/wmDBp8f0Z2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/wmDBp8f0Z2.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/woqch6WNMH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/woqch6WNMH.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/x1AVtHbq4f.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/x1AVtHbq4f.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/xEOJNLq3je.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/xEOJNLq3je.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/xM6CnVshaE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/xM6CnVshaE.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/xOe1maF1HZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/xOe1maF1HZ.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/xVFVQAk3u3.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/xVFVQAk3u3.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/xWEhNnxjgn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/xWEhNnxjgn.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/xmhnIZPlm0.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/xmhnIZPlm0.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/xqXMSXBMl8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/xqXMSXBMl8.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/xqemv5BeQH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/xqemv5BeQH.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/y8Wf7aTXFb.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/y8Wf7aTXFb.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/yCWOaOd0DH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/yCWOaOd0DH.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/yI34mPjVtK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/yI34mPjVtK.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/yQu5xEnWkt.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/yQu5xEnWkt.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/yVvQYsdxaq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/yVvQYsdxaq.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/yaMxpb9T34.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/yaMxpb9T34.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/ygTzDOCr3r.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/ygTzDOCr3r.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/z4XWuGECC2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/z4XWuGECC2.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/z9nNYIgtFz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/z9nNYIgtFz.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/zFiwaVTd6p.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/zFiwaVTd6p.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/zI6QHiNniJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/zI6QHiNniJ.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/zVrQLGqXwe.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/zVrQLGqXwe.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/zYVWOnWkq4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/zYVWOnWkq4.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/zZ91YoJG9X.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/zZ91YoJG9X.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/zuxZ6Tg1Ha.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0-us/zuxZ6Tg1Ha.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/06T2RNzfTz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/06T2RNzfTz.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/07aN2OB1qj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/07aN2OB1qj.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/0JTPBSFvcC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/0JTPBSFvcC.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/0McUuUDCYj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/0McUuUDCYj.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/0T3L0HU9F5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/0T3L0HU9F5.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/0UrWNfXMbn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/0UrWNfXMbn.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/0We2g9ZRI1.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/0We2g9ZRI1.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/0crDi3Beji.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/0crDi3Beji.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/0dN19RtMpy.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/0dN19RtMpy.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/0nyPk4lS5G.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/0nyPk4lS5G.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/0sV5NP6Raj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/0sV5NP6Raj.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/0tlxl8JzK2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/0tlxl8JzK2.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/13VaDTQa1F.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/13VaDTQa1F.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/177ObAyjaW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/177ObAyjaW.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/1SIwphdqPw.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/1SIwphdqPw.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/1Wku3If0yF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/1Wku3If0yF.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/1fkLnqEKq5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/1fkLnqEKq5.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/1guqW4QDJq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/1guqW4QDJq.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/1zvL3jc30s.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/1zvL3jc30s.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/2BK4YBngu6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/2BK4YBngu6.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/2DcJnHQ1Wc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/2DcJnHQ1Wc.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/2EmGTjbMHL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/2EmGTjbMHL.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/2bgBJIgdGy.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/2bgBJIgdGy.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/3DKPTxt9nK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/3DKPTxt9nK.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/3K5GXTKPrP.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/3K5GXTKPrP.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/3QFEobjwmC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/3QFEobjwmC.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/3RDZKRFFEV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/3RDZKRFFEV.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/3s0rgujAIg.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/3s0rgujAIg.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/4Ax5wLUa4c.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/4Ax5wLUa4c.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/4EsYZXHdpa.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/4EsYZXHdpa.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/4MA1GGxtB2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/4MA1GGxtB2.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/4TA0dltn8Z.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/4TA0dltn8Z.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/4XwovA4lrF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/4XwovA4lrF.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/4iwufNM5Y6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/4iwufNM5Y6.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/4kQSb8Mpxb.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/4kQSb8Mpxb.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/4knxgNV22P.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/4knxgNV22P.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/4prVlpN79q.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/4prVlpN79q.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/54K50WUaKI.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/54K50WUaKI.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/5E9QwsWPit.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/5E9QwsWPit.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/5JUr6L7hij.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/5JUr6L7hij.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/5WMn1FI8mr.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/5WMn1FI8mr.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/5ejPdcXoEW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/5ejPdcXoEW.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/5h6yFrKLct.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/5h6yFrKLct.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/6ezYN7Hv0Z.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/6ezYN7Hv0Z.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/6l2wTrG0a6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/6l2wTrG0a6.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/6oA6qi8Lpj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/6oA6qi8Lpj.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/6pwxM7x9RG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/6pwxM7x9RG.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/70gJ0d6ueN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/70gJ0d6ueN.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/7NBB4SlixM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/7NBB4SlixM.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/7PDb7B0Y2N.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/7PDb7B0Y2N.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/7Pcw6lts4T.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/7Pcw6lts4T.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/7Xcf56RyAr.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/7Xcf56RyAr.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/7n3s1BSMBo.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/7n3s1BSMBo.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/7s32eactiP.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/7s32eactiP.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/81lR1cSmfJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/81lR1cSmfJ.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/8dnUV6Vg0Y.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/8dnUV6Vg0Y.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/8tTziwEdcI.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/8tTziwEdcI.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/8zROpBby2x.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/8zROpBby2x.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/90J1b35WV8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/90J1b35WV8.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/91wjEMiEX6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/91wjEMiEX6.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/9EdR9Yk7ca.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/9EdR9Yk7ca.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/9RZxZPNxIu.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/9RZxZPNxIu.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/9TOztQhkC4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/9TOztQhkC4.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/9jWBrTk7UB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/9jWBrTk7UB.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/9lMN6zFkKE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/9lMN6zFkKE.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/9s6IGHapL2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/9s6IGHapL2.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/A01FvWmA8l.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/A01FvWmA8l.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/A3USVyZwFP.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/A3USVyZwFP.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/AGJgFoElmB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/AGJgFoElmB.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/AKEOkMAk9E.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/AKEOkMAk9E.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/ALzR9tiyk8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/ALzR9tiyk8.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/AenL9akVZ7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/AenL9akVZ7.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/AutcanQMIS.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/AutcanQMIS.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/B19N6aMdz3.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/B19N6aMdz3.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/B1EGKnhW9e.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/B1EGKnhW9e.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/B1oQQ08HGH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/B1oQQ08HGH.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/B54wYu3oDA.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/B54wYu3oDA.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/BBTptRbtCv.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/BBTptRbtCv.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/BGGCRglxce.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/BGGCRglxce.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/BP8ChaEEsu.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/BP8ChaEEsu.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/BWk4SOKZaL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/BWk4SOKZaL.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/Bj2rdZWLh7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/Bj2rdZWLh7.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/C0qtj9qPDQ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/C0qtj9qPDQ.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/C9re7IuLWT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/C9re7IuLWT.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/CNHSzPEwGH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/CNHSzPEwGH.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/CP3AlJWqrp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/CP3AlJWqrp.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/CWYcYC8app.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/CWYcYC8app.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/Cb3SuEIO21.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/Cb3SuEIO21.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/CoZ4zNyWGC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/CoZ4zNyWGC.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/D1CTthvE4P.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/D1CTthvE4P.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/DFn3iuttpy.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/DFn3iuttpy.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/Dc9KyR2b2p.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/Dc9KyR2b2p.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/Dph3kXOCic.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/Dph3kXOCic.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/Dvpv1gBrUQ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/Dvpv1gBrUQ.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/E4qThSDcnD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/E4qThSDcnD.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/EC4qtMsceH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/EC4qtMsceH.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/ERsIqJPx5L.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/ERsIqJPx5L.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/EZXLjw31Dl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/EZXLjw31Dl.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/EsvI0BL049.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/EsvI0BL049.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/F2Pe3EMY8l.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/F2Pe3EMY8l.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/F5lnyEc8P7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/F5lnyEc8P7.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/FCqK7dSpWU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/FCqK7dSpWU.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/FNBWotecr1.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/FNBWotecr1.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/FV6eIbtnYG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/FV6eIbtnYG.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/FXHmkUJdzB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/FXHmkUJdzB.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/Fn00VgWg5Y.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/Fn00VgWg5Y.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/G2sYQwPkhJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/G2sYQwPkhJ.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/G5mzA5SBhk.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/G5mzA5SBhk.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/GDxA5zEvt0.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/GDxA5zEvt0.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/GXsAoZzuGz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/GXsAoZzuGz.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/GgA3nIlfrr.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/GgA3nIlfrr.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/Gl9QSM0HL9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/Gl9QSM0HL9.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/HWdd0atzlF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/HWdd0atzlF.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/HjAQJGqXYX.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/HjAQJGqXYX.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/HzjTooszyT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/HzjTooszyT.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/I3R2n3iDwp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/I3R2n3iDwp.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/I5jP7AdXUO.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/I5jP7AdXUO.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/I8b2lta2dV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/I8b2lta2dV.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/IFfft0YbVF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/IFfft0YbVF.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/IcZKeRjvKW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/IcZKeRjvKW.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/IiI7gJ520W.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/IiI7gJ520W.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/Ij3DQuVRk7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/Ij3DQuVRk7.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/IuHoP54Wlc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/IuHoP54Wlc.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/IwYqIz3EHD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/IwYqIz3EHD.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/J0cKBlje4u.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/J0cKBlje4u.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/J1zbYLAkpc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/J1zbYLAkpc.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/J6HXfDOVhX.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/J6HXfDOVhX.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/JH4VhArCNR.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/JH4VhArCNR.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/JXkrGa9mJm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/JXkrGa9mJm.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/JjTVAGnAQr.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/JjTVAGnAQr.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/JptCVz4qEd.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/JptCVz4qEd.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/JtusM5o9mV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/JtusM5o9mV.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/K8foSEhEd6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/K8foSEhEd6.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/KCFf7gu3Y4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/KCFf7gu3Y4.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/KRrQYpA7NN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/KRrQYpA7NN.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/KkW0XInSXe.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/KkW0XInSXe.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/KmUJvvIFQM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/KmUJvvIFQM.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/KwZarRNYrG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/KwZarRNYrG.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/L2R0Fdeoqj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/L2R0Fdeoqj.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/L6Togn7pnd.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/L6Togn7pnd.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/LGFBsMx1Ue.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/LGFBsMx1Ue.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/LKPjaqZzne.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/LKPjaqZzne.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/LTwPCkotqR.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/LTwPCkotqR.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/LlojbpWjs9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/LlojbpWjs9.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/LnGkF3PV4B.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/LnGkF3PV4B.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/Lw6juAfLhZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/Lw6juAfLhZ.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/M2wCQaSIkx.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/M2wCQaSIkx.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/M7p8sbE3VI.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/M7p8sbE3VI.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/MAaNEFkxNx.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/MAaNEFkxNx.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/MN57efcLju.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/MN57efcLju.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/MTonphGglM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/MTonphGglM.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/MWxYsdcQAm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/MWxYsdcQAm.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/MiEtLwCnzM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/MiEtLwCnzM.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/Mm2925bgtf.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/Mm2925bgtf.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/MnCQlmeEpx.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/MnCQlmeEpx.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/Mnn3wVQyPT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/Mnn3wVQyPT.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/MwWzEyFzMN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/MwWzEyFzMN.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/N3qbcpPajg.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/N3qbcpPajg.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/NBM2jrtjUt.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/NBM2jrtjUt.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/NDycAe2PMg.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/NDycAe2PMg.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/NVaQ8JUMmp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/NVaQ8JUMmp.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/NauzwofxwH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/NauzwofxwH.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/Ngx37kpASZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/Ngx37kpASZ.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/NhzifMsgk2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/NhzifMsgk2.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/NpGzSptAcC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/NpGzSptAcC.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/NpRS0S6JWC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/NpRS0S6JWC.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/NqADIATboI.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/NqADIATboI.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/NwHv5RB2rz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/NwHv5RB2rz.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/O953QNNUI0.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/O953QNNUI0.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/OCchs83O6Y.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/OCchs83O6Y.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/OGxNUCIKC2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/OGxNUCIKC2.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/OJyyKz5GVv.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/OJyyKz5GVv.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/OMOINSyhgb.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/OMOINSyhgb.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/ON96VWl2eE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/ON96VWl2eE.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/OYhonKADC9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/OYhonKADC9.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/OZwHXjKDnl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/OZwHXjKDnl.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/OdEuAfadOv.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/OdEuAfadOv.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/OxyGJylIwW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/OxyGJylIwW.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/PHurkwqv4Z.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/PHurkwqv4Z.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/PXNopPwCXl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/PXNopPwCXl.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/QArvYA1I5y.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/QArvYA1I5y.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/QKdvStkUZD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/QKdvStkUZD.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/QkWxbTjqEQ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/QkWxbTjqEQ.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/QoD4gdBKht.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/QoD4gdBKht.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/QxOTHR8Vr5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/QxOTHR8Vr5.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/R4BCKWzeKK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/R4BCKWzeKK.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/RBTWh9W2wN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/RBTWh9W2wN.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/RSdIxOjWTU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/RSdIxOjWTU.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/RVXzOJsITX.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/RVXzOJsITX.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/RVsXeoSc9F.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/RVsXeoSc9F.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/RWTGsJXzQz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/RWTGsJXzQz.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/RYuyMUd2gk.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/RYuyMUd2gk.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/RpX90PHiU0.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/RpX90PHiU0.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/RvpGNGwBDO.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/RvpGNGwBDO.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/RykGa318Dx.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/RykGa318Dx.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/S4670YUK50.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/S4670YUK50.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/S6gLS26ZJ4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/S6gLS26ZJ4.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/S9LbD4Pr4R.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/S9LbD4Pr4R.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/SAOrYUiv3f.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/SAOrYUiv3f.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/SCkYQvq0A9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/SCkYQvq0A9.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/SDPXeHAEsY.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/SDPXeHAEsY.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/SFVT3QJAYW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/SFVT3QJAYW.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/SNuFk4PnW2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/SNuFk4PnW2.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/ShzxZhno8O.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/ShzxZhno8O.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/SnDPKIXHDi.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/SnDPKIXHDi.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/SzCgZ3qNN5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/SzCgZ3qNN5.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/T520ZP6L8T.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/T520ZP6L8T.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/TJTFd5hAYj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/TJTFd5hAYj.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/TRuTR85WZK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/TRuTR85WZK.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/TgwFqiQRdp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/TgwFqiQRdp.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/Tj8JfMPQOP.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/Tj8JfMPQOP.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/TrSKsrbw64.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/TrSKsrbw64.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/TtsQu77nNc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/TtsQu77nNc.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/U5ugQslU2z.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/U5ugQslU2z.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/UP8fkuONg2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/UP8fkuONg2.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/UQd9WJKHHq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/UQd9WJKHHq.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/UdYGjLjpzk.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/UdYGjLjpzk.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/UeKNqkUYqr.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/UeKNqkUYqr.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/UfKa2OpfYT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/UfKa2OpfYT.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/UmSdXFQzs5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/UmSdXFQzs5.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/Uwk8g9mKl8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/Uwk8g9mKl8.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/V39a2Wfhny.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/V39a2Wfhny.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/V6Alb9zB67.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/V6Alb9zB67.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/VBCxRuQlyS.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/VBCxRuQlyS.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/VCeH9ZweWA.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/VCeH9ZweWA.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/VLXVn8J66H.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/VLXVn8J66H.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/VWVKSidnGZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/VWVKSidnGZ.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/VYon30GsHO.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/VYon30GsHO.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/Vdgc0ZvuWs.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/Vdgc0ZvuWs.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/VfmDAdXzKM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/VfmDAdXzKM.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/VhYMLsMLrL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/VhYMLsMLrL.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/VxqkIhG88M.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/VxqkIhG88M.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/W5bnoMpunF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/W5bnoMpunF.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/WOpGodfIa8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/WOpGodfIa8.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/WVz16ttXmN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/WVz16ttXmN.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/WZDWUF8ibK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/WZDWUF8ibK.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/X5FuWfVgX6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/X5FuWfVgX6.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/XLacQhFM5v.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/XLacQhFM5v.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/XOK5FCR5BV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/XOK5FCR5BV.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/XSCVXLUIBn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/XSCVXLUIBn.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/XpelL4dfYJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/XpelL4dfYJ.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/Y0nmeL8Mk6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/Y0nmeL8Mk6.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/Y3mvjkMqPV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/Y3mvjkMqPV.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/Y5EXqXazv8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/Y5EXqXazv8.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/YGlCkfra9u.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/YGlCkfra9u.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/YHnNk2wz6l.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/YHnNk2wz6l.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/YJDISUV0P9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/YJDISUV0P9.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/YNZk56sw8a.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/YNZk56sw8a.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/YSjosSoyxD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/YSjosSoyxD.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/YYPqiV1dMh.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/YYPqiV1dMh.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/YcFI3Qezx8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/YcFI3Qezx8.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/Z7wOsOEcI7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/Z7wOsOEcI7.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/ZEkMAMmFrT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/ZEkMAMmFrT.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/ZHV48dd3xb.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/ZHV48dd3xb.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/ZPpTfz3cuC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/ZPpTfz3cuC.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/ZSKbzDVpdh.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/ZSKbzDVpdh.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/ZV0dzO1N3D.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/ZV0dzO1N3D.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/ZfCQZQ3Yi4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/ZfCQZQ3Yi4.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/ZgH9SeepAW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/ZgH9SeepAW.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/Zzt021tkHA.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/Zzt021tkHA.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/a1DiihgGoN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/a1DiihgGoN.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/aAzECToODG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/aAzECToODG.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/acAvcgb9wR.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/acAvcgb9wR.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/al6GdI6HHq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/al6GdI6HHq.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/b6lOjv1QB9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/b6lOjv1QB9.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/bCdroQZubL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/bCdroQZubL.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/bGXLKzz8DB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/bGXLKzz8DB.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/bOJODCt4Nj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/bOJODCt4Nj.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/bZMWPiINDJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/bZMWPiINDJ.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/bcY4kDXEiL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/bcY4kDXEiL.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/c6ixLi9Yns.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/c6ixLi9Yns.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/cC1vOfH1YD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/cC1vOfH1YD.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/cKgcqJQFSi.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/cKgcqJQFSi.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/cM7YAi3zbW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/cM7YAi3zbW.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/cZb1hdO5AT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/cZb1hdO5AT.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/cjKn08z80L.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/cjKn08z80L.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/cnoFERqEX9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/cnoFERqEX9.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/dBQTDFizrM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/dBQTDFizrM.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/dBXjMyQ6v5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/dBXjMyQ6v5.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/dQcYTBwxmD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/dQcYTBwxmD.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/dVvABT62C9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/dVvABT62C9.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/e3r8e0DiFz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/e3r8e0DiFz.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/eFsp09gaZX.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/eFsp09gaZX.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/eKleS2KN9V.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/eKleS2KN9V.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/eSoalgVCBH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/eSoalgVCBH.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/eVz6pfc2Aq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/eVz6pfc2Aq.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/eYtwlKx3DL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/eYtwlKx3DL.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/ecmluorkUs.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/ecmluorkUs.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/encSaFhW3u.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/encSaFhW3u.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/fEVDUjY0o4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/fEVDUjY0o4.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/fNBZi3EAxz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/fNBZi3EAxz.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/fQ6iyzZG4E.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/fQ6iyzZG4E.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/fkSI356192.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/fkSI356192.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/fqaD1J6KEH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/fqaD1J6KEH.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/fsCqVRe2XV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/fsCqVRe2XV.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/g32LIqIkv7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/g32LIqIkv7.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/g7NcHJ0Dqm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/g7NcHJ0Dqm.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/gKDRuR0huT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/gKDRuR0huT.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/gjl4ArLhJm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/gjl4ArLhJm.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/gvU8LsfGOx.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/gvU8LsfGOx.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/h9Y4PiPY6w.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/h9Y4PiPY6w.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/hchuG3s1rY.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/hchuG3s1rY.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/hnhVAIsmxU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/hnhVAIsmxU.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/hqtR9072e5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/hqtR9072e5.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/i53vKZdcnE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/i53vKZdcnE.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/iBn3UOpKdu.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/iBn3UOpKdu.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/iI6pw0QLBV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/iI6pw0QLBV.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/iQAGO67miB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/iQAGO67miB.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/iTg6zX0H2i.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/iTg6zX0H2i.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/iq57t3NYGm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/iq57t3NYGm.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/ixUQwlLoQl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/ixUQwlLoQl.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/ixp5a4MCzH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/ixp5a4MCzH.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/izrpe1H39g.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/izrpe1H39g.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/j0gOb12WG7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/j0gOb12WG7.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/j41I8z5Dbm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/j41I8z5Dbm.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/j9KVlh9Elu.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/j9KVlh9Elu.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/jEPN6e30lK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/jEPN6e30lK.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/jHoO30hDWC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/jHoO30hDWC.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/jOEODojhaI.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/jOEODojhaI.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/jSdYYlxIPu.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/jSdYYlxIPu.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/kDrpkD1xK6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/kDrpkD1xK6.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/kODlOvWLVJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/kODlOvWLVJ.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/koWMEughuG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/koWMEughuG.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/kpmo31UbcA.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/kpmo31UbcA.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/kuu79cE7XV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/kuu79cE7XV.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/ky7lfFDW6q.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/ky7lfFDW6q.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/kyEHvPp7Gk.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/kyEHvPp7Gk.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/lOk975L1YB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/lOk975L1YB.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/lW11AhH3pd.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/lW11AhH3pd.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/llHMuoBQb8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/llHMuoBQb8.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/m8AHxnkobT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/m8AHxnkobT.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/mBub665Sw1.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/mBub665Sw1.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/mKU2FtqWwc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/mKU2FtqWwc.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/mN75YcjhNl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/mN75YcjhNl.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/mhhBA6GJJy.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/mhhBA6GJJy.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/nE3Qa1apaH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/nE3Qa1apaH.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/nT8J5haK6F.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/nT8J5haK6F.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/nUWnom5eaz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/nUWnom5eaz.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/nY4f0rBQfZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/nY4f0rBQfZ.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/nenm6c9K9H.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/nenm6c9K9H.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/nrmmmwvAB3.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/nrmmmwvAB3.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/nzdiNgzpBk.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/nzdiNgzpBk.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/oEmtybut45.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/oEmtybut45.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/oV4NuQJ94t.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/oV4NuQJ94t.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/oklahTMTmf.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/oklahTMTmf.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/ors0bDh2bc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/ors0bDh2bc.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/pc50J7VwEQ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/pc50J7VwEQ.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/pqukhkAth1.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/pqukhkAth1.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/q5p595DJ6Q.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/q5p595DJ6Q.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/qE0fojpqnw.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/qE0fojpqnw.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/qGpRbiQ2ae.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/qGpRbiQ2ae.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/qoLqfVeYjg.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/qoLqfVeYjg.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/qxfXnYfFUG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/qxfXnYfFUG.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/r8w1v3Z6lL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/r8w1v3Z6lL.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/rMw8A9V28h.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/rMw8A9V28h.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/rZI5VmbmH8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/rZI5VmbmH8.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/rdy3COwDJ8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/rdy3COwDJ8.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/rlmBhex75r.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/rlmBhex75r.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/rn7ZDhqfGn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/rn7ZDhqfGn.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/rse9BAjK8p.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/rse9BAjK8p.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/rxLnaPSdKY.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/rxLnaPSdKY.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/sDb6wxVAlp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/sDb6wxVAlp.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/sHN8Z0s7Zl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/sHN8Z0s7Zl.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/sIk16HKXOH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/sIk16HKXOH.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/sfXrv8XKuT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/sfXrv8XKuT.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/spAP90Xdxo.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/spAP90Xdxo.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/t2LfLuggKw.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/t2LfLuggKw.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/t6anM049gM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/t6anM049gM.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/t6b9ipJFco.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/t6b9ipJFco.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/t88runt2vt.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/t88runt2vt.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/t96N3ukmC2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/t96N3ukmC2.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/tFHSIUZTRU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/tFHSIUZTRU.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/tOBEeyrzR5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/tOBEeyrzR5.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/tqmxPtSV5e.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/tqmxPtSV5e.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/ttgDLEo0YY.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/ttgDLEo0YY.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/tyDsoFs45y.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/tyDsoFs45y.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/tyrqHRTjct.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/tyrqHRTjct.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/uMrfngv4qE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/uMrfngv4qE.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/ufp5xt5UlZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/ufp5xt5UlZ.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/ukDSDTeRKn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/ukDSDTeRKn.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/vAhi6T2iCs.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/vAhi6T2iCs.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/vDddl4MmlU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/vDddl4MmlU.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/vLwvkrUp8m.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/vLwvkrUp8m.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/vO7uWdob4g.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/vO7uWdob4g.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/vUjLCf2llh.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/vUjLCf2llh.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/vdOsQV2zZZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/vdOsQV2zZZ.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/vqoyQGzxwZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/vqoyQGzxwZ.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/vuum3mHSut.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/vuum3mHSut.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/wff7vOGYXM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/wff7vOGYXM.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/wkgn6vRUUp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/wkgn6vRUUp.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/wmDBp8f0Z2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/wmDBp8f0Z2.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/woqch6WNMH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/woqch6WNMH.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/x1AVtHbq4f.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/x1AVtHbq4f.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/xEOJNLq3je.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/xEOJNLq3je.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/xM6CnVshaE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/xM6CnVshaE.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/xOe1maF1HZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/xOe1maF1HZ.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/xVFVQAk3u3.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/xVFVQAk3u3.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/xWEhNnxjgn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/xWEhNnxjgn.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/xmhnIZPlm0.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/xmhnIZPlm0.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/xqXMSXBMl8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/xqXMSXBMl8.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/xqemv5BeQH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/xqemv5BeQH.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/y8Wf7aTXFb.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/y8Wf7aTXFb.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/yCWOaOd0DH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/yCWOaOd0DH.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/yI34mPjVtK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/yI34mPjVtK.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/yQu5xEnWkt.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/yQu5xEnWkt.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/yVvQYsdxaq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/yVvQYsdxaq.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/yaMxpb9T34.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/yaMxpb9T34.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/ygTzDOCr3r.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/ygTzDOCr3r.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/z4XWuGECC2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/z4XWuGECC2.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/z9nNYIgtFz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/z9nNYIgtFz.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/zFiwaVTd6p.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/zFiwaVTd6p.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/zI6QHiNniJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/zI6QHiNniJ.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/zVrQLGqXwe.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/zVrQLGqXwe.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/zYVWOnWkq4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/zYVWOnWkq4.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/zZ91YoJG9X.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/zZ91YoJG9X.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/zuxZ6Tg1Ha.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v5.0/zuxZ6Tg1Ha.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/06T2RNzfTz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/06T2RNzfTz.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/07aN2OB1qj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/07aN2OB1qj.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/0JTPBSFvcC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/0JTPBSFvcC.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/0McUuUDCYj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/0McUuUDCYj.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/0T3L0HU9F5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/0T3L0HU9F5.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/0UrWNfXMbn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/0UrWNfXMbn.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/0We2g9ZRI1.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/0We2g9ZRI1.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/0crDi3Beji.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/0crDi3Beji.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/0dN19RtMpy.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/0dN19RtMpy.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/0nyPk4lS5G.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/0nyPk4lS5G.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/0sV5NP6Raj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/0sV5NP6Raj.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/0tlxl8JzK2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/0tlxl8JzK2.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/13VaDTQa1F.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/13VaDTQa1F.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/177ObAyjaW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/177ObAyjaW.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/1SIwphdqPw.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/1SIwphdqPw.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/1Wku3If0yF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/1Wku3If0yF.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/1fkLnqEKq5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/1fkLnqEKq5.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/1guqW4QDJq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/1guqW4QDJq.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/1zvL3jc30s.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/1zvL3jc30s.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/2BK4YBngu6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/2BK4YBngu6.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/2DcJnHQ1Wc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/2DcJnHQ1Wc.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/2EmGTjbMHL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/2EmGTjbMHL.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/2bgBJIgdGy.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/2bgBJIgdGy.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/3DKPTxt9nK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/3DKPTxt9nK.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/3K5GXTKPrP.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/3K5GXTKPrP.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/3QFEobjwmC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/3QFEobjwmC.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/3RDZKRFFEV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/3RDZKRFFEV.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/3s0rgujAIg.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/3s0rgujAIg.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/4Ax5wLUa4c.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/4Ax5wLUa4c.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/4EsYZXHdpa.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/4EsYZXHdpa.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/4MA1GGxtB2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/4MA1GGxtB2.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/4TA0dltn8Z.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/4TA0dltn8Z.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/4XwovA4lrF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/4XwovA4lrF.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/4iwufNM5Y6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/4iwufNM5Y6.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/4kQSb8Mpxb.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/4kQSb8Mpxb.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/4knxgNV22P.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/4knxgNV22P.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/4prVlpN79q.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/4prVlpN79q.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/54K50WUaKI.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/54K50WUaKI.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/5E9QwsWPit.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/5E9QwsWPit.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/5JUr6L7hij.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/5JUr6L7hij.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/5WMn1FI8mr.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/5WMn1FI8mr.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/5ejPdcXoEW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/5ejPdcXoEW.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/5h6yFrKLct.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/5h6yFrKLct.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/6ezYN7Hv0Z.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/6ezYN7Hv0Z.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/6l2wTrG0a6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/6l2wTrG0a6.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/6oA6qi8Lpj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/6oA6qi8Lpj.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/6pwxM7x9RG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/6pwxM7x9RG.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/70gJ0d6ueN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/70gJ0d6ueN.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/7NBB4SlixM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/7NBB4SlixM.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/7PDb7B0Y2N.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/7PDb7B0Y2N.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/7Pcw6lts4T.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/7Pcw6lts4T.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/7Xcf56RyAr.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/7Xcf56RyAr.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/7n3s1BSMBo.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/7n3s1BSMBo.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/7s32eactiP.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/7s32eactiP.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/81lR1cSmfJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/81lR1cSmfJ.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/8dnUV6Vg0Y.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/8dnUV6Vg0Y.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/8tTziwEdcI.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/8tTziwEdcI.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/8zROpBby2x.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/8zROpBby2x.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/90J1b35WV8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/90J1b35WV8.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/91wjEMiEX6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/91wjEMiEX6.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/9EdR9Yk7ca.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/9EdR9Yk7ca.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/9RZxZPNxIu.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/9RZxZPNxIu.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/9TOztQhkC4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/9TOztQhkC4.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/9jWBrTk7UB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/9jWBrTk7UB.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/9lMN6zFkKE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/9lMN6zFkKE.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/9s6IGHapL2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/9s6IGHapL2.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/A01FvWmA8l.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/A01FvWmA8l.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/A3USVyZwFP.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/A3USVyZwFP.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/AGJgFoElmB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/AGJgFoElmB.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/AKEOkMAk9E.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/AKEOkMAk9E.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/ALzR9tiyk8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/ALzR9tiyk8.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/AenL9akVZ7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/AenL9akVZ7.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/AutcanQMIS.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/AutcanQMIS.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/B19N6aMdz3.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/B19N6aMdz3.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/B1EGKnhW9e.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/B1EGKnhW9e.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/B1oQQ08HGH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/B1oQQ08HGH.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/B54wYu3oDA.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/B54wYu3oDA.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/BBTptRbtCv.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/BBTptRbtCv.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/BGGCRglxce.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/BGGCRglxce.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/BP8ChaEEsu.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/BP8ChaEEsu.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/BWk4SOKZaL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/BWk4SOKZaL.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/Bj2rdZWLh7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/Bj2rdZWLh7.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/C0qtj9qPDQ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/C0qtj9qPDQ.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/C9re7IuLWT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/C9re7IuLWT.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/CNHSzPEwGH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/CNHSzPEwGH.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/CP3AlJWqrp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/CP3AlJWqrp.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/CWYcYC8app.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/CWYcYC8app.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/Cb3SuEIO21.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/Cb3SuEIO21.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/CoZ4zNyWGC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/CoZ4zNyWGC.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/D1CTthvE4P.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/D1CTthvE4P.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/DFn3iuttpy.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/DFn3iuttpy.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/Dc9KyR2b2p.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/Dc9KyR2b2p.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/Dph3kXOCic.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/Dph3kXOCic.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/Dvpv1gBrUQ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/Dvpv1gBrUQ.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/E4qThSDcnD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/E4qThSDcnD.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/EC4qtMsceH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/EC4qtMsceH.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/ERsIqJPx5L.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/ERsIqJPx5L.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/EZXLjw31Dl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/EZXLjw31Dl.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/EsvI0BL049.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/EsvI0BL049.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/F2Pe3EMY8l.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/F2Pe3EMY8l.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/F5lnyEc8P7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/F5lnyEc8P7.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/FCqK7dSpWU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/FCqK7dSpWU.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/FNBWotecr1.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/FNBWotecr1.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/FV6eIbtnYG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/FV6eIbtnYG.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/FXHmkUJdzB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/FXHmkUJdzB.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/Fn00VgWg5Y.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/Fn00VgWg5Y.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/G2sYQwPkhJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/G2sYQwPkhJ.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/G5mzA5SBhk.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/G5mzA5SBhk.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/GDxA5zEvt0.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/GDxA5zEvt0.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/GXsAoZzuGz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/GXsAoZzuGz.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/GgA3nIlfrr.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/GgA3nIlfrr.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/Gl9QSM0HL9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/Gl9QSM0HL9.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/HWdd0atzlF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/HWdd0atzlF.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/HjAQJGqXYX.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/HjAQJGqXYX.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/HzjTooszyT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/HzjTooszyT.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/I3R2n3iDwp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/I3R2n3iDwp.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/I5jP7AdXUO.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/I5jP7AdXUO.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/I8b2lta2dV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/I8b2lta2dV.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/IFfft0YbVF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/IFfft0YbVF.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/IcZKeRjvKW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/IcZKeRjvKW.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/IiI7gJ520W.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/IiI7gJ520W.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/Ij3DQuVRk7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/Ij3DQuVRk7.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/IuHoP54Wlc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/IuHoP54Wlc.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/IwYqIz3EHD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/IwYqIz3EHD.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/J0cKBlje4u.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/J0cKBlje4u.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/J1zbYLAkpc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/J1zbYLAkpc.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/J6HXfDOVhX.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/J6HXfDOVhX.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/JH4VhArCNR.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/JH4VhArCNR.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/JXkrGa9mJm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/JXkrGa9mJm.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/JjTVAGnAQr.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/JjTVAGnAQr.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/JptCVz4qEd.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/JptCVz4qEd.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/JtusM5o9mV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/JtusM5o9mV.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/K8foSEhEd6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/K8foSEhEd6.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/KCFf7gu3Y4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/KCFf7gu3Y4.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/KRrQYpA7NN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/KRrQYpA7NN.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/KkW0XInSXe.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/KkW0XInSXe.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/KmUJvvIFQM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/KmUJvvIFQM.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/KwZarRNYrG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/KwZarRNYrG.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/L2R0Fdeoqj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/L2R0Fdeoqj.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/L6Togn7pnd.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/L6Togn7pnd.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/LGFBsMx1Ue.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/LGFBsMx1Ue.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/LKPjaqZzne.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/LKPjaqZzne.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/LTwPCkotqR.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/LTwPCkotqR.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/LlojbpWjs9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/LlojbpWjs9.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/LnGkF3PV4B.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/LnGkF3PV4B.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/Lw6juAfLhZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/Lw6juAfLhZ.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/M2wCQaSIkx.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/M2wCQaSIkx.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/M7p8sbE3VI.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/M7p8sbE3VI.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/MAaNEFkxNx.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/MAaNEFkxNx.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/MN57efcLju.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/MN57efcLju.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/MTonphGglM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/MTonphGglM.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/MWxYsdcQAm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/MWxYsdcQAm.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/MiEtLwCnzM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/MiEtLwCnzM.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/Mm2925bgtf.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/Mm2925bgtf.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/MnCQlmeEpx.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/MnCQlmeEpx.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/Mnn3wVQyPT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/Mnn3wVQyPT.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/MwWzEyFzMN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/MwWzEyFzMN.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/N3qbcpPajg.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/N3qbcpPajg.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/NBM2jrtjUt.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/NBM2jrtjUt.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/NDycAe2PMg.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/NDycAe2PMg.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/NVaQ8JUMmp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/NVaQ8JUMmp.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/NauzwofxwH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/NauzwofxwH.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/Ngx37kpASZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/Ngx37kpASZ.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/NhzifMsgk2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/NhzifMsgk2.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/NpGzSptAcC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/NpGzSptAcC.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/NpRS0S6JWC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/NpRS0S6JWC.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/NqADIATboI.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/NqADIATboI.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/NwHv5RB2rz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/NwHv5RB2rz.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/O953QNNUI0.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/O953QNNUI0.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/OCchs83O6Y.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/OCchs83O6Y.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/OGxNUCIKC2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/OGxNUCIKC2.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/OJyyKz5GVv.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/OJyyKz5GVv.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/OMOINSyhgb.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/OMOINSyhgb.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/ON96VWl2eE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/ON96VWl2eE.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/OYhonKADC9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/OYhonKADC9.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/OZwHXjKDnl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/OZwHXjKDnl.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/OdEuAfadOv.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/OdEuAfadOv.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/OxyGJylIwW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/OxyGJylIwW.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/PHurkwqv4Z.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/PHurkwqv4Z.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/PXNopPwCXl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/PXNopPwCXl.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/QArvYA1I5y.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/QArvYA1I5y.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/QKdvStkUZD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/QKdvStkUZD.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/QkWxbTjqEQ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/QkWxbTjqEQ.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/QoD4gdBKht.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/QoD4gdBKht.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/QxOTHR8Vr5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/QxOTHR8Vr5.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/R4BCKWzeKK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/R4BCKWzeKK.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/RBTWh9W2wN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/RBTWh9W2wN.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/RSdIxOjWTU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/RSdIxOjWTU.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/RVXzOJsITX.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/RVXzOJsITX.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/RVsXeoSc9F.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/RVsXeoSc9F.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/RWTGsJXzQz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/RWTGsJXzQz.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/RYuyMUd2gk.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/RYuyMUd2gk.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/RpX90PHiU0.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/RpX90PHiU0.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/RvpGNGwBDO.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/RvpGNGwBDO.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/RykGa318Dx.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/RykGa318Dx.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/S4670YUK50.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/S4670YUK50.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/S6gLS26ZJ4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/S6gLS26ZJ4.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/S9LbD4Pr4R.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/S9LbD4Pr4R.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/SAOrYUiv3f.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/SAOrYUiv3f.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/SCkYQvq0A9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/SCkYQvq0A9.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/SDPXeHAEsY.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/SDPXeHAEsY.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/SFVT3QJAYW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/SFVT3QJAYW.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/SNuFk4PnW2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/SNuFk4PnW2.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/ShzxZhno8O.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/ShzxZhno8O.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/SnDPKIXHDi.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/SnDPKIXHDi.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/SzCgZ3qNN5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/SzCgZ3qNN5.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/T520ZP6L8T.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/T520ZP6L8T.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/TJTFd5hAYj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/TJTFd5hAYj.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/TRuTR85WZK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/TRuTR85WZK.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/TgwFqiQRdp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/TgwFqiQRdp.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/Tj8JfMPQOP.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/Tj8JfMPQOP.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/TrSKsrbw64.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/TrSKsrbw64.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/TtsQu77nNc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/TtsQu77nNc.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/U5ugQslU2z.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/U5ugQslU2z.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/UP8fkuONg2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/UP8fkuONg2.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/UQd9WJKHHq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/UQd9WJKHHq.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/UdYGjLjpzk.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/UdYGjLjpzk.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/UeKNqkUYqr.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/UeKNqkUYqr.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/UfKa2OpfYT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/UfKa2OpfYT.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/UmSdXFQzs5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/UmSdXFQzs5.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/Uwk8g9mKl8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/Uwk8g9mKl8.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/V39a2Wfhny.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/V39a2Wfhny.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/V6Alb9zB67.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/V6Alb9zB67.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/VBCxRuQlyS.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/VBCxRuQlyS.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/VCeH9ZweWA.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/VCeH9ZweWA.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/VLXVn8J66H.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/VLXVn8J66H.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/VWVKSidnGZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/VWVKSidnGZ.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/VYon30GsHO.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/VYon30GsHO.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/Vdgc0ZvuWs.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/Vdgc0ZvuWs.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/VfmDAdXzKM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/VfmDAdXzKM.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/VhYMLsMLrL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/VhYMLsMLrL.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/VxqkIhG88M.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/VxqkIhG88M.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/W5bnoMpunF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/W5bnoMpunF.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/WOpGodfIa8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/WOpGodfIa8.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/WVz16ttXmN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/WVz16ttXmN.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/WZDWUF8ibK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/WZDWUF8ibK.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/X5FuWfVgX6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/X5FuWfVgX6.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/XLacQhFM5v.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/XLacQhFM5v.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/XOK5FCR5BV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/XOK5FCR5BV.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/XSCVXLUIBn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/XSCVXLUIBn.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/XpelL4dfYJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/XpelL4dfYJ.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/Y0nmeL8Mk6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/Y0nmeL8Mk6.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/Y3mvjkMqPV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/Y3mvjkMqPV.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/Y5EXqXazv8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/Y5EXqXazv8.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/YGlCkfra9u.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/YGlCkfra9u.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/YHnNk2wz6l.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/YHnNk2wz6l.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/YJDISUV0P9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/YJDISUV0P9.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/YNZk56sw8a.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/YNZk56sw8a.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/YSjosSoyxD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/YSjosSoyxD.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/YYPqiV1dMh.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/YYPqiV1dMh.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/YcFI3Qezx8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/YcFI3Qezx8.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/Z7wOsOEcI7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/Z7wOsOEcI7.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/ZEkMAMmFrT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/ZEkMAMmFrT.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/ZHV48dd3xb.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/ZHV48dd3xb.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/ZPpTfz3cuC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/ZPpTfz3cuC.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/ZSKbzDVpdh.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/ZSKbzDVpdh.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/ZV0dzO1N3D.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/ZV0dzO1N3D.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/ZfCQZQ3Yi4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/ZfCQZQ3Yi4.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/ZgH9SeepAW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/ZgH9SeepAW.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/Zzt021tkHA.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/Zzt021tkHA.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/a1DiihgGoN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/a1DiihgGoN.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/aAzECToODG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/aAzECToODG.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/acAvcgb9wR.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/acAvcgb9wR.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/al6GdI6HHq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/al6GdI6HHq.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/b6lOjv1QB9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/b6lOjv1QB9.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/bCdroQZubL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/bCdroQZubL.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/bGXLKzz8DB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/bGXLKzz8DB.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/bOJODCt4Nj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/bOJODCt4Nj.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/bZMWPiINDJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/bZMWPiINDJ.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/bcY4kDXEiL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/bcY4kDXEiL.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/c6ixLi9Yns.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/c6ixLi9Yns.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/cC1vOfH1YD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/cC1vOfH1YD.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/cKgcqJQFSi.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/cKgcqJQFSi.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/cM7YAi3zbW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/cM7YAi3zbW.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/cZb1hdO5AT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/cZb1hdO5AT.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/cjKn08z80L.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/cjKn08z80L.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/cnoFERqEX9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/cnoFERqEX9.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/dBQTDFizrM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/dBQTDFizrM.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/dBXjMyQ6v5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/dBXjMyQ6v5.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/dQcYTBwxmD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/dQcYTBwxmD.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/dVvABT62C9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/dVvABT62C9.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/e3r8e0DiFz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/e3r8e0DiFz.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/eFsp09gaZX.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/eFsp09gaZX.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/eKleS2KN9V.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/eKleS2KN9V.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/eSoalgVCBH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/eSoalgVCBH.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/eVz6pfc2Aq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/eVz6pfc2Aq.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/eYtwlKx3DL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/eYtwlKx3DL.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/ecmluorkUs.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/ecmluorkUs.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/encSaFhW3u.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/encSaFhW3u.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/fEVDUjY0o4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/fEVDUjY0o4.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/fNBZi3EAxz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/fNBZi3EAxz.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/fQ6iyzZG4E.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/fQ6iyzZG4E.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/fkSI356192.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/fkSI356192.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/fqaD1J6KEH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/fqaD1J6KEH.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/fsCqVRe2XV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/fsCqVRe2XV.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/g32LIqIkv7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/g32LIqIkv7.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/g7NcHJ0Dqm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/g7NcHJ0Dqm.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/gKDRuR0huT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/gKDRuR0huT.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/gjl4ArLhJm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/gjl4ArLhJm.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/gvU8LsfGOx.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/gvU8LsfGOx.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/h9Y4PiPY6w.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/h9Y4PiPY6w.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/hchuG3s1rY.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/hchuG3s1rY.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/hnhVAIsmxU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/hnhVAIsmxU.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/hqtR9072e5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/hqtR9072e5.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/i53vKZdcnE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/i53vKZdcnE.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/iBn3UOpKdu.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/iBn3UOpKdu.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/iI6pw0QLBV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/iI6pw0QLBV.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/iQAGO67miB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/iQAGO67miB.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/iTg6zX0H2i.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/iTg6zX0H2i.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/iq57t3NYGm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/iq57t3NYGm.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/ixUQwlLoQl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/ixUQwlLoQl.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/ixp5a4MCzH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/ixp5a4MCzH.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/izrpe1H39g.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/izrpe1H39g.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/j0gOb12WG7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/j0gOb12WG7.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/j41I8z5Dbm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/j41I8z5Dbm.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/j9KVlh9Elu.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/j9KVlh9Elu.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/jEPN6e30lK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/jEPN6e30lK.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/jHoO30hDWC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/jHoO30hDWC.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/jOEODojhaI.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/jOEODojhaI.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/jSdYYlxIPu.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/jSdYYlxIPu.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/kDrpkD1xK6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/kDrpkD1xK6.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/kODlOvWLVJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/kODlOvWLVJ.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/koWMEughuG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/koWMEughuG.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/kpmo31UbcA.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/kpmo31UbcA.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/kuu79cE7XV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/kuu79cE7XV.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/ky7lfFDW6q.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/ky7lfFDW6q.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/kyEHvPp7Gk.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/kyEHvPp7Gk.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/lOk975L1YB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/lOk975L1YB.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/lW11AhH3pd.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/lW11AhH3pd.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/llHMuoBQb8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/llHMuoBQb8.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/m8AHxnkobT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/m8AHxnkobT.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/mBub665Sw1.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/mBub665Sw1.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/mKU2FtqWwc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/mKU2FtqWwc.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/mN75YcjhNl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/mN75YcjhNl.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/mhhBA6GJJy.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/mhhBA6GJJy.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/nE3Qa1apaH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/nE3Qa1apaH.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/nT8J5haK6F.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/nT8J5haK6F.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/nUWnom5eaz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/nUWnom5eaz.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/nY4f0rBQfZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/nY4f0rBQfZ.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/nenm6c9K9H.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/nenm6c9K9H.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/nrmmmwvAB3.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/nrmmmwvAB3.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/nzdiNgzpBk.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/nzdiNgzpBk.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/oEmtybut45.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/oEmtybut45.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/oV4NuQJ94t.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/oV4NuQJ94t.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/oklahTMTmf.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/oklahTMTmf.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/ors0bDh2bc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/ors0bDh2bc.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/pc50J7VwEQ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/pc50J7VwEQ.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/pqukhkAth1.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/pqukhkAth1.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/q5p595DJ6Q.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/q5p595DJ6Q.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/qE0fojpqnw.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/qE0fojpqnw.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/qGpRbiQ2ae.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/qGpRbiQ2ae.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/qoLqfVeYjg.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/qoLqfVeYjg.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/qxfXnYfFUG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/qxfXnYfFUG.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/r8w1v3Z6lL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/r8w1v3Z6lL.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/rMw8A9V28h.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/rMw8A9V28h.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/rZI5VmbmH8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/rZI5VmbmH8.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/rdy3COwDJ8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/rdy3COwDJ8.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/rlmBhex75r.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/rlmBhex75r.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/rn7ZDhqfGn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/rn7ZDhqfGn.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/rse9BAjK8p.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/rse9BAjK8p.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/rxLnaPSdKY.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/rxLnaPSdKY.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/sDb6wxVAlp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/sDb6wxVAlp.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/sHN8Z0s7Zl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/sHN8Z0s7Zl.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/sIk16HKXOH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/sIk16HKXOH.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/sfXrv8XKuT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/sfXrv8XKuT.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/spAP90Xdxo.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/spAP90Xdxo.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/t2LfLuggKw.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/t2LfLuggKw.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/t6anM049gM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/t6anM049gM.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/t6b9ipJFco.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/t6b9ipJFco.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/t88runt2vt.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/t88runt2vt.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/t96N3ukmC2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/t96N3ukmC2.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/tFHSIUZTRU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/tFHSIUZTRU.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/tOBEeyrzR5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/tOBEeyrzR5.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/tqmxPtSV5e.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/tqmxPtSV5e.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/ttgDLEo0YY.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/ttgDLEo0YY.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/tyDsoFs45y.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/tyDsoFs45y.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/tyrqHRTjct.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/tyrqHRTjct.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/uMrfngv4qE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/uMrfngv4qE.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/ufp5xt5UlZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/ufp5xt5UlZ.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/ukDSDTeRKn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/ukDSDTeRKn.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/vAhi6T2iCs.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/vAhi6T2iCs.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/vDddl4MmlU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/vDddl4MmlU.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/vLwvkrUp8m.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/vLwvkrUp8m.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/vO7uWdob4g.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/vO7uWdob4g.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/vUjLCf2llh.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/vUjLCf2llh.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/vdOsQV2zZZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/vdOsQV2zZZ.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/vqoyQGzxwZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/vqoyQGzxwZ.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/vuum3mHSut.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/vuum3mHSut.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/wff7vOGYXM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/wff7vOGYXM.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/wkgn6vRUUp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/wkgn6vRUUp.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/wmDBp8f0Z2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/wmDBp8f0Z2.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/woqch6WNMH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/woqch6WNMH.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/x1AVtHbq4f.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/x1AVtHbq4f.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/xEOJNLq3je.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/xEOJNLq3je.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/xM6CnVshaE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/xM6CnVshaE.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/xOe1maF1HZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/xOe1maF1HZ.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/xVFVQAk3u3.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/xVFVQAk3u3.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/xWEhNnxjgn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/xWEhNnxjgn.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/xmhnIZPlm0.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/xmhnIZPlm0.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/xqXMSXBMl8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/xqXMSXBMl8.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/xqemv5BeQH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/xqemv5BeQH.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/y8Wf7aTXFb.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/y8Wf7aTXFb.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/yCWOaOd0DH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/yCWOaOd0DH.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/yI34mPjVtK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/yI34mPjVtK.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/yQu5xEnWkt.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/yQu5xEnWkt.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/yVvQYsdxaq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/yVvQYsdxaq.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/yaMxpb9T34.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/yaMxpb9T34.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/ygTzDOCr3r.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/ygTzDOCr3r.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/z4XWuGECC2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/z4XWuGECC2.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/z9nNYIgtFz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/z9nNYIgtFz.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/zFiwaVTd6p.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/zFiwaVTd6p.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/zI6QHiNniJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/zI6QHiNniJ.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/zVrQLGqXwe.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/zVrQLGqXwe.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/zYVWOnWkq4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/zYVWOnWkq4.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/zZ91YoJG9X.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/zZ91YoJG9X.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/zuxZ6Tg1Ha.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-fr/zuxZ6Tg1Ha.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/06T2RNzfTz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/06T2RNzfTz.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/07aN2OB1qj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/07aN2OB1qj.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/0JTPBSFvcC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/0JTPBSFvcC.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/0McUuUDCYj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/0McUuUDCYj.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/0T3L0HU9F5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/0T3L0HU9F5.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/0UrWNfXMbn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/0UrWNfXMbn.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/0We2g9ZRI1.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/0We2g9ZRI1.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/0crDi3Beji.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/0crDi3Beji.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/0dN19RtMpy.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/0dN19RtMpy.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/0nyPk4lS5G.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/0nyPk4lS5G.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/0sV5NP6Raj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/0sV5NP6Raj.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/0tlxl8JzK2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/0tlxl8JzK2.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/13VaDTQa1F.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/13VaDTQa1F.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/177ObAyjaW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/177ObAyjaW.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/1SIwphdqPw.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/1SIwphdqPw.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/1Wku3If0yF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/1Wku3If0yF.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/1fkLnqEKq5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/1fkLnqEKq5.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/1guqW4QDJq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/1guqW4QDJq.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/1zvL3jc30s.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/1zvL3jc30s.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/2BK4YBngu6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/2BK4YBngu6.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/2DcJnHQ1Wc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/2DcJnHQ1Wc.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/2EmGTjbMHL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/2EmGTjbMHL.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/2bgBJIgdGy.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/2bgBJIgdGy.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/3DKPTxt9nK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/3DKPTxt9nK.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/3K5GXTKPrP.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/3K5GXTKPrP.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/3QFEobjwmC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/3QFEobjwmC.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/3RDZKRFFEV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/3RDZKRFFEV.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/3s0rgujAIg.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/3s0rgujAIg.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/4Ax5wLUa4c.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/4Ax5wLUa4c.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/4EsYZXHdpa.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/4EsYZXHdpa.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/4MA1GGxtB2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/4MA1GGxtB2.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/4TA0dltn8Z.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/4TA0dltn8Z.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/4XwovA4lrF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/4XwovA4lrF.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/4iwufNM5Y6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/4iwufNM5Y6.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/4kQSb8Mpxb.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/4kQSb8Mpxb.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/4knxgNV22P.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/4knxgNV22P.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/4prVlpN79q.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/4prVlpN79q.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/54K50WUaKI.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/54K50WUaKI.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/5E9QwsWPit.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/5E9QwsWPit.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/5JUr6L7hij.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/5JUr6L7hij.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/5WMn1FI8mr.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/5WMn1FI8mr.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/5ejPdcXoEW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/5ejPdcXoEW.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/5h6yFrKLct.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/5h6yFrKLct.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/6ezYN7Hv0Z.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/6ezYN7Hv0Z.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/6l2wTrG0a6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/6l2wTrG0a6.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/6oA6qi8Lpj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/6oA6qi8Lpj.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/6pwxM7x9RG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/6pwxM7x9RG.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/70gJ0d6ueN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/70gJ0d6ueN.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/7NBB4SlixM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/7NBB4SlixM.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/7PDb7B0Y2N.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/7PDb7B0Y2N.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/7Pcw6lts4T.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/7Pcw6lts4T.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/7Xcf56RyAr.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/7Xcf56RyAr.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/7n3s1BSMBo.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/7n3s1BSMBo.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/7s32eactiP.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/7s32eactiP.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/81lR1cSmfJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/81lR1cSmfJ.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/8dnUV6Vg0Y.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/8dnUV6Vg0Y.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/8tTziwEdcI.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/8tTziwEdcI.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/8zROpBby2x.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/8zROpBby2x.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/90J1b35WV8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/90J1b35WV8.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/91wjEMiEX6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/91wjEMiEX6.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/9EdR9Yk7ca.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/9EdR9Yk7ca.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/9RZxZPNxIu.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/9RZxZPNxIu.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/9TOztQhkC4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/9TOztQhkC4.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/9jWBrTk7UB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/9jWBrTk7UB.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/9lMN6zFkKE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/9lMN6zFkKE.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/9s6IGHapL2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/9s6IGHapL2.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/A01FvWmA8l.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/A01FvWmA8l.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/A3USVyZwFP.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/A3USVyZwFP.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/AGJgFoElmB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/AGJgFoElmB.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/AKEOkMAk9E.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/AKEOkMAk9E.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/ALzR9tiyk8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/ALzR9tiyk8.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/AenL9akVZ7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/AenL9akVZ7.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/AutcanQMIS.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/AutcanQMIS.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/B19N6aMdz3.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/B19N6aMdz3.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/B1EGKnhW9e.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/B1EGKnhW9e.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/B1oQQ08HGH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/B1oQQ08HGH.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/B54wYu3oDA.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/B54wYu3oDA.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/BBTptRbtCv.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/BBTptRbtCv.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/BGGCRglxce.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/BGGCRglxce.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/BP8ChaEEsu.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/BP8ChaEEsu.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/BWk4SOKZaL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/BWk4SOKZaL.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/Bj2rdZWLh7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/Bj2rdZWLh7.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/C0qtj9qPDQ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/C0qtj9qPDQ.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/C9re7IuLWT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/C9re7IuLWT.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/CNHSzPEwGH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/CNHSzPEwGH.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/CP3AlJWqrp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/CP3AlJWqrp.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/CWYcYC8app.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/CWYcYC8app.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/Cb3SuEIO21.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/Cb3SuEIO21.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/CoZ4zNyWGC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/CoZ4zNyWGC.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/D1CTthvE4P.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/D1CTthvE4P.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/DFn3iuttpy.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/DFn3iuttpy.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/Dc9KyR2b2p.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/Dc9KyR2b2p.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/Dph3kXOCic.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/Dph3kXOCic.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/Dvpv1gBrUQ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/Dvpv1gBrUQ.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/E4qThSDcnD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/E4qThSDcnD.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/EC4qtMsceH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/EC4qtMsceH.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/ERsIqJPx5L.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/ERsIqJPx5L.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/EZXLjw31Dl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/EZXLjw31Dl.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/EsvI0BL049.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/EsvI0BL049.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/F2Pe3EMY8l.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/F2Pe3EMY8l.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/F5lnyEc8P7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/F5lnyEc8P7.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/FCqK7dSpWU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/FCqK7dSpWU.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/FNBWotecr1.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/FNBWotecr1.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/FV6eIbtnYG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/FV6eIbtnYG.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/FXHmkUJdzB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/FXHmkUJdzB.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/Fn00VgWg5Y.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/Fn00VgWg5Y.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/G2sYQwPkhJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/G2sYQwPkhJ.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/G5mzA5SBhk.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/G5mzA5SBhk.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/GDxA5zEvt0.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/GDxA5zEvt0.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/GXsAoZzuGz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/GXsAoZzuGz.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/GgA3nIlfrr.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/GgA3nIlfrr.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/Gl9QSM0HL9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/Gl9QSM0HL9.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/HWdd0atzlF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/HWdd0atzlF.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/HjAQJGqXYX.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/HjAQJGqXYX.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/HzjTooszyT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/HzjTooszyT.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/I3R2n3iDwp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/I3R2n3iDwp.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/I5jP7AdXUO.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/I5jP7AdXUO.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/I8b2lta2dV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/I8b2lta2dV.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/IFfft0YbVF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/IFfft0YbVF.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/IcZKeRjvKW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/IcZKeRjvKW.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/IiI7gJ520W.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/IiI7gJ520W.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/Ij3DQuVRk7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/Ij3DQuVRk7.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/IuHoP54Wlc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/IuHoP54Wlc.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/IwYqIz3EHD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/IwYqIz3EHD.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/J0cKBlje4u.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/J0cKBlje4u.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/J1zbYLAkpc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/J1zbYLAkpc.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/J6HXfDOVhX.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/J6HXfDOVhX.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/JH4VhArCNR.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/JH4VhArCNR.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/JXkrGa9mJm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/JXkrGa9mJm.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/JjTVAGnAQr.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/JjTVAGnAQr.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/JptCVz4qEd.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/JptCVz4qEd.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/JtusM5o9mV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/JtusM5o9mV.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/K8foSEhEd6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/K8foSEhEd6.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/KCFf7gu3Y4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/KCFf7gu3Y4.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/KRrQYpA7NN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/KRrQYpA7NN.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/KkW0XInSXe.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/KkW0XInSXe.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/KmUJvvIFQM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/KmUJvvIFQM.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/KwZarRNYrG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/KwZarRNYrG.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/L2R0Fdeoqj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/L2R0Fdeoqj.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/L6Togn7pnd.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/L6Togn7pnd.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/LGFBsMx1Ue.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/LGFBsMx1Ue.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/LKPjaqZzne.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/LKPjaqZzne.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/LTwPCkotqR.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/LTwPCkotqR.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/LlojbpWjs9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/LlojbpWjs9.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/LnGkF3PV4B.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/LnGkF3PV4B.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/Lw6juAfLhZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/Lw6juAfLhZ.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/M2wCQaSIkx.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/M2wCQaSIkx.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/M7p8sbE3VI.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/M7p8sbE3VI.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/MAaNEFkxNx.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/MAaNEFkxNx.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/MN57efcLju.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/MN57efcLju.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/MTonphGglM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/MTonphGglM.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/MWxYsdcQAm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/MWxYsdcQAm.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/MiEtLwCnzM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/MiEtLwCnzM.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/Mm2925bgtf.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/Mm2925bgtf.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/MnCQlmeEpx.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/MnCQlmeEpx.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/Mnn3wVQyPT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/Mnn3wVQyPT.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/MwWzEyFzMN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/MwWzEyFzMN.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/N3qbcpPajg.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/N3qbcpPajg.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/NBM2jrtjUt.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/NBM2jrtjUt.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/NDycAe2PMg.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/NDycAe2PMg.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/NVaQ8JUMmp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/NVaQ8JUMmp.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/NauzwofxwH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/NauzwofxwH.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/Ngx37kpASZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/Ngx37kpASZ.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/NhzifMsgk2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/NhzifMsgk2.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/NpGzSptAcC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/NpGzSptAcC.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/NpRS0S6JWC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/NpRS0S6JWC.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/NqADIATboI.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/NqADIATboI.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/NwHv5RB2rz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/NwHv5RB2rz.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/O953QNNUI0.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/O953QNNUI0.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/OCchs83O6Y.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/OCchs83O6Y.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/OGxNUCIKC2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/OGxNUCIKC2.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/OJyyKz5GVv.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/OJyyKz5GVv.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/OMOINSyhgb.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/OMOINSyhgb.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/ON96VWl2eE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/ON96VWl2eE.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/OYhonKADC9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/OYhonKADC9.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/OZwHXjKDnl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/OZwHXjKDnl.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/OdEuAfadOv.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/OdEuAfadOv.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/OxyGJylIwW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/OxyGJylIwW.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/PHurkwqv4Z.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/PHurkwqv4Z.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/PXNopPwCXl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/PXNopPwCXl.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/QArvYA1I5y.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/QArvYA1I5y.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/QKdvStkUZD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/QKdvStkUZD.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/QkWxbTjqEQ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/QkWxbTjqEQ.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/QoD4gdBKht.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/QoD4gdBKht.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/QxOTHR8Vr5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/QxOTHR8Vr5.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/R4BCKWzeKK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/R4BCKWzeKK.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/RBTWh9W2wN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/RBTWh9W2wN.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/RSdIxOjWTU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/RSdIxOjWTU.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/RVXzOJsITX.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/RVXzOJsITX.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/RVsXeoSc9F.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/RVsXeoSc9F.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/RWTGsJXzQz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/RWTGsJXzQz.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/RYuyMUd2gk.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/RYuyMUd2gk.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/RpX90PHiU0.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/RpX90PHiU0.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/RvpGNGwBDO.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/RvpGNGwBDO.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/RykGa318Dx.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/RykGa318Dx.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/S4670YUK50.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/S4670YUK50.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/S6gLS26ZJ4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/S6gLS26ZJ4.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/S9LbD4Pr4R.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/S9LbD4Pr4R.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/SAOrYUiv3f.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/SAOrYUiv3f.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/SCkYQvq0A9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/SCkYQvq0A9.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/SDPXeHAEsY.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/SDPXeHAEsY.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/SFVT3QJAYW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/SFVT3QJAYW.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/SNuFk4PnW2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/SNuFk4PnW2.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/ShzxZhno8O.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/ShzxZhno8O.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/SnDPKIXHDi.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/SnDPKIXHDi.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/SzCgZ3qNN5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/SzCgZ3qNN5.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/T520ZP6L8T.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/T520ZP6L8T.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/TJTFd5hAYj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/TJTFd5hAYj.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/TRuTR85WZK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/TRuTR85WZK.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/TgwFqiQRdp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/TgwFqiQRdp.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/Tj8JfMPQOP.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/Tj8JfMPQOP.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/TrSKsrbw64.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/TrSKsrbw64.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/TtsQu77nNc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/TtsQu77nNc.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/U5ugQslU2z.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/U5ugQslU2z.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/UP8fkuONg2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/UP8fkuONg2.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/UQd9WJKHHq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/UQd9WJKHHq.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/UdYGjLjpzk.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/UdYGjLjpzk.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/UeKNqkUYqr.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/UeKNqkUYqr.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/UfKa2OpfYT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/UfKa2OpfYT.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/UmSdXFQzs5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/UmSdXFQzs5.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/Uwk8g9mKl8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/Uwk8g9mKl8.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/V39a2Wfhny.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/V39a2Wfhny.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/V6Alb9zB67.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/V6Alb9zB67.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/VBCxRuQlyS.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/VBCxRuQlyS.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/VCeH9ZweWA.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/VCeH9ZweWA.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/VLXVn8J66H.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/VLXVn8J66H.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/VWVKSidnGZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/VWVKSidnGZ.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/VYon30GsHO.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/VYon30GsHO.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/Vdgc0ZvuWs.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/Vdgc0ZvuWs.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/VfmDAdXzKM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/VfmDAdXzKM.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/VhYMLsMLrL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/VhYMLsMLrL.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/VxqkIhG88M.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/VxqkIhG88M.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/W5bnoMpunF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/W5bnoMpunF.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/WOpGodfIa8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/WOpGodfIa8.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/WVz16ttXmN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/WVz16ttXmN.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/WZDWUF8ibK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/WZDWUF8ibK.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/X5FuWfVgX6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/X5FuWfVgX6.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/XLacQhFM5v.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/XLacQhFM5v.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/XOK5FCR5BV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/XOK5FCR5BV.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/XSCVXLUIBn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/XSCVXLUIBn.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/XpelL4dfYJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/XpelL4dfYJ.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/Y0nmeL8Mk6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/Y0nmeL8Mk6.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/Y3mvjkMqPV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/Y3mvjkMqPV.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/Y5EXqXazv8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/Y5EXqXazv8.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/YGlCkfra9u.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/YGlCkfra9u.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/YHnNk2wz6l.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/YHnNk2wz6l.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/YJDISUV0P9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/YJDISUV0P9.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/YNZk56sw8a.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/YNZk56sw8a.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/YSjosSoyxD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/YSjosSoyxD.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/YYPqiV1dMh.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/YYPqiV1dMh.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/YcFI3Qezx8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/YcFI3Qezx8.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/Z7wOsOEcI7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/Z7wOsOEcI7.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/ZEkMAMmFrT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/ZEkMAMmFrT.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/ZHV48dd3xb.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/ZHV48dd3xb.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/ZPpTfz3cuC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/ZPpTfz3cuC.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/ZSKbzDVpdh.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/ZSKbzDVpdh.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/ZV0dzO1N3D.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/ZV0dzO1N3D.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/ZfCQZQ3Yi4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/ZfCQZQ3Yi4.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/ZgH9SeepAW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/ZgH9SeepAW.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/Zzt021tkHA.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/Zzt021tkHA.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/a1DiihgGoN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/a1DiihgGoN.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/aAzECToODG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/aAzECToODG.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/acAvcgb9wR.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/acAvcgb9wR.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/al6GdI6HHq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/al6GdI6HHq.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/b6lOjv1QB9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/b6lOjv1QB9.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/bCdroQZubL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/bCdroQZubL.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/bGXLKzz8DB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/bGXLKzz8DB.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/bOJODCt4Nj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/bOJODCt4Nj.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/bZMWPiINDJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/bZMWPiINDJ.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/bcY4kDXEiL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/bcY4kDXEiL.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/c6ixLi9Yns.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/c6ixLi9Yns.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/cC1vOfH1YD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/cC1vOfH1YD.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/cKgcqJQFSi.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/cKgcqJQFSi.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/cM7YAi3zbW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/cM7YAi3zbW.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/cZb1hdO5AT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/cZb1hdO5AT.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/cjKn08z80L.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/cjKn08z80L.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/cnoFERqEX9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/cnoFERqEX9.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/dBQTDFizrM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/dBQTDFizrM.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/dBXjMyQ6v5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/dBXjMyQ6v5.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/dQcYTBwxmD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/dQcYTBwxmD.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/dVvABT62C9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/dVvABT62C9.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/e3r8e0DiFz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/e3r8e0DiFz.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/eFsp09gaZX.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/eFsp09gaZX.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/eKleS2KN9V.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/eKleS2KN9V.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/eSoalgVCBH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/eSoalgVCBH.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/eVz6pfc2Aq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/eVz6pfc2Aq.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/eYtwlKx3DL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/eYtwlKx3DL.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/ecmluorkUs.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/ecmluorkUs.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/encSaFhW3u.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/encSaFhW3u.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/fEVDUjY0o4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/fEVDUjY0o4.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/fNBZi3EAxz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/fNBZi3EAxz.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/fQ6iyzZG4E.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/fQ6iyzZG4E.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/fkSI356192.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/fkSI356192.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/fqaD1J6KEH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/fqaD1J6KEH.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/fsCqVRe2XV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/fsCqVRe2XV.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/g32LIqIkv7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/g32LIqIkv7.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/g7NcHJ0Dqm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/g7NcHJ0Dqm.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/gKDRuR0huT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/gKDRuR0huT.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/gjl4ArLhJm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/gjl4ArLhJm.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/gvU8LsfGOx.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/gvU8LsfGOx.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/h9Y4PiPY6w.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/h9Y4PiPY6w.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/hchuG3s1rY.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/hchuG3s1rY.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/hnhVAIsmxU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/hnhVAIsmxU.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/hqtR9072e5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/hqtR9072e5.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/i53vKZdcnE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/i53vKZdcnE.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/iBn3UOpKdu.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/iBn3UOpKdu.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/iI6pw0QLBV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/iI6pw0QLBV.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/iQAGO67miB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/iQAGO67miB.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/iTg6zX0H2i.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/iTg6zX0H2i.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/iq57t3NYGm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/iq57t3NYGm.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/ixUQwlLoQl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/ixUQwlLoQl.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/ixp5a4MCzH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/ixp5a4MCzH.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/izrpe1H39g.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/izrpe1H39g.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/j0gOb12WG7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/j0gOb12WG7.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/j41I8z5Dbm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/j41I8z5Dbm.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/j9KVlh9Elu.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/j9KVlh9Elu.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/jEPN6e30lK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/jEPN6e30lK.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/jHoO30hDWC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/jHoO30hDWC.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/jOEODojhaI.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/jOEODojhaI.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/jSdYYlxIPu.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/jSdYYlxIPu.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/kDrpkD1xK6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/kDrpkD1xK6.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/kODlOvWLVJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/kODlOvWLVJ.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/koWMEughuG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/koWMEughuG.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/kpmo31UbcA.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/kpmo31UbcA.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/kuu79cE7XV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/kuu79cE7XV.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/ky7lfFDW6q.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/ky7lfFDW6q.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/kyEHvPp7Gk.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/kyEHvPp7Gk.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/lOk975L1YB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/lOk975L1YB.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/lW11AhH3pd.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/lW11AhH3pd.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/llHMuoBQb8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/llHMuoBQb8.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/m8AHxnkobT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/m8AHxnkobT.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/mBub665Sw1.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/mBub665Sw1.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/mKU2FtqWwc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/mKU2FtqWwc.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/mN75YcjhNl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/mN75YcjhNl.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/mhhBA6GJJy.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/mhhBA6GJJy.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/nE3Qa1apaH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/nE3Qa1apaH.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/nT8J5haK6F.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/nT8J5haK6F.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/nUWnom5eaz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/nUWnom5eaz.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/nY4f0rBQfZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/nY4f0rBQfZ.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/nenm6c9K9H.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/nenm6c9K9H.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/nrmmmwvAB3.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/nrmmmwvAB3.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/nzdiNgzpBk.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/nzdiNgzpBk.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/oEmtybut45.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/oEmtybut45.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/oV4NuQJ94t.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/oV4NuQJ94t.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/oklahTMTmf.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/oklahTMTmf.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/ors0bDh2bc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/ors0bDh2bc.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/pc50J7VwEQ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/pc50J7VwEQ.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/pqukhkAth1.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/pqukhkAth1.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/q5p595DJ6Q.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/q5p595DJ6Q.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/qE0fojpqnw.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/qE0fojpqnw.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/qGpRbiQ2ae.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/qGpRbiQ2ae.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/qoLqfVeYjg.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/qoLqfVeYjg.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/qxfXnYfFUG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/qxfXnYfFUG.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/r8w1v3Z6lL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/r8w1v3Z6lL.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/rMw8A9V28h.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/rMw8A9V28h.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/rZI5VmbmH8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/rZI5VmbmH8.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/rdy3COwDJ8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/rdy3COwDJ8.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/rlmBhex75r.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/rlmBhex75r.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/rn7ZDhqfGn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/rn7ZDhqfGn.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/rse9BAjK8p.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/rse9BAjK8p.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/rxLnaPSdKY.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/rxLnaPSdKY.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/sDb6wxVAlp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/sDb6wxVAlp.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/sHN8Z0s7Zl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/sHN8Z0s7Zl.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/sIk16HKXOH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/sIk16HKXOH.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/sfXrv8XKuT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/sfXrv8XKuT.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/spAP90Xdxo.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/spAP90Xdxo.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/t2LfLuggKw.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/t2LfLuggKw.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/t6anM049gM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/t6anM049gM.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/t6b9ipJFco.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/t6b9ipJFco.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/t88runt2vt.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/t88runt2vt.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/t96N3ukmC2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/t96N3ukmC2.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/tFHSIUZTRU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/tFHSIUZTRU.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/tOBEeyrzR5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/tOBEeyrzR5.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/tqmxPtSV5e.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/tqmxPtSV5e.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/ttgDLEo0YY.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/ttgDLEo0YY.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/tyDsoFs45y.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/tyDsoFs45y.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/tyrqHRTjct.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/tyrqHRTjct.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/uMrfngv4qE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/uMrfngv4qE.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/ufp5xt5UlZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/ufp5xt5UlZ.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/ukDSDTeRKn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/ukDSDTeRKn.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/vAhi6T2iCs.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/vAhi6T2iCs.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/vDddl4MmlU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/vDddl4MmlU.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/vLwvkrUp8m.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/vLwvkrUp8m.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/vO7uWdob4g.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/vO7uWdob4g.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/vUjLCf2llh.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/vUjLCf2llh.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/vdOsQV2zZZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/vdOsQV2zZZ.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/vqoyQGzxwZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/vqoyQGzxwZ.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/vuum3mHSut.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/vuum3mHSut.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/wff7vOGYXM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/wff7vOGYXM.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/wkgn6vRUUp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/wkgn6vRUUp.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/wmDBp8f0Z2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/wmDBp8f0Z2.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/woqch6WNMH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/woqch6WNMH.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/x1AVtHbq4f.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/x1AVtHbq4f.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/xEOJNLq3je.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/xEOJNLq3je.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/xM6CnVshaE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/xM6CnVshaE.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/xOe1maF1HZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/xOe1maF1HZ.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/xVFVQAk3u3.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/xVFVQAk3u3.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/xWEhNnxjgn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/xWEhNnxjgn.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/xmhnIZPlm0.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/xmhnIZPlm0.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/xqXMSXBMl8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/xqXMSXBMl8.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/xqemv5BeQH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/xqemv5BeQH.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/y8Wf7aTXFb.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/y8Wf7aTXFb.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/yCWOaOd0DH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/yCWOaOd0DH.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/yI34mPjVtK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/yI34mPjVtK.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/yQu5xEnWkt.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/yQu5xEnWkt.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/yVvQYsdxaq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/yVvQYsdxaq.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/yaMxpb9T34.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/yaMxpb9T34.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/ygTzDOCr3r.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/ygTzDOCr3r.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/z4XWuGECC2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/z4XWuGECC2.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/z9nNYIgtFz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/z9nNYIgtFz.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/zFiwaVTd6p.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/zFiwaVTd6p.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/zI6QHiNniJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/zI6QHiNniJ.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/zVrQLGqXwe.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/zVrQLGqXwe.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/zYVWOnWkq4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/zYVWOnWkq4.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/zZ91YoJG9X.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/zZ91YoJG9X.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/zuxZ6Tg1Ha.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0-us/zuxZ6Tg1Ha.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/06T2RNzfTz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/06T2RNzfTz.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/07aN2OB1qj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/07aN2OB1qj.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/0JTPBSFvcC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/0JTPBSFvcC.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/0McUuUDCYj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/0McUuUDCYj.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/0T3L0HU9F5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/0T3L0HU9F5.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/0UrWNfXMbn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/0UrWNfXMbn.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/0We2g9ZRI1.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/0We2g9ZRI1.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/0crDi3Beji.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/0crDi3Beji.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/0dN19RtMpy.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/0dN19RtMpy.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/0nyPk4lS5G.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/0nyPk4lS5G.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/0sV5NP6Raj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/0sV5NP6Raj.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/0tlxl8JzK2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/0tlxl8JzK2.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/13VaDTQa1F.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/13VaDTQa1F.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/177ObAyjaW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/177ObAyjaW.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/1SIwphdqPw.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/1SIwphdqPw.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/1Wku3If0yF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/1Wku3If0yF.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/1fkLnqEKq5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/1fkLnqEKq5.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/1guqW4QDJq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/1guqW4QDJq.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/1zvL3jc30s.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/1zvL3jc30s.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/2BK4YBngu6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/2BK4YBngu6.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/2DcJnHQ1Wc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/2DcJnHQ1Wc.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/2EmGTjbMHL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/2EmGTjbMHL.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/2bgBJIgdGy.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/2bgBJIgdGy.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/3DKPTxt9nK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/3DKPTxt9nK.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/3K5GXTKPrP.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/3K5GXTKPrP.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/3QFEobjwmC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/3QFEobjwmC.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/3RDZKRFFEV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/3RDZKRFFEV.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/3s0rgujAIg.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/3s0rgujAIg.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/4Ax5wLUa4c.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/4Ax5wLUa4c.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/4EsYZXHdpa.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/4EsYZXHdpa.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/4MA1GGxtB2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/4MA1GGxtB2.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/4TA0dltn8Z.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/4TA0dltn8Z.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/4XwovA4lrF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/4XwovA4lrF.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/4iwufNM5Y6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/4iwufNM5Y6.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/4kQSb8Mpxb.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/4kQSb8Mpxb.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/4knxgNV22P.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/4knxgNV22P.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/4prVlpN79q.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/4prVlpN79q.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/54K50WUaKI.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/54K50WUaKI.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/5E9QwsWPit.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/5E9QwsWPit.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/5JUr6L7hij.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/5JUr6L7hij.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/5WMn1FI8mr.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/5WMn1FI8mr.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/5ejPdcXoEW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/5ejPdcXoEW.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/5h6yFrKLct.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/5h6yFrKLct.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/6ezYN7Hv0Z.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/6ezYN7Hv0Z.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/6l2wTrG0a6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/6l2wTrG0a6.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/6oA6qi8Lpj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/6oA6qi8Lpj.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/6pwxM7x9RG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/6pwxM7x9RG.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/70gJ0d6ueN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/70gJ0d6ueN.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/7NBB4SlixM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/7NBB4SlixM.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/7PDb7B0Y2N.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/7PDb7B0Y2N.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/7Pcw6lts4T.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/7Pcw6lts4T.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/7Xcf56RyAr.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/7Xcf56RyAr.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/7n3s1BSMBo.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/7n3s1BSMBo.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/7s32eactiP.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/7s32eactiP.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/81lR1cSmfJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/81lR1cSmfJ.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/8dnUV6Vg0Y.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/8dnUV6Vg0Y.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/8tTziwEdcI.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/8tTziwEdcI.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/8zROpBby2x.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/8zROpBby2x.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/90J1b35WV8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/90J1b35WV8.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/91wjEMiEX6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/91wjEMiEX6.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/9EdR9Yk7ca.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/9EdR9Yk7ca.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/9RZxZPNxIu.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/9RZxZPNxIu.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/9TOztQhkC4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/9TOztQhkC4.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/9jWBrTk7UB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/9jWBrTk7UB.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/9lMN6zFkKE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/9lMN6zFkKE.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/9s6IGHapL2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/9s6IGHapL2.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/A01FvWmA8l.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/A01FvWmA8l.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/A3USVyZwFP.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/A3USVyZwFP.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/AGJgFoElmB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/AGJgFoElmB.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/AKEOkMAk9E.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/AKEOkMAk9E.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/ALzR9tiyk8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/ALzR9tiyk8.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/AenL9akVZ7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/AenL9akVZ7.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/AutcanQMIS.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/AutcanQMIS.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/B19N6aMdz3.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/B19N6aMdz3.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/B1EGKnhW9e.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/B1EGKnhW9e.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/B1oQQ08HGH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/B1oQQ08HGH.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/B54wYu3oDA.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/B54wYu3oDA.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/BBTptRbtCv.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/BBTptRbtCv.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/BGGCRglxce.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/BGGCRglxce.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/BP8ChaEEsu.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/BP8ChaEEsu.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/BWk4SOKZaL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/BWk4SOKZaL.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/Bj2rdZWLh7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/Bj2rdZWLh7.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/C0qtj9qPDQ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/C0qtj9qPDQ.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/C9re7IuLWT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/C9re7IuLWT.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/CNHSzPEwGH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/CNHSzPEwGH.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/CP3AlJWqrp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/CP3AlJWqrp.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/CWYcYC8app.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/CWYcYC8app.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/Cb3SuEIO21.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/Cb3SuEIO21.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/CoZ4zNyWGC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/CoZ4zNyWGC.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/D1CTthvE4P.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/D1CTthvE4P.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/DFn3iuttpy.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/DFn3iuttpy.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/Dc9KyR2b2p.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/Dc9KyR2b2p.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/Dph3kXOCic.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/Dph3kXOCic.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/Dvpv1gBrUQ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/Dvpv1gBrUQ.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/E4qThSDcnD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/E4qThSDcnD.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/EC4qtMsceH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/EC4qtMsceH.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/ERsIqJPx5L.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/ERsIqJPx5L.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/EZXLjw31Dl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/EZXLjw31Dl.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/EsvI0BL049.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/EsvI0BL049.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/F2Pe3EMY8l.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/F2Pe3EMY8l.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/F5lnyEc8P7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/F5lnyEc8P7.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/FCqK7dSpWU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/FCqK7dSpWU.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/FNBWotecr1.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/FNBWotecr1.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/FV6eIbtnYG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/FV6eIbtnYG.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/FXHmkUJdzB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/FXHmkUJdzB.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/Fn00VgWg5Y.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/Fn00VgWg5Y.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/G2sYQwPkhJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/G2sYQwPkhJ.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/G5mzA5SBhk.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/G5mzA5SBhk.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/GDxA5zEvt0.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/GDxA5zEvt0.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/GXsAoZzuGz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/GXsAoZzuGz.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/GgA3nIlfrr.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/GgA3nIlfrr.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/Gl9QSM0HL9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/Gl9QSM0HL9.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/HWdd0atzlF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/HWdd0atzlF.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/HjAQJGqXYX.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/HjAQJGqXYX.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/HzjTooszyT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/HzjTooszyT.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/I3R2n3iDwp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/I3R2n3iDwp.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/I5jP7AdXUO.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/I5jP7AdXUO.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/I8b2lta2dV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/I8b2lta2dV.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/IFfft0YbVF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/IFfft0YbVF.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/IcZKeRjvKW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/IcZKeRjvKW.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/IiI7gJ520W.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/IiI7gJ520W.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/Ij3DQuVRk7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/Ij3DQuVRk7.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/IuHoP54Wlc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/IuHoP54Wlc.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/IwYqIz3EHD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/IwYqIz3EHD.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/J0cKBlje4u.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/J0cKBlje4u.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/J1zbYLAkpc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/J1zbYLAkpc.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/J6HXfDOVhX.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/J6HXfDOVhX.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/JH4VhArCNR.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/JH4VhArCNR.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/JXkrGa9mJm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/JXkrGa9mJm.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/JjTVAGnAQr.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/JjTVAGnAQr.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/JptCVz4qEd.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/JptCVz4qEd.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/JtusM5o9mV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/JtusM5o9mV.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/K8foSEhEd6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/K8foSEhEd6.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/KCFf7gu3Y4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/KCFf7gu3Y4.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/KRrQYpA7NN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/KRrQYpA7NN.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/KkW0XInSXe.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/KkW0XInSXe.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/KmUJvvIFQM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/KmUJvvIFQM.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/KwZarRNYrG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/KwZarRNYrG.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/L2R0Fdeoqj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/L2R0Fdeoqj.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/L6Togn7pnd.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/L6Togn7pnd.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/LGFBsMx1Ue.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/LGFBsMx1Ue.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/LKPjaqZzne.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/LKPjaqZzne.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/LTwPCkotqR.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/LTwPCkotqR.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/LlojbpWjs9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/LlojbpWjs9.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/LnGkF3PV4B.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/LnGkF3PV4B.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/Lw6juAfLhZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/Lw6juAfLhZ.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/M2wCQaSIkx.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/M2wCQaSIkx.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/M7p8sbE3VI.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/M7p8sbE3VI.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/MAaNEFkxNx.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/MAaNEFkxNx.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/MN57efcLju.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/MN57efcLju.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/MTonphGglM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/MTonphGglM.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/MWxYsdcQAm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/MWxYsdcQAm.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/MiEtLwCnzM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/MiEtLwCnzM.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/Mm2925bgtf.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/Mm2925bgtf.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/MnCQlmeEpx.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/MnCQlmeEpx.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/Mnn3wVQyPT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/Mnn3wVQyPT.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/MwWzEyFzMN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/MwWzEyFzMN.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/N3qbcpPajg.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/N3qbcpPajg.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/NBM2jrtjUt.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/NBM2jrtjUt.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/NDycAe2PMg.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/NDycAe2PMg.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/NVaQ8JUMmp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/NVaQ8JUMmp.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/NauzwofxwH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/NauzwofxwH.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/Ngx37kpASZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/Ngx37kpASZ.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/NhzifMsgk2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/NhzifMsgk2.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/NpGzSptAcC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/NpGzSptAcC.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/NpRS0S6JWC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/NpRS0S6JWC.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/NqADIATboI.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/NqADIATboI.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/NwHv5RB2rz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/NwHv5RB2rz.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/O953QNNUI0.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/O953QNNUI0.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/OCchs83O6Y.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/OCchs83O6Y.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/OGxNUCIKC2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/OGxNUCIKC2.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/OJyyKz5GVv.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/OJyyKz5GVv.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/OMOINSyhgb.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/OMOINSyhgb.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/ON96VWl2eE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/ON96VWl2eE.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/OYhonKADC9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/OYhonKADC9.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/OZwHXjKDnl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/OZwHXjKDnl.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/OdEuAfadOv.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/OdEuAfadOv.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/OxyGJylIwW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/OxyGJylIwW.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/PHurkwqv4Z.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/PHurkwqv4Z.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/PXNopPwCXl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/PXNopPwCXl.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/QArvYA1I5y.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/QArvYA1I5y.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/QKdvStkUZD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/QKdvStkUZD.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/QkWxbTjqEQ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/QkWxbTjqEQ.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/QoD4gdBKht.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/QoD4gdBKht.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/QxOTHR8Vr5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/QxOTHR8Vr5.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/R4BCKWzeKK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/R4BCKWzeKK.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/RBTWh9W2wN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/RBTWh9W2wN.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/RSdIxOjWTU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/RSdIxOjWTU.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/RVXzOJsITX.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/RVXzOJsITX.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/RVsXeoSc9F.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/RVsXeoSc9F.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/RWTGsJXzQz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/RWTGsJXzQz.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/RYuyMUd2gk.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/RYuyMUd2gk.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/RpX90PHiU0.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/RpX90PHiU0.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/RvpGNGwBDO.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/RvpGNGwBDO.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/RykGa318Dx.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/RykGa318Dx.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/S4670YUK50.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/S4670YUK50.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/S6gLS26ZJ4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/S6gLS26ZJ4.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/S9LbD4Pr4R.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/S9LbD4Pr4R.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/SAOrYUiv3f.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/SAOrYUiv3f.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/SCkYQvq0A9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/SCkYQvq0A9.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/SDPXeHAEsY.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/SDPXeHAEsY.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/SFVT3QJAYW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/SFVT3QJAYW.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/SNuFk4PnW2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/SNuFk4PnW2.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/ShzxZhno8O.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/ShzxZhno8O.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/SnDPKIXHDi.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/SnDPKIXHDi.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/SzCgZ3qNN5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/SzCgZ3qNN5.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/T520ZP6L8T.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/T520ZP6L8T.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/TJTFd5hAYj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/TJTFd5hAYj.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/TRuTR85WZK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/TRuTR85WZK.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/TgwFqiQRdp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/TgwFqiQRdp.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/Tj8JfMPQOP.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/Tj8JfMPQOP.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/TrSKsrbw64.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/TrSKsrbw64.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/TtsQu77nNc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/TtsQu77nNc.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/U5ugQslU2z.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/U5ugQslU2z.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/UP8fkuONg2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/UP8fkuONg2.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/UQd9WJKHHq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/UQd9WJKHHq.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/UdYGjLjpzk.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/UdYGjLjpzk.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/UeKNqkUYqr.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/UeKNqkUYqr.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/UfKa2OpfYT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/UfKa2OpfYT.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/UmSdXFQzs5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/UmSdXFQzs5.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/Uwk8g9mKl8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/Uwk8g9mKl8.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/V39a2Wfhny.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/V39a2Wfhny.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/V6Alb9zB67.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/V6Alb9zB67.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/VBCxRuQlyS.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/VBCxRuQlyS.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/VCeH9ZweWA.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/VCeH9ZweWA.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/VLXVn8J66H.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/VLXVn8J66H.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/VWVKSidnGZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/VWVKSidnGZ.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/VYon30GsHO.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/VYon30GsHO.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/Vdgc0ZvuWs.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/Vdgc0ZvuWs.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/VfmDAdXzKM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/VfmDAdXzKM.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/VhYMLsMLrL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/VhYMLsMLrL.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/VxqkIhG88M.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/VxqkIhG88M.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/W5bnoMpunF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/W5bnoMpunF.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/WOpGodfIa8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/WOpGodfIa8.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/WVz16ttXmN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/WVz16ttXmN.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/WZDWUF8ibK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/WZDWUF8ibK.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/X5FuWfVgX6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/X5FuWfVgX6.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/XLacQhFM5v.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/XLacQhFM5v.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/XOK5FCR5BV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/XOK5FCR5BV.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/XSCVXLUIBn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/XSCVXLUIBn.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/XpelL4dfYJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/XpelL4dfYJ.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/Y0nmeL8Mk6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/Y0nmeL8Mk6.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/Y3mvjkMqPV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/Y3mvjkMqPV.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/Y5EXqXazv8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/Y5EXqXazv8.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/YGlCkfra9u.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/YGlCkfra9u.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/YHnNk2wz6l.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/YHnNk2wz6l.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/YJDISUV0P9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/YJDISUV0P9.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/YNZk56sw8a.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/YNZk56sw8a.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/YSjosSoyxD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/YSjosSoyxD.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/YYPqiV1dMh.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/YYPqiV1dMh.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/YcFI3Qezx8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/YcFI3Qezx8.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/Z7wOsOEcI7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/Z7wOsOEcI7.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/ZEkMAMmFrT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/ZEkMAMmFrT.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/ZHV48dd3xb.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/ZHV48dd3xb.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/ZPpTfz3cuC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/ZPpTfz3cuC.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/ZSKbzDVpdh.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/ZSKbzDVpdh.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/ZV0dzO1N3D.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/ZV0dzO1N3D.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/ZfCQZQ3Yi4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/ZfCQZQ3Yi4.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/ZgH9SeepAW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/ZgH9SeepAW.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/Zzt021tkHA.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/Zzt021tkHA.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/a1DiihgGoN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/a1DiihgGoN.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/aAzECToODG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/aAzECToODG.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/acAvcgb9wR.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/acAvcgb9wR.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/al6GdI6HHq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/al6GdI6HHq.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/b6lOjv1QB9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/b6lOjv1QB9.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/bCdroQZubL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/bCdroQZubL.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/bGXLKzz8DB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/bGXLKzz8DB.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/bOJODCt4Nj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/bOJODCt4Nj.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/bZMWPiINDJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/bZMWPiINDJ.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/bcY4kDXEiL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/bcY4kDXEiL.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/c6ixLi9Yns.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/c6ixLi9Yns.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/cC1vOfH1YD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/cC1vOfH1YD.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/cKgcqJQFSi.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/cKgcqJQFSi.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/cM7YAi3zbW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/cM7YAi3zbW.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/cZb1hdO5AT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/cZb1hdO5AT.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/cjKn08z80L.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/cjKn08z80L.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/cnoFERqEX9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/cnoFERqEX9.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/dBQTDFizrM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/dBQTDFizrM.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/dBXjMyQ6v5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/dBXjMyQ6v5.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/dQcYTBwxmD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/dQcYTBwxmD.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/dVvABT62C9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/dVvABT62C9.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/e3r8e0DiFz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/e3r8e0DiFz.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/eFsp09gaZX.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/eFsp09gaZX.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/eKleS2KN9V.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/eKleS2KN9V.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/eSoalgVCBH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/eSoalgVCBH.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/eVz6pfc2Aq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/eVz6pfc2Aq.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/eYtwlKx3DL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/eYtwlKx3DL.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/ecmluorkUs.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/ecmluorkUs.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/encSaFhW3u.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/encSaFhW3u.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/fEVDUjY0o4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/fEVDUjY0o4.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/fNBZi3EAxz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/fNBZi3EAxz.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/fQ6iyzZG4E.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/fQ6iyzZG4E.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/fkSI356192.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/fkSI356192.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/fqaD1J6KEH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/fqaD1J6KEH.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/fsCqVRe2XV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/fsCqVRe2XV.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/g32LIqIkv7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/g32LIqIkv7.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/g7NcHJ0Dqm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/g7NcHJ0Dqm.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/gKDRuR0huT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/gKDRuR0huT.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/gjl4ArLhJm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/gjl4ArLhJm.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/gvU8LsfGOx.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/gvU8LsfGOx.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/h9Y4PiPY6w.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/h9Y4PiPY6w.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/hchuG3s1rY.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/hchuG3s1rY.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/hnhVAIsmxU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/hnhVAIsmxU.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/hqtR9072e5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/hqtR9072e5.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/i53vKZdcnE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/i53vKZdcnE.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/iBn3UOpKdu.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/iBn3UOpKdu.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/iI6pw0QLBV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/iI6pw0QLBV.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/iQAGO67miB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/iQAGO67miB.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/iTg6zX0H2i.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/iTg6zX0H2i.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/iq57t3NYGm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/iq57t3NYGm.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/ixUQwlLoQl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/ixUQwlLoQl.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/ixp5a4MCzH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/ixp5a4MCzH.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/izrpe1H39g.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/izrpe1H39g.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/j0gOb12WG7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/j0gOb12WG7.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/j41I8z5Dbm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/j41I8z5Dbm.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/j9KVlh9Elu.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/j9KVlh9Elu.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/jEPN6e30lK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/jEPN6e30lK.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/jHoO30hDWC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/jHoO30hDWC.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/jOEODojhaI.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/jOEODojhaI.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/jSdYYlxIPu.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/jSdYYlxIPu.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/kDrpkD1xK6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/kDrpkD1xK6.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/kODlOvWLVJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/kODlOvWLVJ.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/koWMEughuG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/koWMEughuG.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/kpmo31UbcA.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/kpmo31UbcA.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/kuu79cE7XV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/kuu79cE7XV.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/ky7lfFDW6q.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/ky7lfFDW6q.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/kyEHvPp7Gk.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/kyEHvPp7Gk.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/lOk975L1YB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/lOk975L1YB.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/lW11AhH3pd.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/lW11AhH3pd.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/llHMuoBQb8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/llHMuoBQb8.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/m8AHxnkobT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/m8AHxnkobT.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/mBub665Sw1.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/mBub665Sw1.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/mKU2FtqWwc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/mKU2FtqWwc.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/mN75YcjhNl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/mN75YcjhNl.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/mhhBA6GJJy.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/mhhBA6GJJy.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/nE3Qa1apaH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/nE3Qa1apaH.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/nT8J5haK6F.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/nT8J5haK6F.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/nUWnom5eaz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/nUWnom5eaz.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/nY4f0rBQfZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/nY4f0rBQfZ.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/nenm6c9K9H.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/nenm6c9K9H.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/nrmmmwvAB3.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/nrmmmwvAB3.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/nzdiNgzpBk.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/nzdiNgzpBk.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/oEmtybut45.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/oEmtybut45.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/oV4NuQJ94t.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/oV4NuQJ94t.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/oklahTMTmf.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/oklahTMTmf.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/ors0bDh2bc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/ors0bDh2bc.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/pc50J7VwEQ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/pc50J7VwEQ.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/pqukhkAth1.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/pqukhkAth1.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/q5p595DJ6Q.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/q5p595DJ6Q.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/qE0fojpqnw.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/qE0fojpqnw.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/qGpRbiQ2ae.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/qGpRbiQ2ae.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/qoLqfVeYjg.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/qoLqfVeYjg.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/qxfXnYfFUG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/qxfXnYfFUG.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/r8w1v3Z6lL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/r8w1v3Z6lL.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/rMw8A9V28h.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/rMw8A9V28h.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/rZI5VmbmH8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/rZI5VmbmH8.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/rdy3COwDJ8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/rdy3COwDJ8.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/rlmBhex75r.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/rlmBhex75r.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/rn7ZDhqfGn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/rn7ZDhqfGn.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/rse9BAjK8p.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/rse9BAjK8p.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/rxLnaPSdKY.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/rxLnaPSdKY.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/sDb6wxVAlp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/sDb6wxVAlp.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/sHN8Z0s7Zl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/sHN8Z0s7Zl.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/sIk16HKXOH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/sIk16HKXOH.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/sfXrv8XKuT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/sfXrv8XKuT.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/spAP90Xdxo.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/spAP90Xdxo.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/t2LfLuggKw.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/t2LfLuggKw.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/t6anM049gM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/t6anM049gM.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/t6b9ipJFco.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/t6b9ipJFco.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/t88runt2vt.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/t88runt2vt.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/t96N3ukmC2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/t96N3ukmC2.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/tFHSIUZTRU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/tFHSIUZTRU.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/tOBEeyrzR5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/tOBEeyrzR5.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/tqmxPtSV5e.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/tqmxPtSV5e.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/ttgDLEo0YY.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/ttgDLEo0YY.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/tyDsoFs45y.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/tyDsoFs45y.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/tyrqHRTjct.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/tyrqHRTjct.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/uMrfngv4qE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/uMrfngv4qE.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/ufp5xt5UlZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/ufp5xt5UlZ.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/ukDSDTeRKn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/ukDSDTeRKn.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/vAhi6T2iCs.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/vAhi6T2iCs.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/vDddl4MmlU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/vDddl4MmlU.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/vLwvkrUp8m.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/vLwvkrUp8m.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/vO7uWdob4g.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/vO7uWdob4g.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/vUjLCf2llh.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/vUjLCf2llh.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/vdOsQV2zZZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/vdOsQV2zZZ.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/vqoyQGzxwZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/vqoyQGzxwZ.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/vuum3mHSut.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/vuum3mHSut.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/wff7vOGYXM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/wff7vOGYXM.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/wkgn6vRUUp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/wkgn6vRUUp.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/wmDBp8f0Z2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/wmDBp8f0Z2.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/woqch6WNMH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/woqch6WNMH.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/x1AVtHbq4f.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/x1AVtHbq4f.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/xEOJNLq3je.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/xEOJNLq3je.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/xM6CnVshaE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/xM6CnVshaE.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/xOe1maF1HZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/xOe1maF1HZ.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/xVFVQAk3u3.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/xVFVQAk3u3.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/xWEhNnxjgn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/xWEhNnxjgn.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/xmhnIZPlm0.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/xmhnIZPlm0.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/xqXMSXBMl8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/xqXMSXBMl8.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/xqemv5BeQH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/xqemv5BeQH.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/y8Wf7aTXFb.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/y8Wf7aTXFb.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/yCWOaOd0DH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/yCWOaOd0DH.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/yI34mPjVtK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/yI34mPjVtK.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/yQu5xEnWkt.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/yQu5xEnWkt.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/yVvQYsdxaq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/yVvQYsdxaq.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/yaMxpb9T34.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/yaMxpb9T34.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/ygTzDOCr3r.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/ygTzDOCr3r.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/z4XWuGECC2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/z4XWuGECC2.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/z9nNYIgtFz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/z9nNYIgtFz.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/zFiwaVTd6p.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/zFiwaVTd6p.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/zI6QHiNniJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/zI6QHiNniJ.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/zVrQLGqXwe.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/zVrQLGqXwe.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/zYVWOnWkq4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/zYVWOnWkq4.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/zZ91YoJG9X.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/zZ91YoJG9X.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/zuxZ6Tg1Ha.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v6.0/zuxZ6Tg1Ha.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/06T2RNzfTz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/06T2RNzfTz.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/07aN2OB1qj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/07aN2OB1qj.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/0JTPBSFvcC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/0JTPBSFvcC.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/0McUuUDCYj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/0McUuUDCYj.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/0T3L0HU9F5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/0T3L0HU9F5.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/0UrWNfXMbn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/0UrWNfXMbn.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/0We2g9ZRI1.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/0We2g9ZRI1.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/0crDi3Beji.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/0crDi3Beji.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/0dN19RtMpy.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/0dN19RtMpy.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/0nyPk4lS5G.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/0nyPk4lS5G.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/0sV5NP6Raj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/0sV5NP6Raj.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/0tlxl8JzK2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/0tlxl8JzK2.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/13VaDTQa1F.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/13VaDTQa1F.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/177ObAyjaW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/177ObAyjaW.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/1SIwphdqPw.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/1SIwphdqPw.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/1Wku3If0yF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/1Wku3If0yF.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/1fkLnqEKq5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/1fkLnqEKq5.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/1guqW4QDJq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/1guqW4QDJq.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/1zvL3jc30s.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/1zvL3jc30s.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/2BK4YBngu6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/2BK4YBngu6.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/2DcJnHQ1Wc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/2DcJnHQ1Wc.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/2EmGTjbMHL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/2EmGTjbMHL.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/2bgBJIgdGy.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/2bgBJIgdGy.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/3DKPTxt9nK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/3DKPTxt9nK.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/3K5GXTKPrP.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/3K5GXTKPrP.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/3QFEobjwmC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/3QFEobjwmC.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/3RDZKRFFEV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/3RDZKRFFEV.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/3s0rgujAIg.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/3s0rgujAIg.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/4Ax5wLUa4c.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/4Ax5wLUa4c.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/4EsYZXHdpa.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/4EsYZXHdpa.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/4MA1GGxtB2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/4MA1GGxtB2.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/4TA0dltn8Z.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/4TA0dltn8Z.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/4XwovA4lrF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/4XwovA4lrF.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/4iwufNM5Y6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/4iwufNM5Y6.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/4kQSb8Mpxb.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/4kQSb8Mpxb.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/4knxgNV22P.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/4knxgNV22P.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/4prVlpN79q.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/4prVlpN79q.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/54K50WUaKI.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/54K50WUaKI.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/5E9QwsWPit.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/5E9QwsWPit.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/5JUr6L7hij.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/5JUr6L7hij.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/5WMn1FI8mr.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/5WMn1FI8mr.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/5ejPdcXoEW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/5ejPdcXoEW.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/5h6yFrKLct.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/5h6yFrKLct.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/6ezYN7Hv0Z.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/6ezYN7Hv0Z.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/6l2wTrG0a6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/6l2wTrG0a6.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/6oA6qi8Lpj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/6oA6qi8Lpj.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/6pwxM7x9RG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/6pwxM7x9RG.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/70gJ0d6ueN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/70gJ0d6ueN.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/7NBB4SlixM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/7NBB4SlixM.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/7PDb7B0Y2N.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/7PDb7B0Y2N.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/7Pcw6lts4T.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/7Pcw6lts4T.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/7Xcf56RyAr.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/7Xcf56RyAr.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/7n3s1BSMBo.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/7n3s1BSMBo.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/7s32eactiP.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/7s32eactiP.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/81lR1cSmfJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/81lR1cSmfJ.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/8dnUV6Vg0Y.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/8dnUV6Vg0Y.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/8tTziwEdcI.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/8tTziwEdcI.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/8zROpBby2x.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/8zROpBby2x.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/90J1b35WV8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/90J1b35WV8.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/91wjEMiEX6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/91wjEMiEX6.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/9EdR9Yk7ca.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/9EdR9Yk7ca.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/9RZxZPNxIu.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/9RZxZPNxIu.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/9TOztQhkC4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/9TOztQhkC4.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/9jWBrTk7UB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/9jWBrTk7UB.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/9lMN6zFkKE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/9lMN6zFkKE.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/9s6IGHapL2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/9s6IGHapL2.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/A01FvWmA8l.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/A01FvWmA8l.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/A3USVyZwFP.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/A3USVyZwFP.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/AGJgFoElmB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/AGJgFoElmB.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/AKEOkMAk9E.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/AKEOkMAk9E.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/ALzR9tiyk8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/ALzR9tiyk8.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/AenL9akVZ7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/AenL9akVZ7.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/AutcanQMIS.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/AutcanQMIS.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/B19N6aMdz3.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/B19N6aMdz3.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/B1EGKnhW9e.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/B1EGKnhW9e.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/B1oQQ08HGH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/B1oQQ08HGH.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/B54wYu3oDA.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/B54wYu3oDA.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/BBTptRbtCv.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/BBTptRbtCv.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/BGGCRglxce.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/BGGCRglxce.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/BP8ChaEEsu.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/BP8ChaEEsu.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/BWk4SOKZaL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/BWk4SOKZaL.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/Bj2rdZWLh7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/Bj2rdZWLh7.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/C0qtj9qPDQ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/C0qtj9qPDQ.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/C9re7IuLWT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/C9re7IuLWT.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/CNHSzPEwGH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/CNHSzPEwGH.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/CP3AlJWqrp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/CP3AlJWqrp.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/CWYcYC8app.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/CWYcYC8app.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/Cb3SuEIO21.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/Cb3SuEIO21.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/CoZ4zNyWGC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/CoZ4zNyWGC.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/D1CTthvE4P.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/D1CTthvE4P.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/DFn3iuttpy.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/DFn3iuttpy.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/Dc9KyR2b2p.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/Dc9KyR2b2p.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/Dph3kXOCic.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/Dph3kXOCic.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/Dvpv1gBrUQ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/Dvpv1gBrUQ.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/E4qThSDcnD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/E4qThSDcnD.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/EC4qtMsceH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/EC4qtMsceH.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/ERsIqJPx5L.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/ERsIqJPx5L.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/EZXLjw31Dl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/EZXLjw31Dl.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/EsvI0BL049.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/EsvI0BL049.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/F2Pe3EMY8l.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/F2Pe3EMY8l.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/F5lnyEc8P7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/F5lnyEc8P7.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/FCqK7dSpWU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/FCqK7dSpWU.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/FNBWotecr1.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/FNBWotecr1.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/FV6eIbtnYG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/FV6eIbtnYG.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/FXHmkUJdzB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/FXHmkUJdzB.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/Fn00VgWg5Y.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/Fn00VgWg5Y.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/G2sYQwPkhJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/G2sYQwPkhJ.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/G5mzA5SBhk.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/G5mzA5SBhk.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/GDxA5zEvt0.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/GDxA5zEvt0.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/GXsAoZzuGz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/GXsAoZzuGz.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/GgA3nIlfrr.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/GgA3nIlfrr.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/Gl9QSM0HL9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/Gl9QSM0HL9.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/HWdd0atzlF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/HWdd0atzlF.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/HjAQJGqXYX.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/HjAQJGqXYX.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/HzjTooszyT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/HzjTooszyT.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/I3R2n3iDwp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/I3R2n3iDwp.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/I5jP7AdXUO.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/I5jP7AdXUO.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/I8b2lta2dV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/I8b2lta2dV.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/IFfft0YbVF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/IFfft0YbVF.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/IcZKeRjvKW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/IcZKeRjvKW.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/IiI7gJ520W.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/IiI7gJ520W.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/Ij3DQuVRk7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/Ij3DQuVRk7.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/IuHoP54Wlc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/IuHoP54Wlc.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/IwYqIz3EHD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/IwYqIz3EHD.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/J0cKBlje4u.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/J0cKBlje4u.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/J1zbYLAkpc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/J1zbYLAkpc.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/J6HXfDOVhX.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/J6HXfDOVhX.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/JH4VhArCNR.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/JH4VhArCNR.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/JXkrGa9mJm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/JXkrGa9mJm.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/JjTVAGnAQr.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/JjTVAGnAQr.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/JptCVz4qEd.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/JptCVz4qEd.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/JtusM5o9mV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/JtusM5o9mV.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/K8foSEhEd6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/K8foSEhEd6.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/KCFf7gu3Y4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/KCFf7gu3Y4.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/KRrQYpA7NN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/KRrQYpA7NN.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/KkW0XInSXe.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/KkW0XInSXe.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/KmUJvvIFQM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/KmUJvvIFQM.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/KwZarRNYrG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/KwZarRNYrG.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/L2R0Fdeoqj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/L2R0Fdeoqj.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/L6Togn7pnd.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/L6Togn7pnd.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/LGFBsMx1Ue.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/LGFBsMx1Ue.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/LKPjaqZzne.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/LKPjaqZzne.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/LTwPCkotqR.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/LTwPCkotqR.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/LlojbpWjs9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/LlojbpWjs9.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/LnGkF3PV4B.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/LnGkF3PV4B.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/Lw6juAfLhZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/Lw6juAfLhZ.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/M2wCQaSIkx.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/M2wCQaSIkx.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/M7p8sbE3VI.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/M7p8sbE3VI.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/MAaNEFkxNx.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/MAaNEFkxNx.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/MN57efcLju.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/MN57efcLju.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/MTonphGglM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/MTonphGglM.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/MWxYsdcQAm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/MWxYsdcQAm.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/MiEtLwCnzM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/MiEtLwCnzM.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/Mm2925bgtf.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/Mm2925bgtf.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/MnCQlmeEpx.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/MnCQlmeEpx.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/Mnn3wVQyPT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/Mnn3wVQyPT.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/MwWzEyFzMN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/MwWzEyFzMN.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/N3qbcpPajg.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/N3qbcpPajg.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/NBM2jrtjUt.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/NBM2jrtjUt.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/NDycAe2PMg.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/NDycAe2PMg.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/NVaQ8JUMmp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/NVaQ8JUMmp.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/NauzwofxwH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/NauzwofxwH.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/Ngx37kpASZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/Ngx37kpASZ.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/NhzifMsgk2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/NhzifMsgk2.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/NpGzSptAcC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/NpGzSptAcC.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/NpRS0S6JWC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/NpRS0S6JWC.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/NqADIATboI.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/NqADIATboI.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/NwHv5RB2rz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/NwHv5RB2rz.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/O953QNNUI0.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/O953QNNUI0.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/OCchs83O6Y.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/OCchs83O6Y.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/OGxNUCIKC2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/OGxNUCIKC2.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/OJyyKz5GVv.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/OJyyKz5GVv.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/OMOINSyhgb.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/OMOINSyhgb.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/ON96VWl2eE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/ON96VWl2eE.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/OYhonKADC9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/OYhonKADC9.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/OZwHXjKDnl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/OZwHXjKDnl.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/OdEuAfadOv.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/OdEuAfadOv.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/OxyGJylIwW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/OxyGJylIwW.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/PHurkwqv4Z.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/PHurkwqv4Z.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/PXNopPwCXl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/PXNopPwCXl.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/QArvYA1I5y.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/QArvYA1I5y.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/QKdvStkUZD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/QKdvStkUZD.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/QkWxbTjqEQ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/QkWxbTjqEQ.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/QoD4gdBKht.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/QoD4gdBKht.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/QxOTHR8Vr5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/QxOTHR8Vr5.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/R4BCKWzeKK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/R4BCKWzeKK.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/RBTWh9W2wN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/RBTWh9W2wN.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/RSdIxOjWTU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/RSdIxOjWTU.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/RVXzOJsITX.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/RVXzOJsITX.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/RVsXeoSc9F.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/RVsXeoSc9F.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/RWTGsJXzQz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/RWTGsJXzQz.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/RYuyMUd2gk.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/RYuyMUd2gk.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/RpX90PHiU0.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/RpX90PHiU0.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/RvpGNGwBDO.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/RvpGNGwBDO.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/RykGa318Dx.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/RykGa318Dx.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/S4670YUK50.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/S4670YUK50.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/S6gLS26ZJ4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/S6gLS26ZJ4.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/S9LbD4Pr4R.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/S9LbD4Pr4R.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/SAOrYUiv3f.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/SAOrYUiv3f.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/SCkYQvq0A9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/SCkYQvq0A9.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/SDPXeHAEsY.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/SDPXeHAEsY.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/SFVT3QJAYW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/SFVT3QJAYW.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/SNuFk4PnW2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/SNuFk4PnW2.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/ShzxZhno8O.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/ShzxZhno8O.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/SnDPKIXHDi.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/SnDPKIXHDi.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/SzCgZ3qNN5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/SzCgZ3qNN5.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/T520ZP6L8T.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/T520ZP6L8T.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/TJTFd5hAYj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/TJTFd5hAYj.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/TRuTR85WZK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/TRuTR85WZK.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/TgwFqiQRdp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/TgwFqiQRdp.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/Tj8JfMPQOP.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/Tj8JfMPQOP.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/TrSKsrbw64.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/TrSKsrbw64.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/TtsQu77nNc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/TtsQu77nNc.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/U5ugQslU2z.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/U5ugQslU2z.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/UP8fkuONg2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/UP8fkuONg2.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/UQd9WJKHHq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/UQd9WJKHHq.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/UdYGjLjpzk.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/UdYGjLjpzk.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/UeKNqkUYqr.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/UeKNqkUYqr.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/UfKa2OpfYT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/UfKa2OpfYT.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/UmSdXFQzs5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/UmSdXFQzs5.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/Uwk8g9mKl8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/Uwk8g9mKl8.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/V39a2Wfhny.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/V39a2Wfhny.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/V6Alb9zB67.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/V6Alb9zB67.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/VBCxRuQlyS.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/VBCxRuQlyS.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/VCeH9ZweWA.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/VCeH9ZweWA.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/VLXVn8J66H.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/VLXVn8J66H.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/VWVKSidnGZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/VWVKSidnGZ.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/VYon30GsHO.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/VYon30GsHO.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/Vdgc0ZvuWs.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/Vdgc0ZvuWs.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/VfmDAdXzKM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/VfmDAdXzKM.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/VhYMLsMLrL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/VhYMLsMLrL.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/VxqkIhG88M.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/VxqkIhG88M.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/W5bnoMpunF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/W5bnoMpunF.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/WOpGodfIa8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/WOpGodfIa8.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/WVz16ttXmN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/WVz16ttXmN.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/WZDWUF8ibK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/WZDWUF8ibK.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/X5FuWfVgX6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/X5FuWfVgX6.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/XLacQhFM5v.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/XLacQhFM5v.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/XOK5FCR5BV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/XOK5FCR5BV.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/XSCVXLUIBn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/XSCVXLUIBn.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/XpelL4dfYJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/XpelL4dfYJ.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/Y0nmeL8Mk6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/Y0nmeL8Mk6.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/Y3mvjkMqPV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/Y3mvjkMqPV.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/Y5EXqXazv8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/Y5EXqXazv8.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/YGlCkfra9u.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/YGlCkfra9u.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/YHnNk2wz6l.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/YHnNk2wz6l.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/YJDISUV0P9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/YJDISUV0P9.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/YNZk56sw8a.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/YNZk56sw8a.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/YSjosSoyxD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/YSjosSoyxD.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/YYPqiV1dMh.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/YYPqiV1dMh.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/YcFI3Qezx8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/YcFI3Qezx8.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/Z7wOsOEcI7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/Z7wOsOEcI7.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/ZEkMAMmFrT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/ZEkMAMmFrT.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/ZHV48dd3xb.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/ZHV48dd3xb.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/ZPpTfz3cuC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/ZPpTfz3cuC.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/ZSKbzDVpdh.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/ZSKbzDVpdh.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/ZV0dzO1N3D.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/ZV0dzO1N3D.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/ZfCQZQ3Yi4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/ZfCQZQ3Yi4.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/ZgH9SeepAW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/ZgH9SeepAW.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/Zzt021tkHA.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/Zzt021tkHA.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/a1DiihgGoN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/a1DiihgGoN.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/aAzECToODG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/aAzECToODG.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/acAvcgb9wR.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/acAvcgb9wR.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/al6GdI6HHq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/al6GdI6HHq.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/b6lOjv1QB9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/b6lOjv1QB9.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/bCdroQZubL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/bCdroQZubL.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/bGXLKzz8DB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/bGXLKzz8DB.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/bOJODCt4Nj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/bOJODCt4Nj.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/bZMWPiINDJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/bZMWPiINDJ.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/bcY4kDXEiL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/bcY4kDXEiL.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/c6ixLi9Yns.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/c6ixLi9Yns.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/cC1vOfH1YD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/cC1vOfH1YD.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/cKgcqJQFSi.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/cKgcqJQFSi.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/cM7YAi3zbW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/cM7YAi3zbW.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/cZb1hdO5AT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/cZb1hdO5AT.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/cjKn08z80L.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/cjKn08z80L.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/cnoFERqEX9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/cnoFERqEX9.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/dBQTDFizrM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/dBQTDFizrM.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/dBXjMyQ6v5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/dBXjMyQ6v5.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/dQcYTBwxmD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/dQcYTBwxmD.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/dVvABT62C9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/dVvABT62C9.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/e3r8e0DiFz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/e3r8e0DiFz.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/eFsp09gaZX.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/eFsp09gaZX.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/eKleS2KN9V.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/eKleS2KN9V.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/eSoalgVCBH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/eSoalgVCBH.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/eVz6pfc2Aq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/eVz6pfc2Aq.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/eYtwlKx3DL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/eYtwlKx3DL.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/ecmluorkUs.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/ecmluorkUs.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/encSaFhW3u.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/encSaFhW3u.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/fEVDUjY0o4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/fEVDUjY0o4.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/fNBZi3EAxz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/fNBZi3EAxz.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/fQ6iyzZG4E.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/fQ6iyzZG4E.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/fkSI356192.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/fkSI356192.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/fqaD1J6KEH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/fqaD1J6KEH.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/fsCqVRe2XV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/fsCqVRe2XV.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/g32LIqIkv7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/g32LIqIkv7.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/g7NcHJ0Dqm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/g7NcHJ0Dqm.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/gKDRuR0huT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/gKDRuR0huT.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/gjl4ArLhJm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/gjl4ArLhJm.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/gvU8LsfGOx.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/gvU8LsfGOx.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/h9Y4PiPY6w.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/h9Y4PiPY6w.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/hchuG3s1rY.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/hchuG3s1rY.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/hnhVAIsmxU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/hnhVAIsmxU.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/hqtR9072e5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/hqtR9072e5.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/i53vKZdcnE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/i53vKZdcnE.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/iBn3UOpKdu.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/iBn3UOpKdu.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/iI6pw0QLBV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/iI6pw0QLBV.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/iQAGO67miB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/iQAGO67miB.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/iTg6zX0H2i.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/iTg6zX0H2i.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/iq57t3NYGm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/iq57t3NYGm.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/ixUQwlLoQl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/ixUQwlLoQl.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/ixp5a4MCzH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/ixp5a4MCzH.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/izrpe1H39g.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/izrpe1H39g.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/j0gOb12WG7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/j0gOb12WG7.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/j41I8z5Dbm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/j41I8z5Dbm.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/j9KVlh9Elu.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/j9KVlh9Elu.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/jEPN6e30lK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/jEPN6e30lK.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/jHoO30hDWC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/jHoO30hDWC.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/jOEODojhaI.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/jOEODojhaI.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/jSdYYlxIPu.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/jSdYYlxIPu.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/kDrpkD1xK6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/kDrpkD1xK6.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/kODlOvWLVJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/kODlOvWLVJ.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/koWMEughuG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/koWMEughuG.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/kpmo31UbcA.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/kpmo31UbcA.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/kuu79cE7XV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/kuu79cE7XV.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/ky7lfFDW6q.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/ky7lfFDW6q.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/kyEHvPp7Gk.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/kyEHvPp7Gk.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/lOk975L1YB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/lOk975L1YB.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/lW11AhH3pd.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/lW11AhH3pd.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/llHMuoBQb8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/llHMuoBQb8.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/m8AHxnkobT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/m8AHxnkobT.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/mBub665Sw1.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/mBub665Sw1.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/mKU2FtqWwc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/mKU2FtqWwc.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/mN75YcjhNl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/mN75YcjhNl.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/mhhBA6GJJy.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/mhhBA6GJJy.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/nE3Qa1apaH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/nE3Qa1apaH.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/nT8J5haK6F.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/nT8J5haK6F.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/nUWnom5eaz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/nUWnom5eaz.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/nY4f0rBQfZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/nY4f0rBQfZ.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/nenm6c9K9H.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/nenm6c9K9H.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/nrmmmwvAB3.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/nrmmmwvAB3.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/nzdiNgzpBk.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/nzdiNgzpBk.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/oEmtybut45.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/oEmtybut45.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/oV4NuQJ94t.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/oV4NuQJ94t.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/oklahTMTmf.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/oklahTMTmf.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/ors0bDh2bc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/ors0bDh2bc.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/pc50J7VwEQ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/pc50J7VwEQ.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/pqukhkAth1.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/pqukhkAth1.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/q5p595DJ6Q.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/q5p595DJ6Q.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/qE0fojpqnw.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/qE0fojpqnw.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/qGpRbiQ2ae.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/qGpRbiQ2ae.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/qoLqfVeYjg.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/qoLqfVeYjg.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/qxfXnYfFUG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/qxfXnYfFUG.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/r8w1v3Z6lL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/r8w1v3Z6lL.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/rMw8A9V28h.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/rMw8A9V28h.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/rZI5VmbmH8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/rZI5VmbmH8.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/rdy3COwDJ8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/rdy3COwDJ8.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/rlmBhex75r.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/rlmBhex75r.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/rn7ZDhqfGn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/rn7ZDhqfGn.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/rse9BAjK8p.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/rse9BAjK8p.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/rxLnaPSdKY.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/rxLnaPSdKY.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/sDb6wxVAlp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/sDb6wxVAlp.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/sHN8Z0s7Zl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/sHN8Z0s7Zl.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/sIk16HKXOH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/sIk16HKXOH.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/sfXrv8XKuT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/sfXrv8XKuT.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/spAP90Xdxo.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/spAP90Xdxo.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/t2LfLuggKw.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/t2LfLuggKw.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/t6anM049gM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/t6anM049gM.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/t6b9ipJFco.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/t6b9ipJFco.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/t88runt2vt.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/t88runt2vt.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/t96N3ukmC2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/t96N3ukmC2.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/tFHSIUZTRU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/tFHSIUZTRU.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/tOBEeyrzR5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/tOBEeyrzR5.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/tqmxPtSV5e.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/tqmxPtSV5e.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/ttgDLEo0YY.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/ttgDLEo0YY.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/tyDsoFs45y.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/tyDsoFs45y.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/tyrqHRTjct.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/tyrqHRTjct.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/uMrfngv4qE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/uMrfngv4qE.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/ufp5xt5UlZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/ufp5xt5UlZ.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/ukDSDTeRKn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/ukDSDTeRKn.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/vAhi6T2iCs.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/vAhi6T2iCs.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/vDddl4MmlU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/vDddl4MmlU.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/vLwvkrUp8m.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/vLwvkrUp8m.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/vO7uWdob4g.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/vO7uWdob4g.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/vUjLCf2llh.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/vUjLCf2llh.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/vdOsQV2zZZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/vdOsQV2zZZ.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/vqoyQGzxwZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/vqoyQGzxwZ.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/vuum3mHSut.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/vuum3mHSut.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/wff7vOGYXM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/wff7vOGYXM.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/wkgn6vRUUp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/wkgn6vRUUp.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/wmDBp8f0Z2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/wmDBp8f0Z2.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/woqch6WNMH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/woqch6WNMH.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/x1AVtHbq4f.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/x1AVtHbq4f.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/xEOJNLq3je.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/xEOJNLq3je.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/xM6CnVshaE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/xM6CnVshaE.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/xOe1maF1HZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/xOe1maF1HZ.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/xVFVQAk3u3.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/xVFVQAk3u3.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/xWEhNnxjgn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/xWEhNnxjgn.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/xmhnIZPlm0.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/xmhnIZPlm0.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/xqXMSXBMl8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/xqXMSXBMl8.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/xqemv5BeQH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/xqemv5BeQH.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/y8Wf7aTXFb.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/y8Wf7aTXFb.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/yCWOaOd0DH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/yCWOaOd0DH.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/yI34mPjVtK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/yI34mPjVtK.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/yQu5xEnWkt.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/yQu5xEnWkt.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/yVvQYsdxaq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/yVvQYsdxaq.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/yaMxpb9T34.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/yaMxpb9T34.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/ygTzDOCr3r.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/ygTzDOCr3r.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/z4XWuGECC2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/z4XWuGECC2.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/z9nNYIgtFz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/z9nNYIgtFz.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/zFiwaVTd6p.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/zFiwaVTd6p.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/zI6QHiNniJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/zI6QHiNniJ.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/zVrQLGqXwe.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/zVrQLGqXwe.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/zYVWOnWkq4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/zYVWOnWkq4.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/zZ91YoJG9X.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/zZ91YoJG9X.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/zuxZ6Tg1Ha.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-fr/zuxZ6Tg1Ha.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/06T2RNzfTz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/06T2RNzfTz.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/07aN2OB1qj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/07aN2OB1qj.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/0JTPBSFvcC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/0JTPBSFvcC.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/0McUuUDCYj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/0McUuUDCYj.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/0T3L0HU9F5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/0T3L0HU9F5.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/0UrWNfXMbn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/0UrWNfXMbn.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/0We2g9ZRI1.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/0We2g9ZRI1.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/0crDi3Beji.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/0crDi3Beji.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/0dN19RtMpy.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/0dN19RtMpy.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/0nyPk4lS5G.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/0nyPk4lS5G.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/0sV5NP6Raj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/0sV5NP6Raj.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/0tlxl8JzK2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/0tlxl8JzK2.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/13VaDTQa1F.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/13VaDTQa1F.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/177ObAyjaW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/177ObAyjaW.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/1SIwphdqPw.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/1SIwphdqPw.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/1Wku3If0yF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/1Wku3If0yF.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/1fkLnqEKq5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/1fkLnqEKq5.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/1guqW4QDJq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/1guqW4QDJq.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/1zvL3jc30s.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/1zvL3jc30s.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/2BK4YBngu6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/2BK4YBngu6.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/2DcJnHQ1Wc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/2DcJnHQ1Wc.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/2EmGTjbMHL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/2EmGTjbMHL.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/2bgBJIgdGy.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/2bgBJIgdGy.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/3DKPTxt9nK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/3DKPTxt9nK.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/3K5GXTKPrP.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/3K5GXTKPrP.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/3QFEobjwmC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/3QFEobjwmC.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/3RDZKRFFEV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/3RDZKRFFEV.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/3s0rgujAIg.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/3s0rgujAIg.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/4Ax5wLUa4c.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/4Ax5wLUa4c.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/4EsYZXHdpa.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/4EsYZXHdpa.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/4MA1GGxtB2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/4MA1GGxtB2.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/4TA0dltn8Z.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/4TA0dltn8Z.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/4XwovA4lrF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/4XwovA4lrF.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/4iwufNM5Y6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/4iwufNM5Y6.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/4kQSb8Mpxb.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/4kQSb8Mpxb.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/4knxgNV22P.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/4knxgNV22P.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/4prVlpN79q.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/4prVlpN79q.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/54K50WUaKI.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/54K50WUaKI.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/5E9QwsWPit.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/5E9QwsWPit.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/5JUr6L7hij.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/5JUr6L7hij.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/5WMn1FI8mr.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/5WMn1FI8mr.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/5ejPdcXoEW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/5ejPdcXoEW.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/5h6yFrKLct.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/5h6yFrKLct.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/6ezYN7Hv0Z.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/6ezYN7Hv0Z.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/6l2wTrG0a6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/6l2wTrG0a6.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/6oA6qi8Lpj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/6oA6qi8Lpj.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/6pwxM7x9RG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/6pwxM7x9RG.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/70gJ0d6ueN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/70gJ0d6ueN.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/7NBB4SlixM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/7NBB4SlixM.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/7PDb7B0Y2N.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/7PDb7B0Y2N.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/7Pcw6lts4T.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/7Pcw6lts4T.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/7Xcf56RyAr.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/7Xcf56RyAr.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/7n3s1BSMBo.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/7n3s1BSMBo.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/7s32eactiP.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/7s32eactiP.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/81lR1cSmfJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/81lR1cSmfJ.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/8dnUV6Vg0Y.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/8dnUV6Vg0Y.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/8tTziwEdcI.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/8tTziwEdcI.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/8zROpBby2x.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/8zROpBby2x.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/90J1b35WV8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/90J1b35WV8.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/91wjEMiEX6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/91wjEMiEX6.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/9EdR9Yk7ca.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/9EdR9Yk7ca.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/9RZxZPNxIu.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/9RZxZPNxIu.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/9TOztQhkC4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/9TOztQhkC4.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/9jWBrTk7UB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/9jWBrTk7UB.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/9lMN6zFkKE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/9lMN6zFkKE.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/9s6IGHapL2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/9s6IGHapL2.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/A01FvWmA8l.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/A01FvWmA8l.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/A3USVyZwFP.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/A3USVyZwFP.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/AGJgFoElmB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/AGJgFoElmB.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/AKEOkMAk9E.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/AKEOkMAk9E.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/ALzR9tiyk8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/ALzR9tiyk8.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/AenL9akVZ7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/AenL9akVZ7.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/AutcanQMIS.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/AutcanQMIS.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/B19N6aMdz3.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/B19N6aMdz3.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/B1EGKnhW9e.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/B1EGKnhW9e.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/B1oQQ08HGH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/B1oQQ08HGH.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/B54wYu3oDA.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/B54wYu3oDA.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/BBTptRbtCv.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/BBTptRbtCv.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/BGGCRglxce.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/BGGCRglxce.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/BP8ChaEEsu.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/BP8ChaEEsu.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/BWk4SOKZaL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/BWk4SOKZaL.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/Bj2rdZWLh7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/Bj2rdZWLh7.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/C0qtj9qPDQ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/C0qtj9qPDQ.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/C9re7IuLWT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/C9re7IuLWT.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/CNHSzPEwGH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/CNHSzPEwGH.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/CP3AlJWqrp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/CP3AlJWqrp.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/CWYcYC8app.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/CWYcYC8app.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/Cb3SuEIO21.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/Cb3SuEIO21.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/CoZ4zNyWGC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/CoZ4zNyWGC.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/D1CTthvE4P.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/D1CTthvE4P.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/DFn3iuttpy.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/DFn3iuttpy.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/Dc9KyR2b2p.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/Dc9KyR2b2p.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/Dph3kXOCic.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/Dph3kXOCic.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/Dvpv1gBrUQ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/Dvpv1gBrUQ.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/E4qThSDcnD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/E4qThSDcnD.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/EC4qtMsceH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/EC4qtMsceH.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/ERsIqJPx5L.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/ERsIqJPx5L.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/EZXLjw31Dl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/EZXLjw31Dl.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/EsvI0BL049.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/EsvI0BL049.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/F2Pe3EMY8l.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/F2Pe3EMY8l.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/F5lnyEc8P7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/F5lnyEc8P7.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/FCqK7dSpWU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/FCqK7dSpWU.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/FNBWotecr1.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/FNBWotecr1.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/FV6eIbtnYG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/FV6eIbtnYG.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/FXHmkUJdzB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/FXHmkUJdzB.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/Fn00VgWg5Y.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/Fn00VgWg5Y.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/G2sYQwPkhJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/G2sYQwPkhJ.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/G5mzA5SBhk.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/G5mzA5SBhk.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/GDxA5zEvt0.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/GDxA5zEvt0.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/GXsAoZzuGz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/GXsAoZzuGz.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/GgA3nIlfrr.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/GgA3nIlfrr.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/Gl9QSM0HL9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/Gl9QSM0HL9.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/HWdd0atzlF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/HWdd0atzlF.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/HjAQJGqXYX.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/HjAQJGqXYX.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/HzjTooszyT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/HzjTooszyT.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/I3R2n3iDwp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/I3R2n3iDwp.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/I5jP7AdXUO.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/I5jP7AdXUO.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/I8b2lta2dV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/I8b2lta2dV.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/IFfft0YbVF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/IFfft0YbVF.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/IcZKeRjvKW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/IcZKeRjvKW.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/IiI7gJ520W.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/IiI7gJ520W.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/Ij3DQuVRk7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/Ij3DQuVRk7.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/IuHoP54Wlc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/IuHoP54Wlc.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/IwYqIz3EHD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/IwYqIz3EHD.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/J0cKBlje4u.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/J0cKBlje4u.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/J1zbYLAkpc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/J1zbYLAkpc.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/J6HXfDOVhX.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/J6HXfDOVhX.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/JH4VhArCNR.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/JH4VhArCNR.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/JXkrGa9mJm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/JXkrGa9mJm.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/JjTVAGnAQr.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/JjTVAGnAQr.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/JptCVz4qEd.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/JptCVz4qEd.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/JtusM5o9mV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/JtusM5o9mV.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/K8foSEhEd6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/K8foSEhEd6.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/KCFf7gu3Y4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/KCFf7gu3Y4.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/KRrQYpA7NN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/KRrQYpA7NN.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/KkW0XInSXe.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/KkW0XInSXe.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/KmUJvvIFQM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/KmUJvvIFQM.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/KwZarRNYrG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/KwZarRNYrG.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/L2R0Fdeoqj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/L2R0Fdeoqj.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/L6Togn7pnd.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/L6Togn7pnd.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/LGFBsMx1Ue.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/LGFBsMx1Ue.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/LKPjaqZzne.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/LKPjaqZzne.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/LTwPCkotqR.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/LTwPCkotqR.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/LlojbpWjs9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/LlojbpWjs9.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/LnGkF3PV4B.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/LnGkF3PV4B.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/Lw6juAfLhZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/Lw6juAfLhZ.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/M2wCQaSIkx.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/M2wCQaSIkx.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/M7p8sbE3VI.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/M7p8sbE3VI.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/MAaNEFkxNx.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/MAaNEFkxNx.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/MN57efcLju.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/MN57efcLju.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/MTonphGglM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/MTonphGglM.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/MWxYsdcQAm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/MWxYsdcQAm.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/MiEtLwCnzM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/MiEtLwCnzM.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/Mm2925bgtf.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/Mm2925bgtf.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/MnCQlmeEpx.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/MnCQlmeEpx.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/Mnn3wVQyPT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/Mnn3wVQyPT.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/MwWzEyFzMN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/MwWzEyFzMN.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/N3qbcpPajg.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/N3qbcpPajg.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/NBM2jrtjUt.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/NBM2jrtjUt.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/NDycAe2PMg.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/NDycAe2PMg.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/NVaQ8JUMmp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/NVaQ8JUMmp.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/NauzwofxwH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/NauzwofxwH.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/Ngx37kpASZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/Ngx37kpASZ.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/NhzifMsgk2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/NhzifMsgk2.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/NpGzSptAcC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/NpGzSptAcC.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/NpRS0S6JWC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/NpRS0S6JWC.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/NqADIATboI.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/NqADIATboI.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/NwHv5RB2rz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/NwHv5RB2rz.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/O953QNNUI0.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/O953QNNUI0.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/OCchs83O6Y.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/OCchs83O6Y.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/OGxNUCIKC2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/OGxNUCIKC2.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/OJyyKz5GVv.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/OJyyKz5GVv.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/OMOINSyhgb.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/OMOINSyhgb.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/ON96VWl2eE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/ON96VWl2eE.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/OYhonKADC9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/OYhonKADC9.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/OZwHXjKDnl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/OZwHXjKDnl.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/OdEuAfadOv.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/OdEuAfadOv.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/OxyGJylIwW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/OxyGJylIwW.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/PHurkwqv4Z.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/PHurkwqv4Z.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/PXNopPwCXl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/PXNopPwCXl.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/QArvYA1I5y.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/QArvYA1I5y.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/QKdvStkUZD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/QKdvStkUZD.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/QkWxbTjqEQ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/QkWxbTjqEQ.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/QoD4gdBKht.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/QoD4gdBKht.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/QxOTHR8Vr5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/QxOTHR8Vr5.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/R4BCKWzeKK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/R4BCKWzeKK.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/RBTWh9W2wN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/RBTWh9W2wN.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/RSdIxOjWTU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/RSdIxOjWTU.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/RVXzOJsITX.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/RVXzOJsITX.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/RVsXeoSc9F.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/RVsXeoSc9F.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/RWTGsJXzQz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/RWTGsJXzQz.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/RYuyMUd2gk.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/RYuyMUd2gk.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/RpX90PHiU0.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/RpX90PHiU0.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/RvpGNGwBDO.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/RvpGNGwBDO.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/RykGa318Dx.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/RykGa318Dx.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/S4670YUK50.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/S4670YUK50.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/S6gLS26ZJ4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/S6gLS26ZJ4.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/S9LbD4Pr4R.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/S9LbD4Pr4R.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/SAOrYUiv3f.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/SAOrYUiv3f.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/SCkYQvq0A9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/SCkYQvq0A9.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/SDPXeHAEsY.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/SDPXeHAEsY.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/SFVT3QJAYW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/SFVT3QJAYW.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/SNuFk4PnW2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/SNuFk4PnW2.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/ShzxZhno8O.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/ShzxZhno8O.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/SnDPKIXHDi.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/SnDPKIXHDi.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/SzCgZ3qNN5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/SzCgZ3qNN5.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/T520ZP6L8T.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/T520ZP6L8T.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/TJTFd5hAYj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/TJTFd5hAYj.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/TRuTR85WZK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/TRuTR85WZK.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/TgwFqiQRdp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/TgwFqiQRdp.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/Tj8JfMPQOP.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/Tj8JfMPQOP.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/TrSKsrbw64.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/TrSKsrbw64.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/TtsQu77nNc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/TtsQu77nNc.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/U5ugQslU2z.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/U5ugQslU2z.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/UP8fkuONg2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/UP8fkuONg2.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/UQd9WJKHHq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/UQd9WJKHHq.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/UdYGjLjpzk.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/UdYGjLjpzk.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/UeKNqkUYqr.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/UeKNqkUYqr.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/UfKa2OpfYT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/UfKa2OpfYT.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/UmSdXFQzs5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/UmSdXFQzs5.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/Uwk8g9mKl8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/Uwk8g9mKl8.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/V39a2Wfhny.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/V39a2Wfhny.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/V6Alb9zB67.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/V6Alb9zB67.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/VBCxRuQlyS.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/VBCxRuQlyS.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/VCeH9ZweWA.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/VCeH9ZweWA.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/VLXVn8J66H.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/VLXVn8J66H.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/VWVKSidnGZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/VWVKSidnGZ.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/VYon30GsHO.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/VYon30GsHO.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/Vdgc0ZvuWs.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/Vdgc0ZvuWs.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/VfmDAdXzKM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/VfmDAdXzKM.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/VhYMLsMLrL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/VhYMLsMLrL.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/VxqkIhG88M.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/VxqkIhG88M.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/W5bnoMpunF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/W5bnoMpunF.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/WOpGodfIa8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/WOpGodfIa8.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/WVz16ttXmN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/WVz16ttXmN.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/WZDWUF8ibK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/WZDWUF8ibK.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/X5FuWfVgX6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/X5FuWfVgX6.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/XLacQhFM5v.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/XLacQhFM5v.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/XOK5FCR5BV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/XOK5FCR5BV.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/XSCVXLUIBn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/XSCVXLUIBn.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/XpelL4dfYJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/XpelL4dfYJ.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/Y0nmeL8Mk6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/Y0nmeL8Mk6.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/Y3mvjkMqPV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/Y3mvjkMqPV.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/Y5EXqXazv8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/Y5EXqXazv8.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/YGlCkfra9u.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/YGlCkfra9u.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/YHnNk2wz6l.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/YHnNk2wz6l.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/YJDISUV0P9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/YJDISUV0P9.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/YNZk56sw8a.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/YNZk56sw8a.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/YSjosSoyxD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/YSjosSoyxD.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/YYPqiV1dMh.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/YYPqiV1dMh.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/YcFI3Qezx8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/YcFI3Qezx8.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/Z7wOsOEcI7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/Z7wOsOEcI7.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/ZEkMAMmFrT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/ZEkMAMmFrT.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/ZHV48dd3xb.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/ZHV48dd3xb.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/ZPpTfz3cuC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/ZPpTfz3cuC.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/ZSKbzDVpdh.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/ZSKbzDVpdh.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/ZV0dzO1N3D.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/ZV0dzO1N3D.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/ZfCQZQ3Yi4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/ZfCQZQ3Yi4.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/ZgH9SeepAW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/ZgH9SeepAW.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/Zzt021tkHA.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/Zzt021tkHA.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/a1DiihgGoN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/a1DiihgGoN.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/aAzECToODG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/aAzECToODG.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/acAvcgb9wR.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/acAvcgb9wR.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/al6GdI6HHq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/al6GdI6HHq.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/b6lOjv1QB9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/b6lOjv1QB9.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/bCdroQZubL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/bCdroQZubL.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/bGXLKzz8DB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/bGXLKzz8DB.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/bOJODCt4Nj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/bOJODCt4Nj.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/bZMWPiINDJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/bZMWPiINDJ.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/bcY4kDXEiL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/bcY4kDXEiL.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/c6ixLi9Yns.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/c6ixLi9Yns.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/cC1vOfH1YD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/cC1vOfH1YD.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/cKgcqJQFSi.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/cKgcqJQFSi.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/cM7YAi3zbW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/cM7YAi3zbW.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/cZb1hdO5AT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/cZb1hdO5AT.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/cjKn08z80L.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/cjKn08z80L.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/cnoFERqEX9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/cnoFERqEX9.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/dBQTDFizrM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/dBQTDFizrM.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/dBXjMyQ6v5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/dBXjMyQ6v5.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/dQcYTBwxmD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/dQcYTBwxmD.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/dVvABT62C9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/dVvABT62C9.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/e3r8e0DiFz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/e3r8e0DiFz.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/eFsp09gaZX.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/eFsp09gaZX.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/eKleS2KN9V.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/eKleS2KN9V.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/eSoalgVCBH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/eSoalgVCBH.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/eVz6pfc2Aq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/eVz6pfc2Aq.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/eYtwlKx3DL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/eYtwlKx3DL.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/ecmluorkUs.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/ecmluorkUs.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/encSaFhW3u.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/encSaFhW3u.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/fEVDUjY0o4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/fEVDUjY0o4.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/fNBZi3EAxz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/fNBZi3EAxz.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/fQ6iyzZG4E.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/fQ6iyzZG4E.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/fkSI356192.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/fkSI356192.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/fqaD1J6KEH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/fqaD1J6KEH.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/fsCqVRe2XV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/fsCqVRe2XV.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/g32LIqIkv7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/g32LIqIkv7.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/g7NcHJ0Dqm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/g7NcHJ0Dqm.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/gKDRuR0huT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/gKDRuR0huT.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/gjl4ArLhJm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/gjl4ArLhJm.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/gvU8LsfGOx.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/gvU8LsfGOx.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/h9Y4PiPY6w.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/h9Y4PiPY6w.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/hchuG3s1rY.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/hchuG3s1rY.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/hnhVAIsmxU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/hnhVAIsmxU.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/hqtR9072e5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/hqtR9072e5.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/i53vKZdcnE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/i53vKZdcnE.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/iBn3UOpKdu.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/iBn3UOpKdu.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/iI6pw0QLBV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/iI6pw0QLBV.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/iQAGO67miB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/iQAGO67miB.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/iTg6zX0H2i.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/iTg6zX0H2i.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/iq57t3NYGm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/iq57t3NYGm.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/ixUQwlLoQl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/ixUQwlLoQl.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/ixp5a4MCzH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/ixp5a4MCzH.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/izrpe1H39g.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/izrpe1H39g.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/j0gOb12WG7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/j0gOb12WG7.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/j41I8z5Dbm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/j41I8z5Dbm.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/j9KVlh9Elu.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/j9KVlh9Elu.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/jEPN6e30lK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/jEPN6e30lK.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/jHoO30hDWC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/jHoO30hDWC.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/jOEODojhaI.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/jOEODojhaI.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/jSdYYlxIPu.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/jSdYYlxIPu.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/kDrpkD1xK6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/kDrpkD1xK6.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/kODlOvWLVJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/kODlOvWLVJ.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/koWMEughuG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/koWMEughuG.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/kpmo31UbcA.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/kpmo31UbcA.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/kuu79cE7XV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/kuu79cE7XV.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/ky7lfFDW6q.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/ky7lfFDW6q.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/kyEHvPp7Gk.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/kyEHvPp7Gk.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/lOk975L1YB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/lOk975L1YB.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/lW11AhH3pd.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/lW11AhH3pd.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/llHMuoBQb8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/llHMuoBQb8.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/m8AHxnkobT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/m8AHxnkobT.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/mBub665Sw1.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/mBub665Sw1.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/mKU2FtqWwc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/mKU2FtqWwc.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/mN75YcjhNl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/mN75YcjhNl.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/mhhBA6GJJy.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/mhhBA6GJJy.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/nE3Qa1apaH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/nE3Qa1apaH.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/nT8J5haK6F.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/nT8J5haK6F.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/nUWnom5eaz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/nUWnom5eaz.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/nY4f0rBQfZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/nY4f0rBQfZ.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/nenm6c9K9H.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/nenm6c9K9H.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/nrmmmwvAB3.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/nrmmmwvAB3.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/nzdiNgzpBk.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/nzdiNgzpBk.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/oEmtybut45.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/oEmtybut45.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/oV4NuQJ94t.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/oV4NuQJ94t.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/oklahTMTmf.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/oklahTMTmf.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/ors0bDh2bc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/ors0bDh2bc.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/pc50J7VwEQ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/pc50J7VwEQ.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/pqukhkAth1.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/pqukhkAth1.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/q5p595DJ6Q.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/q5p595DJ6Q.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/qE0fojpqnw.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/qE0fojpqnw.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/qGpRbiQ2ae.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/qGpRbiQ2ae.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/qoLqfVeYjg.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/qoLqfVeYjg.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/qxfXnYfFUG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/qxfXnYfFUG.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/r8w1v3Z6lL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/r8w1v3Z6lL.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/rMw8A9V28h.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/rMw8A9V28h.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/rZI5VmbmH8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/rZI5VmbmH8.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/rdy3COwDJ8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/rdy3COwDJ8.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/rlmBhex75r.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/rlmBhex75r.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/rn7ZDhqfGn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/rn7ZDhqfGn.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/rse9BAjK8p.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/rse9BAjK8p.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/rxLnaPSdKY.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/rxLnaPSdKY.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/sDb6wxVAlp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/sDb6wxVAlp.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/sHN8Z0s7Zl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/sHN8Z0s7Zl.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/sIk16HKXOH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/sIk16HKXOH.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/sfXrv8XKuT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/sfXrv8XKuT.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/spAP90Xdxo.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/spAP90Xdxo.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/t2LfLuggKw.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/t2LfLuggKw.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/t6anM049gM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/t6anM049gM.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/t6b9ipJFco.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/t6b9ipJFco.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/t88runt2vt.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/t88runt2vt.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/t96N3ukmC2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/t96N3ukmC2.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/tFHSIUZTRU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/tFHSIUZTRU.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/tOBEeyrzR5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/tOBEeyrzR5.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/tqmxPtSV5e.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/tqmxPtSV5e.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/ttgDLEo0YY.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/ttgDLEo0YY.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/tyDsoFs45y.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/tyDsoFs45y.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/tyrqHRTjct.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/tyrqHRTjct.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/uMrfngv4qE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/uMrfngv4qE.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/ufp5xt5UlZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/ufp5xt5UlZ.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/ukDSDTeRKn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/ukDSDTeRKn.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/vAhi6T2iCs.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/vAhi6T2iCs.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/vDddl4MmlU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/vDddl4MmlU.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/vLwvkrUp8m.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/vLwvkrUp8m.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/vO7uWdob4g.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/vO7uWdob4g.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/vUjLCf2llh.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/vUjLCf2llh.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/vdOsQV2zZZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/vdOsQV2zZZ.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/vqoyQGzxwZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/vqoyQGzxwZ.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/vuum3mHSut.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/vuum3mHSut.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/wff7vOGYXM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/wff7vOGYXM.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/wkgn6vRUUp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/wkgn6vRUUp.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/wmDBp8f0Z2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/wmDBp8f0Z2.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/woqch6WNMH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/woqch6WNMH.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/x1AVtHbq4f.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/x1AVtHbq4f.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/xEOJNLq3je.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/xEOJNLq3je.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/xM6CnVshaE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/xM6CnVshaE.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/xOe1maF1HZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/xOe1maF1HZ.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/xVFVQAk3u3.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/xVFVQAk3u3.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/xWEhNnxjgn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/xWEhNnxjgn.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/xmhnIZPlm0.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/xmhnIZPlm0.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/xqXMSXBMl8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/xqXMSXBMl8.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/xqemv5BeQH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/xqemv5BeQH.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/y8Wf7aTXFb.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/y8Wf7aTXFb.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/yCWOaOd0DH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/yCWOaOd0DH.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/yI34mPjVtK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/yI34mPjVtK.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/yQu5xEnWkt.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/yQu5xEnWkt.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/yVvQYsdxaq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/yVvQYsdxaq.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/yaMxpb9T34.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/yaMxpb9T34.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/ygTzDOCr3r.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/ygTzDOCr3r.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/z4XWuGECC2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/z4XWuGECC2.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/z9nNYIgtFz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/z9nNYIgtFz.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/zFiwaVTd6p.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/zFiwaVTd6p.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/zI6QHiNniJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/zI6QHiNniJ.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/zVrQLGqXwe.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/zVrQLGqXwe.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/zYVWOnWkq4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/zYVWOnWkq4.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/zZ91YoJG9X.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/zZ91YoJG9X.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/zuxZ6Tg1Ha.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0-us/zuxZ6Tg1Ha.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/06T2RNzfTz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/06T2RNzfTz.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/07aN2OB1qj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/07aN2OB1qj.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/0JTPBSFvcC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/0JTPBSFvcC.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/0McUuUDCYj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/0McUuUDCYj.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/0T3L0HU9F5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/0T3L0HU9F5.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/0UrWNfXMbn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/0UrWNfXMbn.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/0We2g9ZRI1.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/0We2g9ZRI1.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/0crDi3Beji.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/0crDi3Beji.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/0dN19RtMpy.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/0dN19RtMpy.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/0nyPk4lS5G.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/0nyPk4lS5G.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/0sV5NP6Raj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/0sV5NP6Raj.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/0tlxl8JzK2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/0tlxl8JzK2.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/13VaDTQa1F.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/13VaDTQa1F.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/177ObAyjaW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/177ObAyjaW.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/1SIwphdqPw.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/1SIwphdqPw.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/1Wku3If0yF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/1Wku3If0yF.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/1fkLnqEKq5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/1fkLnqEKq5.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/1guqW4QDJq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/1guqW4QDJq.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/1zvL3jc30s.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/1zvL3jc30s.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/2BK4YBngu6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/2BK4YBngu6.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/2DcJnHQ1Wc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/2DcJnHQ1Wc.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/2EmGTjbMHL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/2EmGTjbMHL.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/2bgBJIgdGy.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/2bgBJIgdGy.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/3DKPTxt9nK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/3DKPTxt9nK.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/3K5GXTKPrP.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/3K5GXTKPrP.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/3QFEobjwmC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/3QFEobjwmC.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/3RDZKRFFEV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/3RDZKRFFEV.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/3s0rgujAIg.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/3s0rgujAIg.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/4Ax5wLUa4c.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/4Ax5wLUa4c.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/4EsYZXHdpa.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/4EsYZXHdpa.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/4MA1GGxtB2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/4MA1GGxtB2.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/4TA0dltn8Z.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/4TA0dltn8Z.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/4XwovA4lrF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/4XwovA4lrF.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/4iwufNM5Y6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/4iwufNM5Y6.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/4kQSb8Mpxb.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/4kQSb8Mpxb.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/4knxgNV22P.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/4knxgNV22P.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/4prVlpN79q.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/4prVlpN79q.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/54K50WUaKI.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/54K50WUaKI.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/5E9QwsWPit.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/5E9QwsWPit.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/5JUr6L7hij.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/5JUr6L7hij.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/5WMn1FI8mr.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/5WMn1FI8mr.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/5ejPdcXoEW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/5ejPdcXoEW.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/5h6yFrKLct.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/5h6yFrKLct.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/6ezYN7Hv0Z.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/6ezYN7Hv0Z.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/6l2wTrG0a6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/6l2wTrG0a6.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/6oA6qi8Lpj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/6oA6qi8Lpj.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/6pwxM7x9RG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/6pwxM7x9RG.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/70gJ0d6ueN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/70gJ0d6ueN.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/7NBB4SlixM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/7NBB4SlixM.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/7PDb7B0Y2N.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/7PDb7B0Y2N.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/7Pcw6lts4T.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/7Pcw6lts4T.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/7Xcf56RyAr.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/7Xcf56RyAr.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/7n3s1BSMBo.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/7n3s1BSMBo.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/7s32eactiP.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/7s32eactiP.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/81lR1cSmfJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/81lR1cSmfJ.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/8dnUV6Vg0Y.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/8dnUV6Vg0Y.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/8tTziwEdcI.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/8tTziwEdcI.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/8zROpBby2x.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/8zROpBby2x.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/90J1b35WV8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/90J1b35WV8.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/91wjEMiEX6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/91wjEMiEX6.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/9EdR9Yk7ca.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/9EdR9Yk7ca.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/9RZxZPNxIu.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/9RZxZPNxIu.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/9TOztQhkC4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/9TOztQhkC4.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/9jWBrTk7UB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/9jWBrTk7UB.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/9lMN6zFkKE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/9lMN6zFkKE.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/9s6IGHapL2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/9s6IGHapL2.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/A01FvWmA8l.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/A01FvWmA8l.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/A3USVyZwFP.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/A3USVyZwFP.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/AGJgFoElmB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/AGJgFoElmB.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/AKEOkMAk9E.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/AKEOkMAk9E.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/ALzR9tiyk8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/ALzR9tiyk8.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/AenL9akVZ7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/AenL9akVZ7.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/AutcanQMIS.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/AutcanQMIS.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/B19N6aMdz3.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/B19N6aMdz3.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/B1EGKnhW9e.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/B1EGKnhW9e.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/B1oQQ08HGH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/B1oQQ08HGH.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/B54wYu3oDA.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/B54wYu3oDA.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/BBTptRbtCv.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/BBTptRbtCv.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/BGGCRglxce.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/BGGCRglxce.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/BP8ChaEEsu.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/BP8ChaEEsu.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/BWk4SOKZaL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/BWk4SOKZaL.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/Bj2rdZWLh7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/Bj2rdZWLh7.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/C0qtj9qPDQ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/C0qtj9qPDQ.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/C9re7IuLWT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/C9re7IuLWT.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/CNHSzPEwGH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/CNHSzPEwGH.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/CP3AlJWqrp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/CP3AlJWqrp.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/CWYcYC8app.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/CWYcYC8app.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/Cb3SuEIO21.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/Cb3SuEIO21.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/CoZ4zNyWGC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/CoZ4zNyWGC.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/D1CTthvE4P.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/D1CTthvE4P.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/DFn3iuttpy.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/DFn3iuttpy.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/Dc9KyR2b2p.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/Dc9KyR2b2p.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/Dph3kXOCic.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/Dph3kXOCic.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/Dvpv1gBrUQ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/Dvpv1gBrUQ.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/E4qThSDcnD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/E4qThSDcnD.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/EC4qtMsceH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/EC4qtMsceH.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/ERsIqJPx5L.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/ERsIqJPx5L.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/EZXLjw31Dl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/EZXLjw31Dl.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/EsvI0BL049.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/EsvI0BL049.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/F2Pe3EMY8l.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/F2Pe3EMY8l.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/F5lnyEc8P7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/F5lnyEc8P7.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/FCqK7dSpWU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/FCqK7dSpWU.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/FNBWotecr1.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/FNBWotecr1.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/FV6eIbtnYG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/FV6eIbtnYG.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/FXHmkUJdzB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/FXHmkUJdzB.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/Fn00VgWg5Y.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/Fn00VgWg5Y.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/G2sYQwPkhJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/G2sYQwPkhJ.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/G5mzA5SBhk.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/G5mzA5SBhk.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/GDxA5zEvt0.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/GDxA5zEvt0.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/GXsAoZzuGz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/GXsAoZzuGz.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/GgA3nIlfrr.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/GgA3nIlfrr.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/Gl9QSM0HL9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/Gl9QSM0HL9.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/HWdd0atzlF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/HWdd0atzlF.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/HjAQJGqXYX.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/HjAQJGqXYX.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/HzjTooszyT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/HzjTooszyT.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/I3R2n3iDwp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/I3R2n3iDwp.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/I5jP7AdXUO.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/I5jP7AdXUO.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/I8b2lta2dV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/I8b2lta2dV.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/IFfft0YbVF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/IFfft0YbVF.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/IcZKeRjvKW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/IcZKeRjvKW.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/IiI7gJ520W.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/IiI7gJ520W.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/Ij3DQuVRk7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/Ij3DQuVRk7.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/IuHoP54Wlc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/IuHoP54Wlc.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/IwYqIz3EHD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/IwYqIz3EHD.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/J0cKBlje4u.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/J0cKBlje4u.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/J1zbYLAkpc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/J1zbYLAkpc.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/J6HXfDOVhX.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/J6HXfDOVhX.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/JH4VhArCNR.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/JH4VhArCNR.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/JXkrGa9mJm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/JXkrGa9mJm.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/JjTVAGnAQr.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/JjTVAGnAQr.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/JptCVz4qEd.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/JptCVz4qEd.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/JtusM5o9mV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/JtusM5o9mV.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/K8foSEhEd6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/K8foSEhEd6.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/KCFf7gu3Y4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/KCFf7gu3Y4.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/KRrQYpA7NN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/KRrQYpA7NN.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/KkW0XInSXe.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/KkW0XInSXe.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/KmUJvvIFQM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/KmUJvvIFQM.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/KwZarRNYrG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/KwZarRNYrG.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/L2R0Fdeoqj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/L2R0Fdeoqj.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/L6Togn7pnd.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/L6Togn7pnd.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/LGFBsMx1Ue.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/LGFBsMx1Ue.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/LKPjaqZzne.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/LKPjaqZzne.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/LTwPCkotqR.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/LTwPCkotqR.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/LlojbpWjs9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/LlojbpWjs9.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/LnGkF3PV4B.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/LnGkF3PV4B.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/Lw6juAfLhZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/Lw6juAfLhZ.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/M2wCQaSIkx.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/M2wCQaSIkx.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/M7p8sbE3VI.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/M7p8sbE3VI.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/MAaNEFkxNx.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/MAaNEFkxNx.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/MN57efcLju.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/MN57efcLju.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/MTonphGglM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/MTonphGglM.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/MWxYsdcQAm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/MWxYsdcQAm.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/MiEtLwCnzM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/MiEtLwCnzM.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/Mm2925bgtf.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/Mm2925bgtf.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/MnCQlmeEpx.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/MnCQlmeEpx.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/Mnn3wVQyPT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/Mnn3wVQyPT.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/MwWzEyFzMN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/MwWzEyFzMN.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/N3qbcpPajg.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/N3qbcpPajg.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/NBM2jrtjUt.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/NBM2jrtjUt.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/NDycAe2PMg.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/NDycAe2PMg.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/NVaQ8JUMmp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/NVaQ8JUMmp.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/NauzwofxwH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/NauzwofxwH.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/Ngx37kpASZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/Ngx37kpASZ.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/NhzifMsgk2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/NhzifMsgk2.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/NpGzSptAcC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/NpGzSptAcC.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/NpRS0S6JWC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/NpRS0S6JWC.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/NqADIATboI.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/NqADIATboI.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/NwHv5RB2rz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/NwHv5RB2rz.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/O953QNNUI0.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/O953QNNUI0.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/OCchs83O6Y.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/OCchs83O6Y.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/OGxNUCIKC2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/OGxNUCIKC2.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/OJyyKz5GVv.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/OJyyKz5GVv.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/OMOINSyhgb.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/OMOINSyhgb.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/ON96VWl2eE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/ON96VWl2eE.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/OYhonKADC9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/OYhonKADC9.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/OZwHXjKDnl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/OZwHXjKDnl.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/OdEuAfadOv.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/OdEuAfadOv.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/OxyGJylIwW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/OxyGJylIwW.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/PHurkwqv4Z.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/PHurkwqv4Z.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/PXNopPwCXl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/PXNopPwCXl.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/QArvYA1I5y.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/QArvYA1I5y.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/QKdvStkUZD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/QKdvStkUZD.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/QkWxbTjqEQ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/QkWxbTjqEQ.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/QoD4gdBKht.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/QoD4gdBKht.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/QxOTHR8Vr5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/QxOTHR8Vr5.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/R4BCKWzeKK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/R4BCKWzeKK.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/RBTWh9W2wN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/RBTWh9W2wN.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/RSdIxOjWTU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/RSdIxOjWTU.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/RVXzOJsITX.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/RVXzOJsITX.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/RVsXeoSc9F.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/RVsXeoSc9F.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/RWTGsJXzQz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/RWTGsJXzQz.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/RYuyMUd2gk.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/RYuyMUd2gk.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/RpX90PHiU0.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/RpX90PHiU0.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/RvpGNGwBDO.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/RvpGNGwBDO.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/RykGa318Dx.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/RykGa318Dx.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/S4670YUK50.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/S4670YUK50.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/S6gLS26ZJ4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/S6gLS26ZJ4.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/S9LbD4Pr4R.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/S9LbD4Pr4R.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/SAOrYUiv3f.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/SAOrYUiv3f.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/SCkYQvq0A9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/SCkYQvq0A9.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/SDPXeHAEsY.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/SDPXeHAEsY.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/SFVT3QJAYW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/SFVT3QJAYW.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/SNuFk4PnW2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/SNuFk4PnW2.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/ShzxZhno8O.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/ShzxZhno8O.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/SnDPKIXHDi.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/SnDPKIXHDi.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/SzCgZ3qNN5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/SzCgZ3qNN5.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/T520ZP6L8T.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/T520ZP6L8T.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/TJTFd5hAYj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/TJTFd5hAYj.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/TRuTR85WZK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/TRuTR85WZK.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/TgwFqiQRdp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/TgwFqiQRdp.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/Tj8JfMPQOP.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/Tj8JfMPQOP.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/TrSKsrbw64.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/TrSKsrbw64.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/TtsQu77nNc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/TtsQu77nNc.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/U5ugQslU2z.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/U5ugQslU2z.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/UP8fkuONg2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/UP8fkuONg2.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/UQd9WJKHHq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/UQd9WJKHHq.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/UdYGjLjpzk.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/UdYGjLjpzk.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/UeKNqkUYqr.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/UeKNqkUYqr.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/UfKa2OpfYT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/UfKa2OpfYT.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/UmSdXFQzs5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/UmSdXFQzs5.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/Uwk8g9mKl8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/Uwk8g9mKl8.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/V39a2Wfhny.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/V39a2Wfhny.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/V6Alb9zB67.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/V6Alb9zB67.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/VBCxRuQlyS.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/VBCxRuQlyS.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/VCeH9ZweWA.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/VCeH9ZweWA.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/VLXVn8J66H.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/VLXVn8J66H.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/VWVKSidnGZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/VWVKSidnGZ.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/VYon30GsHO.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/VYon30GsHO.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/Vdgc0ZvuWs.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/Vdgc0ZvuWs.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/VfmDAdXzKM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/VfmDAdXzKM.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/VhYMLsMLrL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/VhYMLsMLrL.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/VxqkIhG88M.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/VxqkIhG88M.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/W5bnoMpunF.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/W5bnoMpunF.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/WOpGodfIa8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/WOpGodfIa8.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/WVz16ttXmN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/WVz16ttXmN.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/WZDWUF8ibK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/WZDWUF8ibK.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/X5FuWfVgX6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/X5FuWfVgX6.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/XLacQhFM5v.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/XLacQhFM5v.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/XOK5FCR5BV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/XOK5FCR5BV.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/XSCVXLUIBn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/XSCVXLUIBn.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/XpelL4dfYJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/XpelL4dfYJ.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/Y0nmeL8Mk6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/Y0nmeL8Mk6.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/Y3mvjkMqPV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/Y3mvjkMqPV.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/Y5EXqXazv8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/Y5EXqXazv8.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/YGlCkfra9u.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/YGlCkfra9u.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/YHnNk2wz6l.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/YHnNk2wz6l.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/YJDISUV0P9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/YJDISUV0P9.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/YNZk56sw8a.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/YNZk56sw8a.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/YSjosSoyxD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/YSjosSoyxD.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/YYPqiV1dMh.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/YYPqiV1dMh.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/YcFI3Qezx8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/YcFI3Qezx8.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/Z7wOsOEcI7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/Z7wOsOEcI7.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/ZEkMAMmFrT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/ZEkMAMmFrT.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/ZHV48dd3xb.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/ZHV48dd3xb.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/ZPpTfz3cuC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/ZPpTfz3cuC.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/ZSKbzDVpdh.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/ZSKbzDVpdh.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/ZV0dzO1N3D.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/ZV0dzO1N3D.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/ZfCQZQ3Yi4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/ZfCQZQ3Yi4.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/ZgH9SeepAW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/ZgH9SeepAW.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/Zzt021tkHA.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/Zzt021tkHA.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/a1DiihgGoN.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/a1DiihgGoN.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/aAzECToODG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/aAzECToODG.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/acAvcgb9wR.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/acAvcgb9wR.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/al6GdI6HHq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/al6GdI6HHq.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/b6lOjv1QB9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/b6lOjv1QB9.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/bCdroQZubL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/bCdroQZubL.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/bGXLKzz8DB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/bGXLKzz8DB.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/bOJODCt4Nj.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/bOJODCt4Nj.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/bZMWPiINDJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/bZMWPiINDJ.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/bcY4kDXEiL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/bcY4kDXEiL.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/c6ixLi9Yns.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/c6ixLi9Yns.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/cC1vOfH1YD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/cC1vOfH1YD.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/cKgcqJQFSi.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/cKgcqJQFSi.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/cM7YAi3zbW.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/cM7YAi3zbW.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/cZb1hdO5AT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/cZb1hdO5AT.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/cjKn08z80L.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/cjKn08z80L.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/cnoFERqEX9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/cnoFERqEX9.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/dBQTDFizrM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/dBQTDFizrM.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/dBXjMyQ6v5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/dBXjMyQ6v5.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/dQcYTBwxmD.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/dQcYTBwxmD.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/dVvABT62C9.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/dVvABT62C9.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/e3r8e0DiFz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/e3r8e0DiFz.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/eFsp09gaZX.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/eFsp09gaZX.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/eKleS2KN9V.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/eKleS2KN9V.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/eSoalgVCBH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/eSoalgVCBH.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/eVz6pfc2Aq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/eVz6pfc2Aq.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/eYtwlKx3DL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/eYtwlKx3DL.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/ecmluorkUs.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/ecmluorkUs.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/encSaFhW3u.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/encSaFhW3u.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/fEVDUjY0o4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/fEVDUjY0o4.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/fNBZi3EAxz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/fNBZi3EAxz.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/fQ6iyzZG4E.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/fQ6iyzZG4E.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/fkSI356192.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/fkSI356192.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/fqaD1J6KEH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/fqaD1J6KEH.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/fsCqVRe2XV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/fsCqVRe2XV.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/g32LIqIkv7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/g32LIqIkv7.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/g7NcHJ0Dqm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/g7NcHJ0Dqm.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/gKDRuR0huT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/gKDRuR0huT.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/gjl4ArLhJm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/gjl4ArLhJm.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/gvU8LsfGOx.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/gvU8LsfGOx.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/h9Y4PiPY6w.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/h9Y4PiPY6w.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/hchuG3s1rY.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/hchuG3s1rY.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/hnhVAIsmxU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/hnhVAIsmxU.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/hqtR9072e5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/hqtR9072e5.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/i53vKZdcnE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/i53vKZdcnE.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/iBn3UOpKdu.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/iBn3UOpKdu.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/iI6pw0QLBV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/iI6pw0QLBV.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/iQAGO67miB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/iQAGO67miB.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/iTg6zX0H2i.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/iTg6zX0H2i.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/iq57t3NYGm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/iq57t3NYGm.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/ixUQwlLoQl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/ixUQwlLoQl.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/ixp5a4MCzH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/ixp5a4MCzH.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/izrpe1H39g.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/izrpe1H39g.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/j0gOb12WG7.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/j0gOb12WG7.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/j41I8z5Dbm.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/j41I8z5Dbm.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/j9KVlh9Elu.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/j9KVlh9Elu.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/jEPN6e30lK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/jEPN6e30lK.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/jHoO30hDWC.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/jHoO30hDWC.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/jOEODojhaI.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/jOEODojhaI.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/jSdYYlxIPu.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/jSdYYlxIPu.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/kDrpkD1xK6.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/kDrpkD1xK6.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/kODlOvWLVJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/kODlOvWLVJ.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/koWMEughuG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/koWMEughuG.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/kpmo31UbcA.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/kpmo31UbcA.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/kuu79cE7XV.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/kuu79cE7XV.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/ky7lfFDW6q.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/ky7lfFDW6q.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/kyEHvPp7Gk.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/kyEHvPp7Gk.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/lOk975L1YB.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/lOk975L1YB.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/lW11AhH3pd.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/lW11AhH3pd.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/llHMuoBQb8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/llHMuoBQb8.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/m8AHxnkobT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/m8AHxnkobT.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/mBub665Sw1.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/mBub665Sw1.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/mKU2FtqWwc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/mKU2FtqWwc.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/mN75YcjhNl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/mN75YcjhNl.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/mhhBA6GJJy.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/mhhBA6GJJy.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/nE3Qa1apaH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/nE3Qa1apaH.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/nT8J5haK6F.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/nT8J5haK6F.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/nUWnom5eaz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/nUWnom5eaz.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/nY4f0rBQfZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/nY4f0rBQfZ.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/nenm6c9K9H.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/nenm6c9K9H.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/nrmmmwvAB3.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/nrmmmwvAB3.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/nzdiNgzpBk.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/nzdiNgzpBk.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/oEmtybut45.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/oEmtybut45.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/oV4NuQJ94t.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/oV4NuQJ94t.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/oklahTMTmf.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/oklahTMTmf.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/ors0bDh2bc.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/ors0bDh2bc.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/pc50J7VwEQ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/pc50J7VwEQ.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/pqukhkAth1.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/pqukhkAth1.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/q5p595DJ6Q.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/q5p595DJ6Q.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/qE0fojpqnw.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/qE0fojpqnw.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/qGpRbiQ2ae.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/qGpRbiQ2ae.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/qoLqfVeYjg.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/qoLqfVeYjg.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/qxfXnYfFUG.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/qxfXnYfFUG.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/r8w1v3Z6lL.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/r8w1v3Z6lL.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/rMw8A9V28h.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/rMw8A9V28h.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/rZI5VmbmH8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/rZI5VmbmH8.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/rdy3COwDJ8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/rdy3COwDJ8.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/rlmBhex75r.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/rlmBhex75r.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/rn7ZDhqfGn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/rn7ZDhqfGn.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/rse9BAjK8p.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/rse9BAjK8p.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/rxLnaPSdKY.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/rxLnaPSdKY.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/sDb6wxVAlp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/sDb6wxVAlp.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/sHN8Z0s7Zl.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/sHN8Z0s7Zl.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/sIk16HKXOH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/sIk16HKXOH.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/sfXrv8XKuT.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/sfXrv8XKuT.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/spAP90Xdxo.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/spAP90Xdxo.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/t2LfLuggKw.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/t2LfLuggKw.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/t6anM049gM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/t6anM049gM.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/t6b9ipJFco.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/t6b9ipJFco.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/t88runt2vt.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/t88runt2vt.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/t96N3ukmC2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/t96N3ukmC2.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/tFHSIUZTRU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/tFHSIUZTRU.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/tOBEeyrzR5.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/tOBEeyrzR5.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/tqmxPtSV5e.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/tqmxPtSV5e.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/ttgDLEo0YY.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/ttgDLEo0YY.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/tyDsoFs45y.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/tyDsoFs45y.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/tyrqHRTjct.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/tyrqHRTjct.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/uMrfngv4qE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/uMrfngv4qE.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/ufp5xt5UlZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/ufp5xt5UlZ.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/ukDSDTeRKn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/ukDSDTeRKn.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/vAhi6T2iCs.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/vAhi6T2iCs.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/vDddl4MmlU.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/vDddl4MmlU.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/vLwvkrUp8m.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/vLwvkrUp8m.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/vO7uWdob4g.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/vO7uWdob4g.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/vUjLCf2llh.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/vUjLCf2llh.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/vdOsQV2zZZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/vdOsQV2zZZ.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/vqoyQGzxwZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/vqoyQGzxwZ.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/vuum3mHSut.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/vuum3mHSut.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/wff7vOGYXM.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/wff7vOGYXM.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/wkgn6vRUUp.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/wkgn6vRUUp.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/wmDBp8f0Z2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/wmDBp8f0Z2.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/woqch6WNMH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/woqch6WNMH.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/x1AVtHbq4f.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/x1AVtHbq4f.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/xEOJNLq3je.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/xEOJNLq3je.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/xM6CnVshaE.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/xM6CnVshaE.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/xOe1maF1HZ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/xOe1maF1HZ.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/xVFVQAk3u3.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/xVFVQAk3u3.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/xWEhNnxjgn.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/xWEhNnxjgn.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/xmhnIZPlm0.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/xmhnIZPlm0.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/xqXMSXBMl8.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/xqXMSXBMl8.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/xqemv5BeQH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/xqemv5BeQH.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/y8Wf7aTXFb.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/y8Wf7aTXFb.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/yCWOaOd0DH.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/yCWOaOd0DH.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/yI34mPjVtK.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/yI34mPjVtK.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/yQu5xEnWkt.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/yQu5xEnWkt.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/yVvQYsdxaq.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/yVvQYsdxaq.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/yaMxpb9T34.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/yaMxpb9T34.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/ygTzDOCr3r.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/ygTzDOCr3r.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/z4XWuGECC2.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/z4XWuGECC2.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/z9nNYIgtFz.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/z9nNYIgtFz.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/zFiwaVTd6p.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/zFiwaVTd6p.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/zI6QHiNniJ.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/zI6QHiNniJ.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/zVrQLGqXwe.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/zVrQLGqXwe.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/zYVWOnWkq4.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/zYVWOnWkq4.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/zZ91YoJG9X.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/zZ91YoJG9X.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/zuxZ6Tg1Ha.verified.txt
+++ b/tests/SnapshotTests/GenerationPermutations/snapshots/snap-v7.0/zuxZ6Tg1Ha.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1-fr/0RqDCSNFog.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1-fr/0RqDCSNFog.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1-fr/8VXB2Ayw8Q.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1-fr/8VXB2Ayw8Q.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1-fr/AjA4jZWDKX.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1-fr/AjA4jZWDKX.verified.txt
@@ -155,7 +155,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1-fr/B9CfOvgNmu.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1-fr/B9CfOvgNmu.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1-fr/IsdKHmH8ZO.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1-fr/IsdKHmH8ZO.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1-fr/KdK6TTDQpk.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1-fr/KdK6TTDQpk.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1-fr/NUHROXiOt9.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1-fr/NUHROXiOt9.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1-fr/PxEFTla44K.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1-fr/PxEFTla44K.verified.txt
@@ -155,7 +155,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1-fr/Q0INojqlts.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1-fr/Q0INojqlts.verified.txt
@@ -134,7 +134,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1-fr/Qjb7OvpJGM.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1-fr/Qjb7OvpJGM.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1-fr/QtdmJ4OCBu.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1-fr/QtdmJ4OCBu.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1-fr/Sg0yhUS3KF.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1-fr/Sg0yhUS3KF.verified.txt
@@ -134,7 +134,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1-fr/SsGgNd5B8V.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1-fr/SsGgNd5B8V.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1-fr/Tw02GMGqV0.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1-fr/Tw02GMGqV0.verified.txt
@@ -155,7 +155,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1-fr/VDByDf9irl.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1-fr/VDByDf9irl.verified.txt
@@ -134,7 +134,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1-fr/Wwl28QbOnP.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1-fr/Wwl28QbOnP.verified.txt
@@ -155,7 +155,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1-fr/XnTTtRBL3k.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1-fr/XnTTtRBL3k.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1-fr/YTWXXvHTiO.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1-fr/YTWXXvHTiO.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1-fr/ZRJoAqVVvb.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1-fr/ZRJoAqVVvb.verified.txt
@@ -134,7 +134,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1-fr/ZaFOPIWhda.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1-fr/ZaFOPIWhda.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1-fr/dTwZEZeVhu.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1-fr/dTwZEZeVhu.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1-fr/edowZi17Nt.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1-fr/edowZi17Nt.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1-fr/fOa6Y3m3Eu.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1-fr/fOa6Y3m3Eu.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1-fr/pB5AVMQH3t.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1-fr/pB5AVMQH3t.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1-fr/r5vLbt9RKW.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1-fr/r5vLbt9RKW.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1-fr/rfT15swE8e.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1-fr/rfT15swE8e.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1-fr/smbplIhBkI.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1-fr/smbplIhBkI.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1-fr/v7qMYkQ7z4.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1-fr/v7qMYkQ7z4.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1-fr/xdXJVrpdqo.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1-fr/xdXJVrpdqo.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1-fr/xqyVPeg2iw.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1-fr/xqyVPeg2iw.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1-fr/y2FXDfXVGz.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1-fr/y2FXDfXVGz.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1-fr/y2hm1XT4Tk.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1-fr/y2hm1XT4Tk.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1/0RqDCSNFog.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1/0RqDCSNFog.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1/8VXB2Ayw8Q.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1/8VXB2Ayw8Q.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1/AjA4jZWDKX.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1/AjA4jZWDKX.verified.txt
@@ -155,7 +155,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1/B9CfOvgNmu.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1/B9CfOvgNmu.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1/InstanceFieldGenerationTests.Instance_names_can_have_reserved_keywords.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1/InstanceFieldGenerationTests.Instance_names_can_have_reserved_keywords.verified.txt
@@ -145,7 +145,7 @@ var validation = CustomerId.validate(value);
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1/IsdKHmH8ZO.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1/IsdKHmH8ZO.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1/KdK6TTDQpk.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1/KdK6TTDQpk.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1/NUHROXiOt9.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1/NUHROXiOt9.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1/PxEFTla44K.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1/PxEFTla44K.verified.txt
@@ -155,7 +155,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1/Q0INojqlts.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1/Q0INojqlts.verified.txt
@@ -134,7 +134,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1/Qjb7OvpJGM.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1/Qjb7OvpJGM.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1/QtdmJ4OCBu.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1/QtdmJ4OCBu.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1/Sg0yhUS3KF.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1/Sg0yhUS3KF.verified.txt
@@ -134,7 +134,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1/SsGgNd5B8V.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1/SsGgNd5B8V.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1/Tw02GMGqV0.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1/Tw02GMGqV0.verified.txt
@@ -155,7 +155,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1/VDByDf9irl.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1/VDByDf9irl.verified.txt
@@ -134,7 +134,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1/Wwl28QbOnP.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1/Wwl28QbOnP.verified.txt
@@ -155,7 +155,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1/XnTTtRBL3k.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1/XnTTtRBL3k.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1/YTWXXvHTiO.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1/YTWXXvHTiO.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1/ZRJoAqVVvb.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1/ZRJoAqVVvb.verified.txt
@@ -134,7 +134,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1/ZaFOPIWhda.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1/ZaFOPIWhda.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1/dTwZEZeVhu.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1/dTwZEZeVhu.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1/edowZi17Nt.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1/edowZi17Nt.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1/fOa6Y3m3Eu.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1/fOa6Y3m3Eu.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1/pB5AVMQH3t.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1/pB5AVMQH3t.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1/r5vLbt9RKW.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1/r5vLbt9RKW.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1/rfT15swE8e.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1/rfT15swE8e.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1/smbplIhBkI.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1/smbplIhBkI.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1/v7qMYkQ7z4.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1/v7qMYkQ7z4.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1/xdXJVrpdqo.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1/xdXJVrpdqo.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1/xqyVPeg2iw.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1/xqyVPeg2iw.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1/y2FXDfXVGz.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1/y2FXDfXVGz.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1/y2hm1XT4Tk.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v3.1/y2hm1XT4Tk.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1-fr/0RqDCSNFog.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1-fr/0RqDCSNFog.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1-fr/8VXB2Ayw8Q.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1-fr/8VXB2Ayw8Q.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1-fr/AjA4jZWDKX.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1-fr/AjA4jZWDKX.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1-fr/B9CfOvgNmu.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1-fr/B9CfOvgNmu.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1-fr/IsdKHmH8ZO.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1-fr/IsdKHmH8ZO.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1-fr/KdK6TTDQpk.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1-fr/KdK6TTDQpk.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1-fr/NUHROXiOt9.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1-fr/NUHROXiOt9.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1-fr/PxEFTla44K.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1-fr/PxEFTla44K.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1-fr/Q0INojqlts.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1-fr/Q0INojqlts.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1-fr/Qjb7OvpJGM.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1-fr/Qjb7OvpJGM.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1-fr/QtdmJ4OCBu.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1-fr/QtdmJ4OCBu.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1-fr/Sg0yhUS3KF.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1-fr/Sg0yhUS3KF.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1-fr/SsGgNd5B8V.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1-fr/SsGgNd5B8V.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1-fr/Tw02GMGqV0.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1-fr/Tw02GMGqV0.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1-fr/VDByDf9irl.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1-fr/VDByDf9irl.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1-fr/Wwl28QbOnP.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1-fr/Wwl28QbOnP.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1-fr/XnTTtRBL3k.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1-fr/XnTTtRBL3k.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1-fr/YTWXXvHTiO.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1-fr/YTWXXvHTiO.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1-fr/ZRJoAqVVvb.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1-fr/ZRJoAqVVvb.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1-fr/ZaFOPIWhda.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1-fr/ZaFOPIWhda.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1-fr/dTwZEZeVhu.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1-fr/dTwZEZeVhu.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1-fr/edowZi17Nt.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1-fr/edowZi17Nt.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1-fr/fOa6Y3m3Eu.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1-fr/fOa6Y3m3Eu.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1-fr/pB5AVMQH3t.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1-fr/pB5AVMQH3t.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1-fr/r5vLbt9RKW.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1-fr/r5vLbt9RKW.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1-fr/rfT15swE8e.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1-fr/rfT15swE8e.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1-fr/smbplIhBkI.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1-fr/smbplIhBkI.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1-fr/v7qMYkQ7z4.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1-fr/v7qMYkQ7z4.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1-fr/xdXJVrpdqo.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1-fr/xdXJVrpdqo.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1-fr/xqyVPeg2iw.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1-fr/xqyVPeg2iw.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1-fr/y2FXDfXVGz.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1-fr/y2FXDfXVGz.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1-fr/y2hm1XT4Tk.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1-fr/y2hm1XT4Tk.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1/0RqDCSNFog.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1/0RqDCSNFog.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1/8VXB2Ayw8Q.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1/8VXB2Ayw8Q.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1/AjA4jZWDKX.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1/AjA4jZWDKX.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1/B9CfOvgNmu.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1/B9CfOvgNmu.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1/InstanceFieldGenerationTests.Instance_names_can_have_reserved_keywords.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1/InstanceFieldGenerationTests.Instance_names_can_have_reserved_keywords.verified.txt
@@ -143,7 +143,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1/IsdKHmH8ZO.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1/IsdKHmH8ZO.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1/KdK6TTDQpk.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1/KdK6TTDQpk.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1/NUHROXiOt9.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1/NUHROXiOt9.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1/PxEFTla44K.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1/PxEFTla44K.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1/Q0INojqlts.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1/Q0INojqlts.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1/Qjb7OvpJGM.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1/Qjb7OvpJGM.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1/QtdmJ4OCBu.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1/QtdmJ4OCBu.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1/Sg0yhUS3KF.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1/Sg0yhUS3KF.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1/SsGgNd5B8V.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1/SsGgNd5B8V.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1/Tw02GMGqV0.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1/Tw02GMGqV0.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1/VDByDf9irl.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1/VDByDf9irl.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1/Wwl28QbOnP.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1/Wwl28QbOnP.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1/XnTTtRBL3k.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1/XnTTtRBL3k.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1/YTWXXvHTiO.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1/YTWXXvHTiO.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1/ZRJoAqVVvb.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1/ZRJoAqVVvb.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1/ZaFOPIWhda.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1/ZaFOPIWhda.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1/dTwZEZeVhu.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1/dTwZEZeVhu.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1/edowZi17Nt.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1/edowZi17Nt.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1/fOa6Y3m3Eu.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1/fOa6Y3m3Eu.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1/pB5AVMQH3t.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1/pB5AVMQH3t.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1/r5vLbt9RKW.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1/r5vLbt9RKW.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1/rfT15swE8e.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1/rfT15swE8e.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1/smbplIhBkI.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1/smbplIhBkI.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1/v7qMYkQ7z4.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1/v7qMYkQ7z4.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1/xdXJVrpdqo.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1/xdXJVrpdqo.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1/xqyVPeg2iw.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1/xqyVPeg2iw.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1/y2FXDfXVGz.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1/y2FXDfXVGz.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1/y2hm1XT4Tk.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.6.1/y2hm1XT4Tk.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8-fr/0RqDCSNFog.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8-fr/0RqDCSNFog.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8-fr/8VXB2Ayw8Q.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8-fr/8VXB2Ayw8Q.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8-fr/AjA4jZWDKX.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8-fr/AjA4jZWDKX.verified.txt
@@ -155,7 +155,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8-fr/B9CfOvgNmu.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8-fr/B9CfOvgNmu.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8-fr/IsdKHmH8ZO.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8-fr/IsdKHmH8ZO.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8-fr/KdK6TTDQpk.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8-fr/KdK6TTDQpk.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8-fr/NUHROXiOt9.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8-fr/NUHROXiOt9.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8-fr/PxEFTla44K.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8-fr/PxEFTla44K.verified.txt
@@ -155,7 +155,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8-fr/Q0INojqlts.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8-fr/Q0INojqlts.verified.txt
@@ -134,7 +134,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8-fr/Qjb7OvpJGM.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8-fr/Qjb7OvpJGM.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8-fr/QtdmJ4OCBu.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8-fr/QtdmJ4OCBu.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8-fr/Sg0yhUS3KF.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8-fr/Sg0yhUS3KF.verified.txt
@@ -134,7 +134,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8-fr/SsGgNd5B8V.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8-fr/SsGgNd5B8V.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8-fr/Tw02GMGqV0.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8-fr/Tw02GMGqV0.verified.txt
@@ -155,7 +155,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8-fr/VDByDf9irl.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8-fr/VDByDf9irl.verified.txt
@@ -134,7 +134,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8-fr/Wwl28QbOnP.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8-fr/Wwl28QbOnP.verified.txt
@@ -155,7 +155,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8-fr/XnTTtRBL3k.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8-fr/XnTTtRBL3k.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8-fr/YTWXXvHTiO.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8-fr/YTWXXvHTiO.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8-fr/ZRJoAqVVvb.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8-fr/ZRJoAqVVvb.verified.txt
@@ -134,7 +134,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8-fr/ZaFOPIWhda.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8-fr/ZaFOPIWhda.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8-fr/dTwZEZeVhu.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8-fr/dTwZEZeVhu.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8-fr/edowZi17Nt.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8-fr/edowZi17Nt.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8-fr/fOa6Y3m3Eu.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8-fr/fOa6Y3m3Eu.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8-fr/pB5AVMQH3t.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8-fr/pB5AVMQH3t.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8-fr/r5vLbt9RKW.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8-fr/r5vLbt9RKW.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8-fr/rfT15swE8e.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8-fr/rfT15swE8e.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8-fr/smbplIhBkI.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8-fr/smbplIhBkI.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8-fr/v7qMYkQ7z4.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8-fr/v7qMYkQ7z4.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8-fr/xdXJVrpdqo.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8-fr/xdXJVrpdqo.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8-fr/xqyVPeg2iw.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8-fr/xqyVPeg2iw.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8-fr/y2FXDfXVGz.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8-fr/y2FXDfXVGz.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8-fr/y2hm1XT4Tk.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8-fr/y2hm1XT4Tk.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8/0RqDCSNFog.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8/0RqDCSNFog.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8/8VXB2Ayw8Q.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8/8VXB2Ayw8Q.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8/AjA4jZWDKX.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8/AjA4jZWDKX.verified.txt
@@ -155,7 +155,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8/B9CfOvgNmu.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8/B9CfOvgNmu.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8/InstanceFieldGenerationTests.Instance_names_can_have_reserved_keywords.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8/InstanceFieldGenerationTests.Instance_names_can_have_reserved_keywords.verified.txt
@@ -145,7 +145,7 @@ var validation = CustomerId.validate(value);
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8/IsdKHmH8ZO.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8/IsdKHmH8ZO.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8/KdK6TTDQpk.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8/KdK6TTDQpk.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8/NUHROXiOt9.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8/NUHROXiOt9.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8/PxEFTla44K.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8/PxEFTla44K.verified.txt
@@ -155,7 +155,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8/Q0INojqlts.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8/Q0INojqlts.verified.txt
@@ -134,7 +134,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8/Qjb7OvpJGM.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8/Qjb7OvpJGM.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8/QtdmJ4OCBu.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8/QtdmJ4OCBu.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8/Sg0yhUS3KF.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8/Sg0yhUS3KF.verified.txt
@@ -134,7 +134,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8/SsGgNd5B8V.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8/SsGgNd5B8V.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8/Tw02GMGqV0.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8/Tw02GMGqV0.verified.txt
@@ -155,7 +155,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8/VDByDf9irl.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8/VDByDf9irl.verified.txt
@@ -134,7 +134,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8/Wwl28QbOnP.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8/Wwl28QbOnP.verified.txt
@@ -155,7 +155,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8/XnTTtRBL3k.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8/XnTTtRBL3k.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8/YTWXXvHTiO.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8/YTWXXvHTiO.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8/ZRJoAqVVvb.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8/ZRJoAqVVvb.verified.txt
@@ -134,7 +134,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8/ZaFOPIWhda.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8/ZaFOPIWhda.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8/dTwZEZeVhu.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8/dTwZEZeVhu.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8/edowZi17Nt.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8/edowZi17Nt.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8/fOa6Y3m3Eu.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8/fOa6Y3m3Eu.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8/pB5AVMQH3t.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8/pB5AVMQH3t.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8/r5vLbt9RKW.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8/r5vLbt9RKW.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8/rfT15swE8e.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8/rfT15swE8e.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8/smbplIhBkI.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8/smbplIhBkI.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8/v7qMYkQ7z4.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8/v7qMYkQ7z4.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8/xdXJVrpdqo.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8/xdXJVrpdqo.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8/xqyVPeg2iw.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8/xqyVPeg2iw.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8/y2FXDfXVGz.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8/y2FXDfXVGz.verified.txt
@@ -176,7 +176,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8/y2hm1XT4Tk.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v4.8/y2hm1XT4Tk.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0-fr/0RqDCSNFog.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0-fr/0RqDCSNFog.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0-fr/8VXB2Ayw8Q.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0-fr/8VXB2Ayw8Q.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0-fr/AjA4jZWDKX.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0-fr/AjA4jZWDKX.verified.txt
@@ -155,7 +155,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0-fr/B9CfOvgNmu.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0-fr/B9CfOvgNmu.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0-fr/IsdKHmH8ZO.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0-fr/IsdKHmH8ZO.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0-fr/KdK6TTDQpk.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0-fr/KdK6TTDQpk.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0-fr/NUHROXiOt9.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0-fr/NUHROXiOt9.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0-fr/PxEFTla44K.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0-fr/PxEFTla44K.verified.txt
@@ -155,7 +155,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0-fr/Q0INojqlts.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0-fr/Q0INojqlts.verified.txt
@@ -134,7 +134,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0-fr/Qjb7OvpJGM.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0-fr/Qjb7OvpJGM.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0-fr/QtdmJ4OCBu.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0-fr/QtdmJ4OCBu.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0-fr/Sg0yhUS3KF.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0-fr/Sg0yhUS3KF.verified.txt
@@ -134,7 +134,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0-fr/SsGgNd5B8V.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0-fr/SsGgNd5B8V.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0-fr/Tw02GMGqV0.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0-fr/Tw02GMGqV0.verified.txt
@@ -155,7 +155,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0-fr/VDByDf9irl.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0-fr/VDByDf9irl.verified.txt
@@ -134,7 +134,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0-fr/Wwl28QbOnP.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0-fr/Wwl28QbOnP.verified.txt
@@ -155,7 +155,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0-fr/XnTTtRBL3k.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0-fr/XnTTtRBL3k.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0-fr/YTWXXvHTiO.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0-fr/YTWXXvHTiO.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0-fr/ZRJoAqVVvb.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0-fr/ZRJoAqVVvb.verified.txt
@@ -134,7 +134,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0-fr/ZaFOPIWhda.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0-fr/ZaFOPIWhda.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0-fr/dTwZEZeVhu.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0-fr/dTwZEZeVhu.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0-fr/edowZi17Nt.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0-fr/edowZi17Nt.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0-fr/fOa6Y3m3Eu.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0-fr/fOa6Y3m3Eu.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0-fr/pB5AVMQH3t.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0-fr/pB5AVMQH3t.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0-fr/r5vLbt9RKW.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0-fr/r5vLbt9RKW.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0-fr/rfT15swE8e.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0-fr/rfT15swE8e.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0-fr/smbplIhBkI.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0-fr/smbplIhBkI.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0-fr/v7qMYkQ7z4.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0-fr/v7qMYkQ7z4.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0-fr/xdXJVrpdqo.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0-fr/xdXJVrpdqo.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0-fr/xqyVPeg2iw.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0-fr/xqyVPeg2iw.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0-fr/y2FXDfXVGz.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0-fr/y2FXDfXVGz.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0-fr/y2hm1XT4Tk.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0-fr/y2hm1XT4Tk.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0/0RqDCSNFog.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0/0RqDCSNFog.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0/8VXB2Ayw8Q.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0/8VXB2Ayw8Q.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0/AjA4jZWDKX.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0/AjA4jZWDKX.verified.txt
@@ -155,7 +155,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0/B9CfOvgNmu.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0/B9CfOvgNmu.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0/InstanceFieldGenerationTests.Instance_names_can_have_reserved_keywords.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0/InstanceFieldGenerationTests.Instance_names_can_have_reserved_keywords.verified.txt
@@ -145,7 +145,7 @@ var validation = CustomerId.validate(value);
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0/IsdKHmH8ZO.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0/IsdKHmH8ZO.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0/KdK6TTDQpk.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0/KdK6TTDQpk.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0/NUHROXiOt9.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0/NUHROXiOt9.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0/PxEFTla44K.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0/PxEFTla44K.verified.txt
@@ -155,7 +155,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0/Q0INojqlts.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0/Q0INojqlts.verified.txt
@@ -134,7 +134,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0/Qjb7OvpJGM.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0/Qjb7OvpJGM.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0/QtdmJ4OCBu.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0/QtdmJ4OCBu.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0/Sg0yhUS3KF.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0/Sg0yhUS3KF.verified.txt
@@ -134,7 +134,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0/SsGgNd5B8V.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0/SsGgNd5B8V.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0/Tw02GMGqV0.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0/Tw02GMGqV0.verified.txt
@@ -155,7 +155,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0/VDByDf9irl.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0/VDByDf9irl.verified.txt
@@ -134,7 +134,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0/Wwl28QbOnP.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0/Wwl28QbOnP.verified.txt
@@ -155,7 +155,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0/XnTTtRBL3k.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0/XnTTtRBL3k.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0/YTWXXvHTiO.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0/YTWXXvHTiO.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0/ZRJoAqVVvb.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0/ZRJoAqVVvb.verified.txt
@@ -134,7 +134,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0/ZaFOPIWhda.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0/ZaFOPIWhda.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0/dTwZEZeVhu.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0/dTwZEZeVhu.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0/edowZi17Nt.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0/edowZi17Nt.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0/fOa6Y3m3Eu.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0/fOa6Y3m3Eu.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0/pB5AVMQH3t.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0/pB5AVMQH3t.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0/r5vLbt9RKW.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0/r5vLbt9RKW.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0/rfT15swE8e.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0/rfT15swE8e.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0/smbplIhBkI.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0/smbplIhBkI.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0/v7qMYkQ7z4.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0/v7qMYkQ7z4.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0/xdXJVrpdqo.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0/xdXJVrpdqo.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0/xqyVPeg2iw.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0/xqyVPeg2iw.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0/y2FXDfXVGz.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0/y2FXDfXVGz.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0/y2hm1XT4Tk.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v5.0/y2hm1XT4Tk.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0-fr/0RqDCSNFog.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0-fr/0RqDCSNFog.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0-fr/8VXB2Ayw8Q.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0-fr/8VXB2Ayw8Q.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0-fr/AjA4jZWDKX.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0-fr/AjA4jZWDKX.verified.txt
@@ -155,7 +155,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0-fr/B9CfOvgNmu.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0-fr/B9CfOvgNmu.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0-fr/IsdKHmH8ZO.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0-fr/IsdKHmH8ZO.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0-fr/KdK6TTDQpk.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0-fr/KdK6TTDQpk.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0-fr/NUHROXiOt9.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0-fr/NUHROXiOt9.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0-fr/PxEFTla44K.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0-fr/PxEFTla44K.verified.txt
@@ -155,7 +155,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0-fr/Q0INojqlts.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0-fr/Q0INojqlts.verified.txt
@@ -134,7 +134,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0-fr/Qjb7OvpJGM.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0-fr/Qjb7OvpJGM.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0-fr/QtdmJ4OCBu.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0-fr/QtdmJ4OCBu.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0-fr/Sg0yhUS3KF.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0-fr/Sg0yhUS3KF.verified.txt
@@ -134,7 +134,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0-fr/SsGgNd5B8V.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0-fr/SsGgNd5B8V.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0-fr/Tw02GMGqV0.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0-fr/Tw02GMGqV0.verified.txt
@@ -155,7 +155,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0-fr/VDByDf9irl.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0-fr/VDByDf9irl.verified.txt
@@ -134,7 +134,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0-fr/Wwl28QbOnP.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0-fr/Wwl28QbOnP.verified.txt
@@ -155,7 +155,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0-fr/XnTTtRBL3k.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0-fr/XnTTtRBL3k.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0-fr/YTWXXvHTiO.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0-fr/YTWXXvHTiO.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0-fr/ZRJoAqVVvb.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0-fr/ZRJoAqVVvb.verified.txt
@@ -134,7 +134,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0-fr/ZaFOPIWhda.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0-fr/ZaFOPIWhda.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0-fr/dTwZEZeVhu.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0-fr/dTwZEZeVhu.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0-fr/edowZi17Nt.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0-fr/edowZi17Nt.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0-fr/fOa6Y3m3Eu.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0-fr/fOa6Y3m3Eu.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0-fr/pB5AVMQH3t.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0-fr/pB5AVMQH3t.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0-fr/r5vLbt9RKW.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0-fr/r5vLbt9RKW.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0-fr/rfT15swE8e.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0-fr/rfT15swE8e.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0-fr/smbplIhBkI.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0-fr/smbplIhBkI.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0-fr/v7qMYkQ7z4.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0-fr/v7qMYkQ7z4.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0-fr/xdXJVrpdqo.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0-fr/xdXJVrpdqo.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0-fr/xqyVPeg2iw.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0-fr/xqyVPeg2iw.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0-fr/y2FXDfXVGz.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0-fr/y2FXDfXVGz.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0-fr/y2hm1XT4Tk.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0-fr/y2hm1XT4Tk.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0/0RqDCSNFog.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0/0RqDCSNFog.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0/8VXB2Ayw8Q.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0/8VXB2Ayw8Q.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0/AjA4jZWDKX.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0/AjA4jZWDKX.verified.txt
@@ -155,7 +155,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0/B9CfOvgNmu.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0/B9CfOvgNmu.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0/InstanceFieldGenerationTests.Instance_names_can_have_reserved_keywords.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0/InstanceFieldGenerationTests.Instance_names_can_have_reserved_keywords.verified.txt
@@ -145,7 +145,7 @@ var validation = CustomerId.validate(value);
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0/IsdKHmH8ZO.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0/IsdKHmH8ZO.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0/KdK6TTDQpk.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0/KdK6TTDQpk.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0/NUHROXiOt9.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0/NUHROXiOt9.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0/PxEFTla44K.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0/PxEFTla44K.verified.txt
@@ -155,7 +155,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0/Q0INojqlts.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0/Q0INojqlts.verified.txt
@@ -134,7 +134,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0/Qjb7OvpJGM.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0/Qjb7OvpJGM.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0/QtdmJ4OCBu.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0/QtdmJ4OCBu.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0/Sg0yhUS3KF.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0/Sg0yhUS3KF.verified.txt
@@ -134,7 +134,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0/SsGgNd5B8V.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0/SsGgNd5B8V.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0/Tw02GMGqV0.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0/Tw02GMGqV0.verified.txt
@@ -155,7 +155,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0/VDByDf9irl.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0/VDByDf9irl.verified.txt
@@ -134,7 +134,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0/Wwl28QbOnP.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0/Wwl28QbOnP.verified.txt
@@ -155,7 +155,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0/XnTTtRBL3k.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0/XnTTtRBL3k.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0/YTWXXvHTiO.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0/YTWXXvHTiO.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0/ZRJoAqVVvb.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0/ZRJoAqVVvb.verified.txt
@@ -134,7 +134,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0/ZaFOPIWhda.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0/ZaFOPIWhda.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0/dTwZEZeVhu.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0/dTwZEZeVhu.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0/edowZi17Nt.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0/edowZi17Nt.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0/fOa6Y3m3Eu.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0/fOa6Y3m3Eu.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0/pB5AVMQH3t.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0/pB5AVMQH3t.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0/r5vLbt9RKW.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0/r5vLbt9RKW.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0/rfT15swE8e.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0/rfT15swE8e.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0/smbplIhBkI.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0/smbplIhBkI.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0/v7qMYkQ7z4.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0/v7qMYkQ7z4.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0/xdXJVrpdqo.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0/xdXJVrpdqo.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0/xqyVPeg2iw.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0/xqyVPeg2iw.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0/y2FXDfXVGz.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0/y2FXDfXVGz.verified.txt
@@ -218,7 +218,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0/y2hm1XT4Tk.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v6.0/y2hm1XT4Tk.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0-fr/0RqDCSNFog.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0-fr/0RqDCSNFog.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0-fr/8VXB2Ayw8Q.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0-fr/8VXB2Ayw8Q.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0-fr/AjA4jZWDKX.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0-fr/AjA4jZWDKX.verified.txt
@@ -155,7 +155,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0-fr/B9CfOvgNmu.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0-fr/B9CfOvgNmu.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0-fr/IsdKHmH8ZO.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0-fr/IsdKHmH8ZO.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0-fr/KdK6TTDQpk.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0-fr/KdK6TTDQpk.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0-fr/NUHROXiOt9.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0-fr/NUHROXiOt9.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0-fr/PxEFTla44K.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0-fr/PxEFTla44K.verified.txt
@@ -155,7 +155,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0-fr/Q0INojqlts.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0-fr/Q0INojqlts.verified.txt
@@ -134,7 +134,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0-fr/Qjb7OvpJGM.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0-fr/Qjb7OvpJGM.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0-fr/QtdmJ4OCBu.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0-fr/QtdmJ4OCBu.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0-fr/Sg0yhUS3KF.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0-fr/Sg0yhUS3KF.verified.txt
@@ -134,7 +134,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0-fr/SsGgNd5B8V.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0-fr/SsGgNd5B8V.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0-fr/Tw02GMGqV0.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0-fr/Tw02GMGqV0.verified.txt
@@ -155,7 +155,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0-fr/VDByDf9irl.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0-fr/VDByDf9irl.verified.txt
@@ -134,7 +134,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0-fr/Wwl28QbOnP.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0-fr/Wwl28QbOnP.verified.txt
@@ -155,7 +155,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0-fr/XnTTtRBL3k.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0-fr/XnTTtRBL3k.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0-fr/YTWXXvHTiO.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0-fr/YTWXXvHTiO.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0-fr/ZRJoAqVVvb.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0-fr/ZRJoAqVVvb.verified.txt
@@ -134,7 +134,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0-fr/ZaFOPIWhda.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0-fr/ZaFOPIWhda.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0-fr/dTwZEZeVhu.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0-fr/dTwZEZeVhu.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0-fr/edowZi17Nt.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0-fr/edowZi17Nt.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0-fr/fOa6Y3m3Eu.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0-fr/fOa6Y3m3Eu.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0-fr/pB5AVMQH3t.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0-fr/pB5AVMQH3t.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0-fr/r5vLbt9RKW.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0-fr/r5vLbt9RKW.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0-fr/rfT15swE8e.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0-fr/rfT15swE8e.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0-fr/smbplIhBkI.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0-fr/smbplIhBkI.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0-fr/v7qMYkQ7z4.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0-fr/v7qMYkQ7z4.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0-fr/xdXJVrpdqo.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0-fr/xdXJVrpdqo.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0-fr/xqyVPeg2iw.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0-fr/xqyVPeg2iw.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0-fr/y2FXDfXVGz.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0-fr/y2FXDfXVGz.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0-fr/y2hm1XT4Tk.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0-fr/y2hm1XT4Tk.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0/0RqDCSNFog.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0/0RqDCSNFog.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0/8VXB2Ayw8Q.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0/8VXB2Ayw8Q.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0/AjA4jZWDKX.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0/AjA4jZWDKX.verified.txt
@@ -155,7 +155,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0/B9CfOvgNmu.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0/B9CfOvgNmu.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0/InstanceFieldGenerationTests.Instance_names_can_have_reserved_keywords.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0/InstanceFieldGenerationTests.Instance_names_can_have_reserved_keywords.verified.txt
@@ -145,7 +145,7 @@ var validation = CustomerId.validate(value);
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0/IsdKHmH8ZO.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0/IsdKHmH8ZO.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0/KdK6TTDQpk.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0/KdK6TTDQpk.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0/NUHROXiOt9.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0/NUHROXiOt9.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0/PxEFTla44K.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0/PxEFTla44K.verified.txt
@@ -155,7 +155,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0/Q0INojqlts.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0/Q0INojqlts.verified.txt
@@ -134,7 +134,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0/Qjb7OvpJGM.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0/Qjb7OvpJGM.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0/QtdmJ4OCBu.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0/QtdmJ4OCBu.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0/Sg0yhUS3KF.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0/Sg0yhUS3KF.verified.txt
@@ -134,7 +134,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0/SsGgNd5B8V.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0/SsGgNd5B8V.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0/Tw02GMGqV0.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0/Tw02GMGqV0.verified.txt
@@ -155,7 +155,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0/VDByDf9irl.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0/VDByDf9irl.verified.txt
@@ -134,7 +134,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0/Wwl28QbOnP.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0/Wwl28QbOnP.verified.txt
@@ -155,7 +155,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0/XnTTtRBL3k.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0/XnTTtRBL3k.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0/YTWXXvHTiO.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0/YTWXXvHTiO.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0/ZRJoAqVVvb.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0/ZRJoAqVVvb.verified.txt
@@ -134,7 +134,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0/ZaFOPIWhda.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0/ZaFOPIWhda.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0/dTwZEZeVhu.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0/dTwZEZeVhu.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0/edowZi17Nt.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0/edowZi17Nt.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0/fOa6Y3m3Eu.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0/fOa6Y3m3Eu.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0/pB5AVMQH3t.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0/pB5AVMQH3t.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0/r5vLbt9RKW.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0/r5vLbt9RKW.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0/rfT15swE8e.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0/rfT15swE8e.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0/smbplIhBkI.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0/smbplIhBkI.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0/v7qMYkQ7z4.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0/v7qMYkQ7z4.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0/xdXJVrpdqo.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0/xdXJVrpdqo.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0/xqyVPeg2iw.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0/xqyVPeg2iw.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0/y2FXDfXVGz.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0/y2FXDfXVGz.verified.txt
@@ -260,7 +260,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0/y2hm1XT4Tk.verified.txt
+++ b/tests/SnapshotTests/InstanceFields/snapshots/snap-v7.0/y2hm1XT4Tk.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.DateTime.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.DateTime.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.DateTimeOffset.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.DateTimeOffset.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.DateTimeOffset_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.DateTimeOffset_customized.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.DateTime_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.DateTime_customized.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.Guid.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.Guid_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.Guid_customized.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbool.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbool.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbool_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbool_customized.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbyte.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbyte.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbyte_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbyte_customized.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonchar.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonchar.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonchar_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonchar_customized.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondecimal.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondecimal.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondecimal_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondecimal_customized.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondouble.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondouble.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondouble_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondouble_customized.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonfloat.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonfloat.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonfloat_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonfloat_customized.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonint.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonint.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonint_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonint_customized.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonlong.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonlong.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonlong_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonlong_customized.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonshort.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonshort.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonshort_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonshort_customized.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonstring.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonstring_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonstring_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonSystem.DateTime.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonSystem.DateTime.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonSystem.DateTimeOffset.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonSystem.DateTimeOffset.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonSystem.DateTimeOffset_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonSystem.DateTimeOffset_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonSystem.DateTime_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonSystem.DateTime_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonSystem.Guid.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonSystem.Guid_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonSystem.Guid_customized.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonbool.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonbool.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonbool_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonbool_customized.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonbyte.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonbyte.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonbyte_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonbyte_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonchar.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonchar.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonchar_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonchar_customized.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJsondecimal.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJsondecimal.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJsondecimal_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJsondecimal_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJsondouble.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJsondouble.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJsondouble_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJsondouble_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonfloat.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonfloat.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonfloat_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonfloat_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonint.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonint.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonint_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonint_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonlong.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonlong.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonlong_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonlong_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonshort.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonshort.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonshort_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonshort_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonstring.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonstring_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonstring_customized.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NoneSystem.DateTime.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NoneSystem.DateTime.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NoneSystem.DateTimeOffset.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NoneSystem.DateTimeOffset.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NoneSystem.DateTimeOffset_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NoneSystem.DateTimeOffset_customized.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NoneSystem.DateTime_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NoneSystem.DateTime_customized.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NoneSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NoneSystem.Guid.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NoneSystem.Guid_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_NoneSystem.Guid_customized.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_Nonebool.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_Nonebool.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_Nonebool_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_Nonebool_customized.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_Nonebyte.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_Nonebyte.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_Nonebyte_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_Nonebyte_customized.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_Nonechar.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_Nonechar.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_Nonechar_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_Nonechar_customized.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_Nonedecimal.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_Nonedecimal.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_Nonedecimal_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_Nonedecimal_customized.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_Nonedouble.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_Nonedouble.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_Nonedouble_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_Nonedouble_customized.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_Nonefloat.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_Nonefloat.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_Nonefloat_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_Nonefloat_customized.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_Noneint.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_Noneint.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_Noneint_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_Noneint_customized.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_Nonelong.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_Nonelong.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_Nonelong_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_Nonelong_customized.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_Noneshort.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_Noneshort.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_Noneshort_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_Noneshort_customized.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_Nonestring.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_Nonestring.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_Nonestring_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_Nonestring_customized.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_SystemTextJsonSystem.DateTime.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_SystemTextJsonSystem.DateTime.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_SystemTextJsonSystem.DateTimeOffset.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_SystemTextJsonSystem.DateTimeOffset.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_SystemTextJsonSystem.DateTimeOffset_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_SystemTextJsonSystem.DateTimeOffset_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_SystemTextJsonSystem.DateTime_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_SystemTextJsonSystem.DateTime_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_SystemTextJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_SystemTextJsonSystem.Guid.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_SystemTextJsonSystem.Guid_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_SystemTextJsonSystem.Guid_customized.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_SystemTextJsonbool.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_SystemTextJsonbool.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_SystemTextJsonbool_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_SystemTextJsonbool_customized.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_SystemTextJsonbyte.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_SystemTextJsonbyte.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_SystemTextJsonbyte_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_SystemTextJsonbyte_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_SystemTextJsonchar.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_SystemTextJsonchar.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_SystemTextJsonchar_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_SystemTextJsonchar_customized.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_SystemTextJsondecimal.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_SystemTextJsondecimal.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_SystemTextJsondecimal_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_SystemTextJsondecimal_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_SystemTextJsondouble.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_SystemTextJsondouble.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_SystemTextJsondouble_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_SystemTextJsondouble_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_SystemTextJsonfloat.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_SystemTextJsonfloat.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_SystemTextJsonfloat_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_SystemTextJsonfloat_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_SystemTextJsonint.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_SystemTextJsonint.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_SystemTextJsonint_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_SystemTextJsonint_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_SystemTextJsonlong.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_SystemTextJsonlong.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_SystemTextJsonlong_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_SystemTextJsonlong_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_SystemTextJsonshort.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_SystemTextJsonshort.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_SystemTextJsonshort_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_SystemTextJsonshort_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_SystemTextJsonstring.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_SystemTextJsonstring_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_partial_structConversions_SystemTextJsonstring_customized.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.DateTime.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.DateTime.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.DateTimeOffset.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.DateTimeOffset.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.DateTimeOffset_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.DateTimeOffset_customized.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.DateTime_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.DateTime_customized.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.Guid.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.Guid_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.Guid_customized.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbool.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbool.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbool_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbool_customized.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbyte.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbyte.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbyte_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbyte_customized.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonchar.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonchar.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonchar_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonchar_customized.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondecimal.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondecimal.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondecimal_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondecimal_customized.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondouble.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondouble.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondouble_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondouble_customized.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonfloat.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonfloat.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonfloat_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonfloat_customized.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonint.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonint.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonint_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonint_customized.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonlong.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonlong.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonlong_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonlong_customized.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonshort.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonshort.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonshort_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonshort_customized.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonstring.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonstring_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonstring_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonSystem.DateTime.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonSystem.DateTime.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonSystem.DateTimeOffset.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonSystem.DateTimeOffset.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonSystem.DateTimeOffset_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonSystem.DateTimeOffset_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonSystem.DateTime_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonSystem.DateTime_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonSystem.Guid.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonSystem.Guid_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonSystem.Guid_customized.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonbool.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonbool.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonbool_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonbool_customized.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonbyte.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonbyte.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonbyte_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonbyte_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonchar.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonchar.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonchar_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonchar_customized.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsondecimal.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsondecimal.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsondecimal_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsondecimal_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsondouble.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsondouble.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsondouble_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsondouble_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonfloat.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonfloat.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonfloat_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonfloat_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonint.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonint.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonint_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonint_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonlong.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonlong.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonlong_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonlong_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonshort.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonshort.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonshort_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonshort_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonstring.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonstring_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonstring_customized.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NoneSystem.DateTime.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NoneSystem.DateTime.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NoneSystem.DateTimeOffset.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NoneSystem.DateTimeOffset.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NoneSystem.DateTimeOffset_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NoneSystem.DateTimeOffset_customized.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NoneSystem.DateTime_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NoneSystem.DateTime_customized.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NoneSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NoneSystem.Guid.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NoneSystem.Guid_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_NoneSystem.Guid_customized.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_Nonebool.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_Nonebool.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_Nonebool_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_Nonebool_customized.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_Nonebyte.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_Nonebyte.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_Nonebyte_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_Nonebyte_customized.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_Nonechar.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_Nonechar.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_Nonechar_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_Nonechar_customized.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_Nonedecimal.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_Nonedecimal.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_Nonedecimal_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_Nonedecimal_customized.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_Nonedouble.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_Nonedouble.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_Nonedouble_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_Nonedouble_customized.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_Nonefloat.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_Nonefloat.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_Nonefloat_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_Nonefloat_customized.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_Noneint.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_Noneint.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_Noneint_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_Noneint_customized.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_Nonelong.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_Nonelong.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_Nonelong_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_Nonelong_customized.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_Noneshort.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_Noneshort.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_Noneshort_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_Noneshort_customized.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_Nonestring.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_Nonestring.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_Nonestring_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_Nonestring_customized.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonSystem.DateTime.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonSystem.DateTime.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonSystem.DateTimeOffset.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonSystem.DateTimeOffset.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonSystem.DateTimeOffset_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonSystem.DateTimeOffset_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonSystem.DateTime_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonSystem.DateTime_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonSystem.Guid.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonSystem.Guid_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonSystem.Guid_customized.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonbool.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonbool.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonbool_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonbool_customized.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonbyte.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonbyte.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonbyte_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonbyte_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonchar.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonchar.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonchar_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonchar_customized.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsondecimal.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsondecimal.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsondecimal_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsondecimal_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsondouble.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsondouble.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsondouble_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsondouble_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonfloat.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonfloat.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonfloat_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonfloat_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonint.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonint.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonint_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonint_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonlong.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonlong.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonlong_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonlong_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonshort.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonshort.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonshort_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonshort_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonstring.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonstring_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v3.1/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonstring_customized.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.DateTime.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.DateTime.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.DateTimeOffset.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.DateTimeOffset.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.DateTimeOffset_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.DateTimeOffset_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.DateTime_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.DateTime_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.Guid.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.Guid_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.Guid_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbool.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbool.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbool_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbool_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbyte.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbyte.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbyte_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbyte_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonchar.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonchar.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonchar_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonchar_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondecimal.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondecimal.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondecimal_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondecimal_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondouble.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondouble.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondouble_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondouble_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonfloat.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonfloat.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonfloat_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonfloat_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonint.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonint.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonint_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonint_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonlong.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonlong.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonlong_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonlong_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonshort.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonshort.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonshort_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonshort_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonstring.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonstring_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonstring_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonSystem.DateTime.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonSystem.DateTime.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonSystem.DateTimeOffset.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonSystem.DateTimeOffset.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonSystem.DateTimeOffset_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonSystem.DateTimeOffset_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonSystem.DateTime_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonSystem.DateTime_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonSystem.Guid.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonSystem.Guid_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonSystem.Guid_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonbool.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonbool.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonbool_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonbool_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonbyte.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonbyte.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonbyte_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonbyte_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonchar.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonchar.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonchar_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonchar_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJsondecimal.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJsondecimal.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJsondecimal_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJsondecimal_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJsondouble.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJsondouble.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJsondouble_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJsondouble_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonfloat.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonfloat.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonfloat_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonfloat_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonint.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonint.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonint_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonint_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonlong.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonlong.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonlong_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonlong_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonshort.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonshort.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonshort_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonshort_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonstring.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonstring_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonstring_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NoneSystem.DateTime.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NoneSystem.DateTime.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NoneSystem.DateTimeOffset.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NoneSystem.DateTimeOffset.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NoneSystem.DateTimeOffset_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NoneSystem.DateTimeOffset_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NoneSystem.DateTime_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NoneSystem.DateTime_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NoneSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NoneSystem.Guid.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NoneSystem.Guid_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_NoneSystem.Guid_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_Nonebool.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_Nonebool.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_Nonebool_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_Nonebool_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_Nonebyte.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_Nonebyte.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_Nonebyte_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_Nonebyte_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_Nonechar.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_Nonechar.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_Nonechar_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_Nonechar_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_Nonedecimal.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_Nonedecimal.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_Nonedecimal_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_Nonedecimal_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_Nonedouble.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_Nonedouble.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_Nonedouble_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_Nonedouble_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_Nonefloat.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_Nonefloat.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_Nonefloat_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_Nonefloat_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_Noneint.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_Noneint.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_Noneint_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_Noneint_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_Nonelong.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_Nonelong.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_Nonelong_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_Nonelong_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_Noneshort.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_Noneshort.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_Noneshort_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_Noneshort_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_Nonestring.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_Nonestring.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_Nonestring_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_Nonestring_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_SystemTextJsonSystem.DateTime.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_SystemTextJsonSystem.DateTime.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_SystemTextJsonSystem.DateTimeOffset.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_SystemTextJsonSystem.DateTimeOffset.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_SystemTextJsonSystem.DateTimeOffset_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_SystemTextJsonSystem.DateTimeOffset_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_SystemTextJsonSystem.DateTime_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_SystemTextJsonSystem.DateTime_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_SystemTextJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_SystemTextJsonSystem.Guid.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_SystemTextJsonSystem.Guid_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_SystemTextJsonSystem.Guid_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_SystemTextJsonbool.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_SystemTextJsonbool.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_SystemTextJsonbool_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_SystemTextJsonbool_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_SystemTextJsonbyte.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_SystemTextJsonbyte.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_SystemTextJsonbyte_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_SystemTextJsonbyte_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_SystemTextJsonchar.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_SystemTextJsonchar.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_SystemTextJsonchar_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_SystemTextJsonchar_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_SystemTextJsondecimal.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_SystemTextJsondecimal.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_SystemTextJsondecimal_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_SystemTextJsondecimal_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_SystemTextJsondouble.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_SystemTextJsondouble.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_SystemTextJsondouble_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_SystemTextJsondouble_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_SystemTextJsonfloat.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_SystemTextJsonfloat.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_SystemTextJsonfloat_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_SystemTextJsonfloat_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_SystemTextJsonint.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_SystemTextJsonint.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_SystemTextJsonint_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_SystemTextJsonint_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_SystemTextJsonlong.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_SystemTextJsonlong.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_SystemTextJsonlong_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_SystemTextJsonlong_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_SystemTextJsonshort.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_SystemTextJsonshort.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_SystemTextJsonshort_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_SystemTextJsonshort_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_SystemTextJsonstring.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_SystemTextJsonstring_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_partial_structConversions_SystemTextJsonstring_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.DateTime.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.DateTime.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.DateTimeOffset.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.DateTimeOffset.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.DateTimeOffset_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.DateTimeOffset_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.DateTime_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.DateTime_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.Guid.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.Guid_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.Guid_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbool.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbool.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbool_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbool_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbyte.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbyte.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbyte_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbyte_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonchar.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonchar.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonchar_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonchar_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondecimal.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondecimal.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondecimal_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondecimal_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondouble.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondouble.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondouble_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondouble_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonfloat.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonfloat.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonfloat_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonfloat_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonint.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonint.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonint_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonint_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonlong.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonlong.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonlong_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonlong_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonshort.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonshort.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonshort_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonshort_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonstring.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonstring_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonstring_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonSystem.DateTime.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonSystem.DateTime.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonSystem.DateTimeOffset.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonSystem.DateTimeOffset.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonSystem.DateTimeOffset_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonSystem.DateTimeOffset_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonSystem.DateTime_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonSystem.DateTime_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonSystem.Guid.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonSystem.Guid_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonSystem.Guid_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonbool.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonbool.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonbool_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonbool_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonbyte.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonbyte.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonbyte_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonbyte_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonchar.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonchar.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonchar_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonchar_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsondecimal.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsondecimal.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsondecimal_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsondecimal_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsondouble.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsondouble.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsondouble_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsondouble_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonfloat.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonfloat.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonfloat_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonfloat_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonint.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonint.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonint_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonint_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonlong.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonlong.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonlong_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonlong_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonshort.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonshort.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonshort_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonshort_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonstring.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonstring_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonstring_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NoneSystem.DateTime.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NoneSystem.DateTime.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NoneSystem.DateTimeOffset.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NoneSystem.DateTimeOffset.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NoneSystem.DateTimeOffset_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NoneSystem.DateTimeOffset_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NoneSystem.DateTime_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NoneSystem.DateTime_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NoneSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NoneSystem.Guid.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NoneSystem.Guid_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_NoneSystem.Guid_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_Nonebool.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_Nonebool.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_Nonebool_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_Nonebool_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_Nonebyte.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_Nonebyte.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_Nonebyte_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_Nonebyte_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_Nonechar.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_Nonechar.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_Nonechar_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_Nonechar_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_Nonedecimal.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_Nonedecimal.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_Nonedecimal_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_Nonedecimal_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_Nonedouble.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_Nonedouble.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_Nonedouble_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_Nonedouble_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_Nonefloat.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_Nonefloat.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_Nonefloat_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_Nonefloat_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_Noneint.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_Noneint.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_Noneint_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_Noneint_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_Nonelong.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_Nonelong.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_Nonelong_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_Nonelong_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_Noneshort.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_Noneshort.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_Noneshort_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_Noneshort_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_Nonestring.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_Nonestring.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_Nonestring_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_Nonestring_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonSystem.DateTime.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonSystem.DateTime.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonSystem.DateTimeOffset.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonSystem.DateTimeOffset.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonSystem.DateTimeOffset_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonSystem.DateTimeOffset_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonSystem.DateTime_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonSystem.DateTime_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonSystem.Guid.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonSystem.Guid_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonSystem.Guid_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonbool.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonbool.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonbool_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonbool_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonbyte.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonbyte.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonbyte_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonbyte_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonchar.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonchar.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonchar_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonchar_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsondecimal.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsondecimal.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsondecimal_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsondecimal_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsondouble.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsondouble.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsondouble_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsondouble_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonfloat.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonfloat.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonfloat_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonfloat_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonint.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonint.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonint_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonint_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonlong.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonlong.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonlong_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonlong_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonshort.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonshort.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonshort_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonshort_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonstring.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonstring_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.6.1/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonstring_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.DateTime.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.DateTime.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.DateTimeOffset.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.DateTimeOffset.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.DateTimeOffset_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.DateTimeOffset_customized.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.DateTime_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.DateTime_customized.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.Guid.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.Guid_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.Guid_customized.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbool.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbool.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbool_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbool_customized.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbyte.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbyte.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbyte_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbyte_customized.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonchar.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonchar.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonchar_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonchar_customized.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondecimal.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondecimal.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondecimal_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondecimal_customized.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondouble.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondouble.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondouble_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondouble_customized.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonfloat.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonfloat.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonfloat_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonfloat_customized.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonint.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonint.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonint_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonint_customized.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonlong.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonlong.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonlong_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonlong_customized.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonshort.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonshort.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonshort_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonshort_customized.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonstring.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonstring_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonstring_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonSystem.DateTime.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonSystem.DateTime.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonSystem.DateTimeOffset.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonSystem.DateTimeOffset.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonSystem.DateTimeOffset_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonSystem.DateTimeOffset_customized.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonSystem.DateTime_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonSystem.DateTime_customized.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonSystem.Guid.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonSystem.Guid_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonSystem.Guid_customized.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonbool.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonbool.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonbool_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonbool_customized.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonbyte.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonbyte.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonbyte_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonbyte_customized.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonchar.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonchar.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonchar_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonchar_customized.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NewtonsoftJsondecimal.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NewtonsoftJsondecimal.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NewtonsoftJsondecimal_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NewtonsoftJsondecimal_customized.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NewtonsoftJsondouble.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NewtonsoftJsondouble.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NewtonsoftJsondouble_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NewtonsoftJsondouble_customized.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonfloat.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonfloat.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonfloat_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonfloat_customized.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonint.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonint.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonint_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonint_customized.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonlong.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonlong.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonlong_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonlong_customized.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonshort.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonshort.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonshort_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonshort_customized.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonstring.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonstring_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonstring_customized.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NoneSystem.DateTime.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NoneSystem.DateTime.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NoneSystem.DateTimeOffset.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NoneSystem.DateTimeOffset.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NoneSystem.DateTimeOffset_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NoneSystem.DateTimeOffset_customized.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NoneSystem.DateTime_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NoneSystem.DateTime_customized.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NoneSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NoneSystem.Guid.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NoneSystem.Guid_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_NoneSystem.Guid_customized.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_Nonebool.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_Nonebool.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_Nonebool_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_Nonebool_customized.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_Nonebyte.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_Nonebyte.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_Nonebyte_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_Nonebyte_customized.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_Nonechar.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_Nonechar.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_Nonechar_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_Nonechar_customized.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_Nonedecimal.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_Nonedecimal.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_Nonedecimal_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_Nonedecimal_customized.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_Nonedouble.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_Nonedouble.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_Nonedouble_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_Nonedouble_customized.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_Nonefloat.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_Nonefloat.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_Nonefloat_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_Nonefloat_customized.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_Noneint.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_Noneint.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_Noneint_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_Noneint_customized.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_Nonelong.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_Nonelong.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_Nonelong_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_Nonelong_customized.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_Noneshort.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_Noneshort.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_Noneshort_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_Noneshort_customized.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_Nonestring.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_Nonestring.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_Nonestring_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_Nonestring_customized.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_SystemTextJsonSystem.DateTime.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_SystemTextJsonSystem.DateTime.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_SystemTextJsonSystem.DateTimeOffset.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_SystemTextJsonSystem.DateTimeOffset.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_SystemTextJsonSystem.DateTimeOffset_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_SystemTextJsonSystem.DateTimeOffset_customized.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_SystemTextJsonSystem.DateTime_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_SystemTextJsonSystem.DateTime_customized.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_SystemTextJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_SystemTextJsonSystem.Guid.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_SystemTextJsonSystem.Guid_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_SystemTextJsonSystem.Guid_customized.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_SystemTextJsonbool.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_SystemTextJsonbool.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_SystemTextJsonbool_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_SystemTextJsonbool_customized.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_SystemTextJsonbyte.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_SystemTextJsonbyte.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_SystemTextJsonbyte_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_SystemTextJsonbyte_customized.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_SystemTextJsonchar.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_SystemTextJsonchar.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_SystemTextJsonchar_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_SystemTextJsonchar_customized.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_SystemTextJsondecimal.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_SystemTextJsondecimal.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_SystemTextJsondecimal_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_SystemTextJsondecimal_customized.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_SystemTextJsondouble.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_SystemTextJsondouble.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_SystemTextJsondouble_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_SystemTextJsondouble_customized.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_SystemTextJsonfloat.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_SystemTextJsonfloat.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_SystemTextJsonfloat_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_SystemTextJsonfloat_customized.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_SystemTextJsonint.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_SystemTextJsonint.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_SystemTextJsonint_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_SystemTextJsonint_customized.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_SystemTextJsonlong.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_SystemTextJsonlong.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_SystemTextJsonlong_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_SystemTextJsonlong_customized.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_SystemTextJsonshort.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_SystemTextJsonshort.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_SystemTextJsonshort_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_SystemTextJsonshort_customized.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_SystemTextJsonstring.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_SystemTextJsonstring_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_partial_structConversions_SystemTextJsonstring_customized.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.DateTime.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.DateTime.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.DateTimeOffset.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.DateTimeOffset.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.DateTimeOffset_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.DateTimeOffset_customized.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.DateTime_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.DateTime_customized.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.Guid.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.Guid_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.Guid_customized.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbool.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbool.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbool_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbool_customized.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbyte.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbyte.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbyte_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbyte_customized.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonchar.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonchar.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonchar_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonchar_customized.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondecimal.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondecimal.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondecimal_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondecimal_customized.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondouble.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondouble.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondouble_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondouble_customized.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonfloat.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonfloat.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonfloat_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonfloat_customized.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonint.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonint.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonint_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonint_customized.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonlong.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonlong.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonlong_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonlong_customized.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonshort.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonshort.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonshort_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonshort_customized.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonstring.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonstring_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonstring_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonSystem.DateTime.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonSystem.DateTime.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonSystem.DateTimeOffset.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonSystem.DateTimeOffset.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonSystem.DateTimeOffset_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonSystem.DateTimeOffset_customized.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonSystem.DateTime_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonSystem.DateTime_customized.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonSystem.Guid.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonSystem.Guid_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonSystem.Guid_customized.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonbool.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonbool.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonbool_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonbool_customized.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonbyte.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonbyte.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonbyte_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonbyte_customized.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonchar.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonchar.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonchar_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonchar_customized.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsondecimal.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsondecimal.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsondecimal_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsondecimal_customized.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsondouble.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsondouble.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsondouble_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsondouble_customized.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonfloat.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonfloat.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonfloat_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonfloat_customized.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonint.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonint.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonint_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonint_customized.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonlong.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonlong.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonlong_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonlong_customized.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonshort.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonshort.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonshort_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonshort_customized.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonstring.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonstring_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonstring_customized.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NoneSystem.DateTime.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NoneSystem.DateTime.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NoneSystem.DateTimeOffset.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NoneSystem.DateTimeOffset.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NoneSystem.DateTimeOffset_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NoneSystem.DateTimeOffset_customized.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NoneSystem.DateTime_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NoneSystem.DateTime_customized.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NoneSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NoneSystem.Guid.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NoneSystem.Guid_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_NoneSystem.Guid_customized.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_Nonebool.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_Nonebool.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_Nonebool_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_Nonebool_customized.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_Nonebyte.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_Nonebyte.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_Nonebyte_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_Nonebyte_customized.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_Nonechar.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_Nonechar.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_Nonechar_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_Nonechar_customized.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_Nonedecimal.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_Nonedecimal.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_Nonedecimal_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_Nonedecimal_customized.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_Nonedouble.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_Nonedouble.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_Nonedouble_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_Nonedouble_customized.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_Nonefloat.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_Nonefloat.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_Nonefloat_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_Nonefloat_customized.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_Noneint.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_Noneint.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_Noneint_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_Noneint_customized.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_Nonelong.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_Nonelong.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_Nonelong_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_Nonelong_customized.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_Noneshort.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_Noneshort.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_Noneshort_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_Noneshort_customized.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_Nonestring.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_Nonestring.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_Nonestring_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_Nonestring_customized.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonSystem.DateTime.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonSystem.DateTime.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonSystem.DateTimeOffset.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonSystem.DateTimeOffset.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonSystem.DateTimeOffset_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonSystem.DateTimeOffset_customized.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonSystem.DateTime_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonSystem.DateTime_customized.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonSystem.Guid.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonSystem.Guid_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonSystem.Guid_customized.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonbool.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonbool.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonbool_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonbool_customized.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonbyte.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonbyte.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonbyte_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonbyte_customized.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonchar.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonchar.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonchar_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonchar_customized.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsondecimal.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsondecimal.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsondecimal_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsondecimal_customized.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsondouble.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsondouble.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsondouble_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsondouble_customized.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonfloat.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonfloat.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonfloat_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonfloat_customized.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonint.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonint.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonint_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonint_customized.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonlong.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonlong.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonlong_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonlong_customized.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonshort.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonshort.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonshort_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonshort_customized.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonstring.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonstring_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v4.8/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonstring_customized.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.DateTime.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.DateTime.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.DateTimeOffset.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.DateTimeOffset.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.DateTimeOffset_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.DateTimeOffset_customized.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.DateTime_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.DateTime_customized.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.Guid.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.Guid_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.Guid_customized.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbool.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbool.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbool_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbool_customized.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbyte.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbyte.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbyte_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbyte_customized.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonchar.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonchar.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonchar_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonchar_customized.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondecimal.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondecimal.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondecimal_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondecimal_customized.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondouble.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondouble.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondouble_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondouble_customized.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonfloat.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonfloat.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonfloat_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonfloat_customized.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonint.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonint.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonint_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonint_customized.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonlong.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonlong.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonlong_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonlong_customized.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonshort.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonshort.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonshort_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonshort_customized.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonstring.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonstring_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonstring_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonSystem.DateTime.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonSystem.DateTime.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonSystem.DateTimeOffset.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonSystem.DateTimeOffset.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonSystem.DateTimeOffset_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonSystem.DateTimeOffset_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonSystem.DateTime_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonSystem.DateTime_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonSystem.Guid.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonSystem.Guid_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonSystem.Guid_customized.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonbool.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonbool.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonbool_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonbool_customized.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonbyte.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonbyte.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonbyte_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonbyte_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonchar.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonchar.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonchar_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonchar_customized.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsondecimal.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsondecimal.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsondecimal_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsondecimal_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsondouble.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsondouble.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsondouble_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsondouble_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonfloat.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonfloat.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonfloat_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonfloat_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonint.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonint.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonint_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonint_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonlong.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonlong.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonlong_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonlong_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonshort.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonshort.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonshort_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonshort_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonstring.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonstring_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonstring_customized.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NoneSystem.DateTime.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NoneSystem.DateTime.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NoneSystem.DateTimeOffset.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NoneSystem.DateTimeOffset.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NoneSystem.DateTimeOffset_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NoneSystem.DateTimeOffset_customized.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NoneSystem.DateTime_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NoneSystem.DateTime_customized.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NoneSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NoneSystem.Guid.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NoneSystem.Guid_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_NoneSystem.Guid_customized.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_Nonebool.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_Nonebool.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_Nonebool_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_Nonebool_customized.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_Nonebyte.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_Nonebyte.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_Nonebyte_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_Nonebyte_customized.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_Nonechar.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_Nonechar.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_Nonechar_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_Nonechar_customized.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_Nonedecimal.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_Nonedecimal.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_Nonedecimal_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_Nonedecimal_customized.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_Nonedouble.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_Nonedouble.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_Nonedouble_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_Nonedouble_customized.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_Nonefloat.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_Nonefloat.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_Nonefloat_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_Nonefloat_customized.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_Noneint.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_Noneint.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_Noneint_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_Noneint_customized.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_Nonelong.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_Nonelong.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_Nonelong_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_Nonelong_customized.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_Noneshort.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_Noneshort.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_Noneshort_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_Noneshort_customized.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_Nonestring.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_Nonestring.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_Nonestring_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_Nonestring_customized.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonSystem.DateTime.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonSystem.DateTime.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonSystem.DateTimeOffset.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonSystem.DateTimeOffset.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonSystem.DateTimeOffset_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonSystem.DateTimeOffset_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonSystem.DateTime_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonSystem.DateTime_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonSystem.Guid.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonSystem.Guid_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonSystem.Guid_customized.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonbool.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonbool.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonbool_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonbool_customized.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonbyte.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonbyte.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonbyte_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonbyte_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonchar.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonchar.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonchar_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonchar_customized.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_SystemTextJsondecimal.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_SystemTextJsondecimal.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_SystemTextJsondecimal_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_SystemTextJsondecimal_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_SystemTextJsondouble.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_SystemTextJsondouble.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_SystemTextJsondouble_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_SystemTextJsondouble_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonfloat.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonfloat.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonfloat_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonfloat_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonint.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonint.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonint_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonint_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonlong.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonlong.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonlong_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonlong_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonshort.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonshort.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonshort_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonshort_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonstring.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonstring_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonstring_customized.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.DateTime.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.DateTime.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.DateTimeOffset.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.DateTimeOffset.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.DateTimeOffset_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.DateTimeOffset_customized.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.DateTime_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.DateTime_customized.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.Guid.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.Guid_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.Guid_customized.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbool.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbool.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbool_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbool_customized.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbyte.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbyte.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbyte_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbyte_customized.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonchar.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonchar.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonchar_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonchar_customized.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondecimal.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondecimal.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondecimal_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondecimal_customized.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondouble.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondouble.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondouble_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondouble_customized.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonfloat.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonfloat.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonfloat_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonfloat_customized.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonint.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonint.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonint_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonint_customized.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonlong.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonlong.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonlong_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonlong_customized.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonshort.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonshort.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonshort_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonshort_customized.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonstring.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonstring_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonstring_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonSystem.DateTime.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonSystem.DateTime.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonSystem.DateTimeOffset.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonSystem.DateTimeOffset.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonSystem.DateTimeOffset_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonSystem.DateTimeOffset_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonSystem.DateTime_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonSystem.DateTime_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonSystem.Guid.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonSystem.Guid_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonSystem.Guid_customized.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonbool.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonbool.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonbool_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonbool_customized.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonbyte.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonbyte.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonbyte_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonbyte_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonchar.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonchar.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonchar_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonchar_customized.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsondecimal.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsondecimal.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsondecimal_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsondecimal_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsondouble.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsondouble.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsondouble_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsondouble_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonfloat.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonfloat.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonfloat_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonfloat_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonint.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonint.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonint_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonint_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonlong.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonlong.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonlong_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonlong_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonshort.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonshort.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonshort_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonshort_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonstring.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonstring_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonstring_customized.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NoneSystem.DateTime.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NoneSystem.DateTime.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NoneSystem.DateTimeOffset.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NoneSystem.DateTimeOffset.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NoneSystem.DateTimeOffset_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NoneSystem.DateTimeOffset_customized.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NoneSystem.DateTime_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NoneSystem.DateTime_customized.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NoneSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NoneSystem.Guid.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NoneSystem.Guid_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_NoneSystem.Guid_customized.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_Nonebool.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_Nonebool.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_Nonebool_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_Nonebool_customized.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_Nonebyte.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_Nonebyte.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_Nonebyte_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_Nonebyte_customized.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_Nonechar.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_Nonechar.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_Nonechar_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_Nonechar_customized.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_Nonedecimal.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_Nonedecimal.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_Nonedecimal_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_Nonedecimal_customized.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_Nonedouble.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_Nonedouble.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_Nonedouble_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_Nonedouble_customized.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_Nonefloat.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_Nonefloat.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_Nonefloat_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_Nonefloat_customized.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_Noneint.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_Noneint.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_Noneint_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_Noneint_customized.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_Nonelong.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_Nonelong.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_Nonelong_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_Nonelong_customized.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_Noneshort.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_Noneshort.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_Noneshort_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_Noneshort_customized.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_Nonestring.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_Nonestring.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_Nonestring_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_Nonestring_customized.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonSystem.DateTime.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonSystem.DateTime.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonSystem.DateTimeOffset.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonSystem.DateTimeOffset.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonSystem.DateTimeOffset_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonSystem.DateTimeOffset_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonSystem.DateTime_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonSystem.DateTime_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonSystem.Guid.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonSystem.Guid_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonSystem.Guid_customized.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonbool.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonbool.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonbool_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonbool_customized.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonbyte.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonbyte.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonbyte_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonbyte_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonchar.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonchar.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonchar_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonchar_customized.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsondecimal.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsondecimal.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsondecimal_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsondecimal_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsondouble.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsondouble.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsondouble_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsondouble_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonfloat.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonfloat.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonfloat_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonfloat_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonint.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonint.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonint_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonint_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonlong.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonlong.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonlong_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonlong_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonshort.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonshort.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonshort_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonshort_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonstring.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonstring_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v5.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonstring_customized.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.DateTime.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.DateTime.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.DateTimeOffset.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.DateTimeOffset.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.DateTimeOffset_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.DateTimeOffset_customized.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.DateTime_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.DateTime_customized.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.Guid.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.Guid_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.Guid_customized.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbool.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbool.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbool_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbool_customized.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbyte.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbyte.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbyte_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbyte_customized.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonchar.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonchar.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonchar_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonchar_customized.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondecimal.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondecimal.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondecimal_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondecimal_customized.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondouble.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondouble.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondouble_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondouble_customized.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonfloat.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonfloat.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonfloat_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonfloat_customized.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonint.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonint.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonint_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonint_customized.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonlong.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonlong.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonlong_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonlong_customized.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonshort.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonshort.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonshort_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonshort_customized.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonstring.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonstring_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonstring_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonSystem.DateTime.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonSystem.DateTime.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonSystem.DateTimeOffset.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonSystem.DateTimeOffset.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonSystem.DateTimeOffset_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonSystem.DateTimeOffset_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonSystem.DateTime_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonSystem.DateTime_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonSystem.Guid.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonSystem.Guid_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonSystem.Guid_customized.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonbool.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonbool.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonbool_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonbool_customized.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonbyte.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonbyte.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonbyte_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonbyte_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonchar.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonchar.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonchar_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonchar_customized.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsondecimal.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsondecimal.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsondecimal_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsondecimal_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsondouble.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsondouble.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsondouble_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsondouble_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonfloat.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonfloat.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonfloat_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonfloat_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonint.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonint.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonint_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonint_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonlong.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonlong.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonlong_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonlong_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonshort.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonshort.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonshort_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonshort_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonstring.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonstring_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonstring_customized.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NoneSystem.DateTime.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NoneSystem.DateTime.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NoneSystem.DateTimeOffset.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NoneSystem.DateTimeOffset.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NoneSystem.DateTimeOffset_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NoneSystem.DateTimeOffset_customized.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NoneSystem.DateTime_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NoneSystem.DateTime_customized.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NoneSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NoneSystem.Guid.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NoneSystem.Guid_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_NoneSystem.Guid_customized.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_Nonebool.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_Nonebool.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_Nonebool_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_Nonebool_customized.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_Nonebyte.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_Nonebyte.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_Nonebyte_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_Nonebyte_customized.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_Nonechar.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_Nonechar.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_Nonechar_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_Nonechar_customized.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_Nonedecimal.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_Nonedecimal.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_Nonedecimal_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_Nonedecimal_customized.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_Nonedouble.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_Nonedouble.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_Nonedouble_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_Nonedouble_customized.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_Nonefloat.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_Nonefloat.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_Nonefloat_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_Nonefloat_customized.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_Noneint.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_Noneint.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_Noneint_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_Noneint_customized.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_Nonelong.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_Nonelong.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_Nonelong_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_Nonelong_customized.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_Noneshort.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_Noneshort.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_Noneshort_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_Noneshort_customized.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_Nonestring.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_Nonestring.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_Nonestring_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_Nonestring_customized.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonSystem.DateTime.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonSystem.DateTime.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonSystem.DateTimeOffset.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonSystem.DateTimeOffset.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonSystem.DateTimeOffset_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonSystem.DateTimeOffset_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonSystem.DateTime_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonSystem.DateTime_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonSystem.Guid.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonSystem.Guid_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonSystem.Guid_customized.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonbool.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonbool.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonbool_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonbool_customized.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonbyte.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonbyte.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonbyte_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonbyte_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonchar.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonchar.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonchar_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonchar_customized.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_SystemTextJsondecimal.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_SystemTextJsondecimal.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_SystemTextJsondecimal_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_SystemTextJsondecimal_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_SystemTextJsondouble.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_SystemTextJsondouble.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_SystemTextJsondouble_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_SystemTextJsondouble_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonfloat.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonfloat.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonfloat_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonfloat_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonint.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonint.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonint_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonint_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonlong.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonlong.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonlong_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonlong_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonshort.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonshort.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonshort_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonshort_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonstring.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonstring_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonstring_customized.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.DateTime.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.DateTime.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.DateTimeOffset.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.DateTimeOffset.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.DateTimeOffset_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.DateTimeOffset_customized.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.DateTime_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.DateTime_customized.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.Guid.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.Guid_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.Guid_customized.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbool.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbool.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbool_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbool_customized.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbyte.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbyte.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbyte_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbyte_customized.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonchar.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonchar.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonchar_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonchar_customized.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondecimal.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondecimal.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondecimal_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondecimal_customized.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondouble.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondouble.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondouble_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondouble_customized.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonfloat.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonfloat.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonfloat_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonfloat_customized.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonint.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonint.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonint_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonint_customized.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonlong.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonlong.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonlong_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonlong_customized.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonshort.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonshort.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonshort_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonshort_customized.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonstring.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonstring_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonstring_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonSystem.DateTime.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonSystem.DateTime.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonSystem.DateTimeOffset.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonSystem.DateTimeOffset.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonSystem.DateTimeOffset_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonSystem.DateTimeOffset_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonSystem.DateTime_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonSystem.DateTime_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonSystem.Guid.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonSystem.Guid_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonSystem.Guid_customized.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonbool.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonbool.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonbool_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonbool_customized.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonbyte.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonbyte.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonbyte_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonbyte_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonchar.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonchar.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonchar_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonchar_customized.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsondecimal.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsondecimal.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsondecimal_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsondecimal_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsondouble.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsondouble.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsondouble_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsondouble_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonfloat.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonfloat.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonfloat_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonfloat_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonint.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonint.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonint_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonint_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonlong.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonlong.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonlong_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonlong_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonshort.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonshort.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonshort_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonshort_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonstring.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonstring_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonstring_customized.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NoneSystem.DateTime.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NoneSystem.DateTime.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NoneSystem.DateTimeOffset.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NoneSystem.DateTimeOffset.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NoneSystem.DateTimeOffset_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NoneSystem.DateTimeOffset_customized.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NoneSystem.DateTime_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NoneSystem.DateTime_customized.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NoneSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NoneSystem.Guid.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NoneSystem.Guid_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_NoneSystem.Guid_customized.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_Nonebool.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_Nonebool.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_Nonebool_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_Nonebool_customized.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_Nonebyte.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_Nonebyte.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_Nonebyte_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_Nonebyte_customized.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_Nonechar.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_Nonechar.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_Nonechar_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_Nonechar_customized.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_Nonedecimal.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_Nonedecimal.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_Nonedecimal_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_Nonedecimal_customized.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_Nonedouble.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_Nonedouble.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_Nonedouble_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_Nonedouble_customized.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_Nonefloat.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_Nonefloat.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_Nonefloat_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_Nonefloat_customized.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_Noneint.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_Noneint.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_Noneint_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_Noneint_customized.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_Nonelong.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_Nonelong.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_Nonelong_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_Nonelong_customized.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_Noneshort.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_Noneshort.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_Noneshort_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_Noneshort_customized.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_Nonestring.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_Nonestring.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_Nonestring_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_Nonestring_customized.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonSystem.DateTime.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonSystem.DateTime.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonSystem.DateTimeOffset.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonSystem.DateTimeOffset.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonSystem.DateTimeOffset_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonSystem.DateTimeOffset_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonSystem.DateTime_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonSystem.DateTime_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonSystem.Guid.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonSystem.Guid_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonSystem.Guid_customized.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonbool.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonbool.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonbool_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonbool_customized.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonbyte.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonbyte.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonbyte_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonbyte_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonchar.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonchar.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonchar_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonchar_customized.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsondecimal.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsondecimal.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsondecimal_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsondecimal_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsondouble.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsondouble.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsondouble_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsondouble_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonfloat.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonfloat.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonfloat_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonfloat_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonint.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonint.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonint_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonint_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonlong.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonlong.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonlong_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonlong_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonshort.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonshort.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonshort_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonshort_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonstring.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonstring_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v6.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonstring_customized.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.DateTime.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.DateTime.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.DateTimeOffset.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.DateTimeOffset.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.DateTimeOffset_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.DateTimeOffset_customized.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.DateTime_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.DateTime_customized.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.Guid.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.Guid_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.Guid_customized.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbool.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbool.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbool_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbool_customized.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbyte.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbyte.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbyte_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbyte_customized.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonchar.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonchar.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonchar_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonchar_customized.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondecimal.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondecimal.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondecimal_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondecimal_customized.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondouble.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondouble.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondouble_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondouble_customized.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonfloat.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonfloat.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonfloat_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonfloat_customized.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonint.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonint.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonint_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonint_customized.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonlong.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonlong.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonlong_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonlong_customized.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonshort.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonshort.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonshort_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonshort_customized.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonstring.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonstring_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonstring_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonSystem.DateTime.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonSystem.DateTime.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonSystem.DateTimeOffset.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonSystem.DateTimeOffset.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonSystem.DateTimeOffset_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonSystem.DateTimeOffset_customized.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonSystem.DateTime_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonSystem.DateTime_customized.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonSystem.Guid.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonSystem.Guid_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonSystem.Guid_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonbool.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonbool.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonbool_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonbool_customized.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonbyte.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonbyte.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonbyte_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonbyte_customized.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonchar.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonchar.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonchar_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonchar_customized.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsondecimal.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsondecimal.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsondecimal_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsondecimal_customized.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsondouble.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsondouble.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsondouble_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsondouble_customized.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonfloat.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonfloat.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonfloat_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonfloat_customized.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonint.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonint.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonint_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonint_customized.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonlong.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonlong.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonlong_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonlong_customized.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonshort.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonshort.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonshort_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonshort_customized.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonstring.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonstring_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NewtonsoftJsonstring_customized.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NoneSystem.DateTime.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NoneSystem.DateTime.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NoneSystem.DateTimeOffset.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NoneSystem.DateTimeOffset.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NoneSystem.DateTimeOffset_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NoneSystem.DateTimeOffset_customized.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NoneSystem.DateTime_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NoneSystem.DateTime_customized.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NoneSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NoneSystem.Guid.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NoneSystem.Guid_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_NoneSystem.Guid_customized.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_Nonebool.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_Nonebool.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_Nonebool_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_Nonebool_customized.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_Nonebyte.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_Nonebyte.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_Nonebyte_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_Nonebyte_customized.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_Nonechar.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_Nonechar.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_Nonechar_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_Nonechar_customized.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_Nonedecimal.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_Nonedecimal.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_Nonedecimal_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_Nonedecimal_customized.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_Nonedouble.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_Nonedouble.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_Nonedouble_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_Nonedouble_customized.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_Nonefloat.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_Nonefloat.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_Nonefloat_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_Nonefloat_customized.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_Noneint.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_Noneint.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_Noneint_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_Noneint_customized.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_Nonelong.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_Nonelong.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_Nonelong_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_Nonelong_customized.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_Noneshort.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_Noneshort.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_Noneshort_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_Noneshort_customized.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_Nonestring.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_Nonestring.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_Nonestring_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_Nonestring_customized.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonSystem.DateTime.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonSystem.DateTime.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonSystem.DateTimeOffset.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonSystem.DateTimeOffset.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonSystem.DateTimeOffset_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonSystem.DateTimeOffset_customized.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonSystem.DateTime_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonSystem.DateTime_customized.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonSystem.Guid.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonSystem.Guid_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonSystem.Guid_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonbool.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonbool.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonbool_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonbool_customized.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonbyte.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonbyte.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonbyte_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonbyte_customized.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonchar.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonchar.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonchar_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonchar_customized.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_SystemTextJsondecimal.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_SystemTextJsondecimal.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_SystemTextJsondecimal_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_SystemTextJsondecimal_customized.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_SystemTextJsondouble.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_SystemTextJsondouble.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_SystemTextJsondouble_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_SystemTextJsondouble_customized.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonfloat.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonfloat.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonfloat_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonfloat_customized.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonint.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonint.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonint_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonint_customized.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonlong.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonlong.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonlong_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonlong_customized.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonshort.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonshort.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonshort_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonshort_customized.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonstring.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonstring_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_partial_structConversions_SystemTextJsonstring_customized.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.DateTime.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.DateTime.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.DateTimeOffset.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.DateTimeOffset.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.DateTimeOffset_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.DateTimeOffset_customized.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.DateTime_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.DateTime_customized.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.Guid.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.Guid_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonSystem.Guid_customized.verified.txt
@@ -217,7 +217,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbool.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbool.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbool_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbool_customized.verified.txt
@@ -175,7 +175,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbyte.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbyte.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbyte_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonbyte_customized.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonchar.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonchar.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonchar_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonchar_customized.verified.txt
@@ -154,7 +154,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondecimal.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondecimal.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondecimal_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondecimal_customized.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondouble.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondouble.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondouble_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsondouble_customized.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonfloat.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonfloat.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonfloat_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonfloat_customized.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonint.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonint.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonint_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonint_customized.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonlong.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonlong.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonlong_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonlong_customized.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonshort.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonshort.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonshort_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonshort_customized.verified.txt
@@ -259,7 +259,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonstring.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonstring_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJson _ Conversions_SystemTextJsonstring_customized.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonSystem.DateTime.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonSystem.DateTime.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonSystem.DateTimeOffset.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonSystem.DateTimeOffset.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonSystem.DateTimeOffset_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonSystem.DateTimeOffset_customized.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonSystem.DateTime_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonSystem.DateTime_customized.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonSystem.Guid.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonSystem.Guid_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonSystem.Guid_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonbool.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonbool.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonbool_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonbool_customized.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonbyte.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonbyte.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonbyte_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonbyte_customized.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonchar.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonchar.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonchar_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonchar_customized.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsondecimal.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsondecimal.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsondecimal_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsondecimal_customized.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsondouble.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsondouble.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsondouble_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsondouble_customized.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonfloat.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonfloat.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonfloat_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonfloat_customized.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonint.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonint.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonint_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonint_customized.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonlong.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonlong.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonlong_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonlong_customized.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonshort.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonshort.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonshort_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonshort_customized.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonstring.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonstring.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonstring_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NewtonsoftJsonstring_customized.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NoneSystem.DateTime.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NoneSystem.DateTime.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NoneSystem.DateTimeOffset.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NoneSystem.DateTimeOffset.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NoneSystem.DateTimeOffset_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NoneSystem.DateTimeOffset_customized.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NoneSystem.DateTime_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NoneSystem.DateTime_customized.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NoneSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NoneSystem.Guid.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NoneSystem.Guid_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_NoneSystem.Guid_customized.verified.txt
@@ -215,7 +215,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_Nonebool.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_Nonebool.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_Nonebool_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_Nonebool_customized.verified.txt
@@ -173,7 +173,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_Nonebyte.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_Nonebyte.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_Nonebyte_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_Nonebyte_customized.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_Nonechar.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_Nonechar.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_Nonechar_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_Nonechar_customized.verified.txt
@@ -152,7 +152,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_Nonedecimal.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_Nonedecimal.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_Nonedecimal_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_Nonedecimal_customized.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_Nonedouble.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_Nonedouble.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_Nonedouble_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_Nonedouble_customized.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_Nonefloat.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_Nonefloat.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_Nonefloat_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_Nonefloat_customized.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_Noneint.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_Noneint.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_Noneint_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_Noneint_customized.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_Nonelong.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_Nonelong.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_Nonelong_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_Nonelong_customized.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_Noneshort.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_Noneshort.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_Noneshort_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_Noneshort_customized.verified.txt
@@ -257,7 +257,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_Nonestring.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_Nonestring.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_Nonestring_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_Nonestring_customized.verified.txt
@@ -131,7 +131,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonSystem.DateTime.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonSystem.DateTime.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonSystem.DateTimeOffset.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonSystem.DateTimeOffset.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonSystem.DateTimeOffset_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonSystem.DateTimeOffset_customized.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTimeOffset>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTimeOffset.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonSystem.DateTime_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonSystem.DateTime_customized.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.DateTime>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.DateTime.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonSystem.Guid.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonSystem.Guid.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonSystem.Guid_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonSystem.Guid_customized.verified.txt
@@ -216,7 +216,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<System.Guid>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Guid.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonbool.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonbool.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonbool_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonbool_customized.verified.txt
@@ -174,7 +174,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<bool>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Boolean.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonbyte.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonbyte.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonbyte_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonbyte_customized.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<byte>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Byte.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonchar.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonchar.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonchar_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonchar_customized.verified.txt
@@ -153,7 +153,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<char>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Char.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsondecimal.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsondecimal.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsondecimal_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsondecimal_customized.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<decimal>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Decimal.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsondouble.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsondouble.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsondouble_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsondouble_customized.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<double>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Double.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonfloat.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonfloat.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonfloat_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonfloat_customized.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<float>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Single.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonint.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonint.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonint_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonint_customized.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonlong.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonlong.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonlong_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonlong_customized.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<long>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int64.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonshort.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonshort.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonshort_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonshort_customized.verified.txt
@@ -258,7 +258,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<short>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.Int16.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonstring.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonstring.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonstring_customized.verified.txt
+++ b/tests/SnapshotTests/JsonNumberCustomizations/snapshots/snap-v7.0/stj_number_as_string_public_readonly_partial_structConversions_SystemTextJsonstring_customized.verified.txt
@@ -132,7 +132,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<string>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="System.String.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ToString/snapshots/snap-v3.1/partial_struct_None.verified.txt
+++ b/tests/SnapshotTests/ToString/snapshots/snap-v3.1/partial_struct_None.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ToString/snapshots/snap-v3.1/readonly_partial_struct_None.verified.txt
+++ b/tests/SnapshotTests/ToString/snapshots/snap-v3.1/readonly_partial_struct_None.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ToString/snapshots/snap-v4.6.1/partial_struct_None.verified.txt
+++ b/tests/SnapshotTests/ToString/snapshots/snap-v4.6.1/partial_struct_None.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ToString/snapshots/snap-v4.6.1/readonly_partial_struct_None.verified.txt
+++ b/tests/SnapshotTests/ToString/snapshots/snap-v4.6.1/readonly_partial_struct_None.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ToString/snapshots/snap-v4.8/partial_struct_None.verified.txt
+++ b/tests/SnapshotTests/ToString/snapshots/snap-v4.8/partial_struct_None.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ToString/snapshots/snap-v4.8/readonly_partial_struct_None.verified.txt
+++ b/tests/SnapshotTests/ToString/snapshots/snap-v4.8/readonly_partial_struct_None.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ToString/snapshots/snap-v5.0/partial_struct_None.verified.txt
+++ b/tests/SnapshotTests/ToString/snapshots/snap-v5.0/partial_struct_None.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ToString/snapshots/snap-v5.0/readonly_partial_struct_None.verified.txt
+++ b/tests/SnapshotTests/ToString/snapshots/snap-v5.0/readonly_partial_struct_None.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ToString/snapshots/snap-v6.0/partial_struct_None.verified.txt
+++ b/tests/SnapshotTests/ToString/snapshots/snap-v6.0/partial_struct_None.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ToString/snapshots/snap-v6.0/readonly_partial_struct_None.verified.txt
+++ b/tests/SnapshotTests/ToString/snapshots/snap-v6.0/readonly_partial_struct_None.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ToString/snapshots/snap-v7.0/partial_struct_None.verified.txt
+++ b/tests/SnapshotTests/ToString/snapshots/snap-v7.0/partial_struct_None.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()

--- a/tests/SnapshotTests/ToString/snapshots/snap-v7.0/readonly_partial_struct_None.verified.txt
+++ b/tests/SnapshotTests/ToString/snapshots/snap-v7.0/readonly_partial_struct_None.verified.txt
@@ -133,7 +133,7 @@ namespace Whatever
         public readonly override global::System.Int32 GetHashCode() => global::System.Collections.Generic.EqualityComparer<global::System.Int32>.Default.GetHashCode(_value);
 
         /// <summary>Returns the string representation of the underlying type</summary>
-    /// <inheritdoc cref="{item.UnderlyingTypeFullName}.ToString()" />
+    /// <inheritdoc cref="global::System.Int32.ToString()" />
     public readonly override global::System.String ToString() => Value.ToString();
 
         private readonly void EnsureInitialized()


### PR DESCRIPTION
Fixes #278 

This PR fixes a broken string interpolation which made the XML doc comment for the generated `ToString()` method invalid.

This change affects pretty much every snapshot so the changes are huge unfortunately. I've broken the PR into two commits - the first is the fix, the second is the snapshot updates